### PR TITLE
refactor: migrate chain watcher to subxt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,13 @@ kalatori.toml
 # dev
 substrate-parser
 substrate-constructor
+
+# `cargo install` files
+/.crates.toml
+/.crates2.json
+
+# locally installed binaries
+/bin
+
+# asset hub node metadata required for subxt compilation
+/metadata.scale

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +136,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +202,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +264,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "atomic-take"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ab6b55fe97976e46f91ddbed8d147d966475dc29b2032757ba47e02376fbc3"
 
 [[package]]
 name = "atomic-waker"
@@ -267,6 +387,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bip39"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
+dependencies = [
+ "bitcoin_hashes",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +433,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -313,11 +467,42 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -371,6 +556,27 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -501,6 +707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +813,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,7 +831,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -611,6 +845,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.106",
 ]
@@ -646,12 +915,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -666,12 +955,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -716,13 +1027,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -747,10 +1064,16 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -760,7 +1083,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -898,6 +1221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,10 +1251,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-decode"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c470df86cf28818dd3cd2fc4667b80dbefe2236c722c3dc1d09e7c6c82d6dfcd"
+dependencies = [
+ "frame-metadata 23.0.0",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-type-resolver",
+ "sp-crypto-hashing",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "frame-metadata"
 version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2753bc34b8cf637f58a4f7c3fcd54e8e588503bc9bba449bd8f5a1ab202b0172"
+dependencies = [
+ "cfg-if",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "frame-metadata"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -984,6 +1341,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1123,6 +1493,28 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
@@ -1134,10 +1526,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
 
 [[package]]
 name = "hmac"
@@ -1145,7 +1559,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -1362,6 +1787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,7 +1862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -1439,6 +1870,15 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "instant"
@@ -1498,6 +1938,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1990,7 @@ version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
 dependencies = [
+ "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "jsonrpsee-ws-client",
@@ -1623,7 +2073,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1637,7 +2087,7 @@ dependencies = [
  "base64ct",
  "clap",
  "const-hex",
- "frame-metadata",
+ "frame-metadata 22.0.0",
  "indoc",
  "jsonrpsee",
  "mnemonic-external",
@@ -1654,6 +2104,7 @@ dependencies = [
  "substrate-constructor",
  "substrate-crypto-light",
  "substrate_parser",
+ "subxt",
  "thiserror 2.0.16",
  "time",
  "tokio",
@@ -1671,6 +2122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-hash"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
+dependencies = [
+ "primitive-types",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1696,6 +2157,60 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
+dependencies = [
+ "arrayref",
+ "base64",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1724,6 +2239,15 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "matchers"
@@ -1791,9 +2315,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd8b607d24e1721a79eb4e30054fe776bf3956a87bd57f59c15fa1f72ad8721"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "zeroize",
 ]
+
+[[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
 
 [[package]]
 name = "names"
@@ -1828,6 +2358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +2397,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1899,6 +2449,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -2009,7 +2565,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -2021,9 +2587,22 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.17",
+ "smallvec",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2032,7 +2611,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2072,6 +2651,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -2115,6 +2705,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2762,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-serde",
+ "scale-info",
  "uint",
 ]
 
@@ -2157,6 +2773,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.6",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2283,6 +2921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags 2.9.4",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,7 +3004,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -2496,6 +3143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,6 +3164,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-bits"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27243ab0d2d6235072b017839c5f0cd1a3b1ce45c0f7a715363b0c7d36c76c94"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "scale-type-resolver",
+ "serde",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d78196772d25b90a98046794ce0fe2588b39ebdfbdc1e45b4c6c85dd43bebad"
+dependencies = [
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-bits",
+ "scale-decode-derive",
+ "scale-type-resolver",
+ "smallvec",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "scale-decode-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4b54a1211260718b92832b661025d1f1a4b6930fbadd6908e00edd265fa5f7"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "scale-encode"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64901733157f9d25ef86843bd783eda439fac7efb0ad5a615d12d2cf3a29464b"
+dependencies = [
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-bits",
+ "scale-encode-derive",
+ "scale-type-resolver",
+ "smallvec",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "scale-encode-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a3993a13b4eafa89350604672c8757b7ea84c7c5947d4b3691e3169c96379b"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,7 +3238,7 @@ checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "bitvec",
  "cfg-if",
- "derive_more",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
  "serde",
@@ -2534,6 +3254,48 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
+dependencies = [
+ "scale-info",
+ "smallvec",
+]
+
+[[package]]
+name = "scale-typegen"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c61b6b706a3eaad63b506ab50a1d2319f817ae01cf753adcc3f055f9f0fcd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "scale-info",
+ "syn 2.0.106",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "scale-value"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca8b26b451ecb7fd7b62b259fa28add63d12ec49bbcac0e01fcb4b5ae0c09aa"
+dependencies = [
+ "base58",
+ "blake2",
+ "either",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-decode",
+ "scale-encode",
+ "scale-type-resolver",
+ "serde",
+ "thiserror 2.0.16",
+ "yap",
 ]
 
 [[package]]
@@ -2559,7 +3321,7 @@ dependencies = [
  "merlin",
  "rand_core 0.6.4",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2719,7 +3481,20 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2730,7 +3505,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2739,7 +3514,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -2784,7 +3559,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2793,6 +3568,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -2813,7 +3594,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -2821,6 +3602,113 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "smoldot"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16e5723359f0048bf64bfdfba64e5732a56847d42c4fd3fe56f18280c813413"
+dependencies = [
+ "arrayvec 0.7.6",
+ "async-lock",
+ "atomic-take",
+ "base64",
+ "bip39",
+ "blake2-rfc",
+ "bs58",
+ "chacha20",
+ "crossbeam-queue",
+ "derive_more 2.0.1",
+ "ed25519-zebra",
+ "either",
+ "event-listener",
+ "fnv",
+ "futures-lite",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hex",
+ "hmac 0.12.1",
+ "itertools",
+ "libm",
+ "libsecp256k1",
+ "merlin",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "pbkdf2",
+ "pin-project",
+ "poly1305",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "ruzstd",
+ "schnorrkel",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3",
+ "siphasher",
+ "slab",
+ "smallvec",
+ "soketto",
+ "twox-hash 2.1.2",
+ "wasmi",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "smoldot-light"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bba9e591716567d704a8252feeb2f1261a286e1e2cbdd4e49e9197c34a14e2"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "base64",
+ "blake2-rfc",
+ "bs58",
+ "derive_more 2.0.1",
+ "either",
+ "event-listener",
+ "fnv",
+ "futures-channel",
+ "futures-lite",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hex",
+ "itertools",
+ "log",
+ "lru",
+ "parking_lot 0.12.4",
+ "pin-project",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "slab",
+ "smol",
+ "smoldot",
+ "zeroize",
+]
 
 [[package]]
 name = "socket2"
@@ -2869,10 +3757,10 @@ checksum = "bc9927a7f81334ed5b8a98a4a978c81324d12bd9713ec76b5c68fd410174c5eb"
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "digest",
- "sha2",
+ "digest 0.10.7",
+ "sha2 0.10.9",
  "sha3",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -2916,7 +3804,7 @@ source = "git+https://github.com/Kalapaja/substrate-constructor.git#49aff01c1c65
 dependencies = [
  "bitvec",
  "external-memory-tools",
- "frame-metadata",
+ "frame-metadata 22.0.0",
  "hex",
  "num-bigint",
  "parity-scale-codec",
@@ -2937,7 +3825,7 @@ dependencies = [
  "base58",
  "blake2b_simd",
  "ed25519-zebra",
- "hmac",
+ "hmac 0.12.1",
  "k256",
  "lazy_static",
  "parity-scale-codec",
@@ -2945,7 +3833,7 @@ dependencies = [
  "rand_core 0.6.4",
  "regex",
  "schnorrkel",
- "sha2",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -2956,7 +3844,7 @@ source = "git+https://github.com/Vovke/substrate-parser#5222ec8986a4b0e50fe0fc99
 dependencies = [
  "bitvec",
  "external-memory-tools",
- "frame-metadata",
+ "frame-metadata 22.0.0",
  "hex",
  "num-bigint",
  "parity-scale-codec",
@@ -2973,6 +3861,174 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "subxt"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddbf938ac1d86a361a84709a71cdbae5d87f370770b563651d1ec052eed9d0b4"
+dependencies = [
+ "async-trait",
+ "derive-where",
+ "either",
+ "frame-metadata 23.0.0",
+ "futures",
+ "hex",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-bits",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-crypto-hashing",
+ "subxt-core",
+ "subxt-lightclient",
+ "subxt-macro",
+ "subxt-metadata",
+ "subxt-rpcs",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "subxt-codegen"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c250ad8cd102d40ae47977b03295a2ff791375f30ddc7474d399fb56efb793b"
+dependencies = [
+ "heck",
+ "parity-scale-codec",
+ "proc-macro2",
+ "quote",
+ "scale-info",
+ "scale-typegen",
+ "subxt-metadata",
+ "syn 2.0.106",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "subxt-core"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5705c5b420294524e41349bf23c6b11aa474ce731de7317f4153390e1927f702"
+dependencies = [
+ "base58",
+ "blake2",
+ "derive-where",
+ "frame-decode",
+ "frame-metadata 23.0.0",
+ "hashbrown 0.14.5",
+ "hex",
+ "impl-serde",
+ "keccak-hash",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-bits",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-crypto-hashing",
+ "subxt-metadata",
+ "thiserror 2.0.16",
+ "tracing",
+]
+
+[[package]]
+name = "subxt-lightclient"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e02732a6c9ae46bc282c1a741b3d3e494021b3e87e7e92cfb3620116d92911"
+dependencies = [
+ "futures",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "smoldot-light",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "subxt-macro"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501bf358698f5ab02a6199a1fcd3f1b482e2f5b6eb5d185411e6a74a175ec8e8"
+dependencies = [
+ "darling",
+ "parity-scale-codec",
+ "proc-macro-error2",
+ "quote",
+ "scale-typegen",
+ "subxt-codegen",
+ "subxt-metadata",
+ "subxt-utils-fetchmetadata",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "subxt-metadata"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fb7c0bfafad78dda7084c6a2444444744af3bbf7b2502399198b9b4c20eddf"
+dependencies = [
+ "frame-decode",
+ "frame-metadata 23.0.0",
+ "hashbrown 0.14.5",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-crypto-hashing",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "subxt-rpcs"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab68a9c20ecedb0cb7d62d64f884e6add91bb70485783bf40aa8eac5c389c6e0"
+dependencies = [
+ "derive-where",
+ "frame-metadata 23.0.0",
+ "futures",
+ "hex",
+ "impl-serde",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "subxt-core",
+ "subxt-lightclient",
+ "thiserror 2.0.16",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "subxt-utils-fetchmetadata"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f6812a653c5a3e63a079aa3b60a3f4c362722753c3222286eaa1800f9002"
+dependencies = [
+ "hex",
+ "parity-scale-codec",
+ "thiserror 2.0.16",
+]
 
 [[package]]
 name = "syn"
@@ -3158,6 +4214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,6 +4231,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3444,10 +4524,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -3480,10 +4566,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -3649,10 +4751,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmi"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
+dependencies = [
+ "arrayvec 0.7.6",
+ "multi-stash",
+ "smallvec",
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80d6b275b1c922021939d561574bf376613493ae2b61c6963b15db0e8813562"
+
+[[package]]
+name = "wasmi_core"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8c51482cc32d31c2c7ff211cd2bedd73c5bd057ba16a2ed0110e7a96097c33"
+dependencies = [
+ "downcast-rs",
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e431a14c186db59212a88516788bd68ed51f87aa1e08d1df742522867b5289a"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags 2.9.4",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4008,6 +5170,24 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "yap"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe269e7b803a5e8e20cbd97860e136529cd83bf2c9c6d37b142467e7e1f051f"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.13.0",
+ "serde",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -402,13 +404,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
  "bitcoin-internals",
- "hex-conservative",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -576,6 +594,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -820,6 +839,21 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1544,6 +1578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec 0.7.6",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,7 +2127,9 @@ dependencies = [
  "async-lock",
  "axum",
  "axum-macros",
+ "base58",
  "base64ct",
+ "blake2b_simd",
  "clap",
  "const-hex",
  "frame-metadata 22.0.0",
@@ -2105,6 +2150,7 @@ dependencies = [
  "substrate-crypto-light",
  "substrate_parser",
  "subxt",
+ "subxt-signer",
  "thiserror 2.0.16",
  "time",
  "tokio",
@@ -2606,12 +2652,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
+ "hmac 0.12.1",
+ "password-hash",
 ]
 
 [[package]]
@@ -3155,6 +3214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,6 +3401,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,6 +3423,35 @@ dependencies = [
  "generic-array",
  "pkcs8",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "rand 0.8.5",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
  "zeroize",
 ]
 
@@ -4020,6 +4129,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "subxt-signer"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb6463f7f46817043de9f20ba11f485ee474378fcdbe4150aa849274523bd1c"
+dependencies = [
+ "base64",
+ "bip39",
+ "cfg-if",
+ "crypto_secretbox",
+ "hex",
+ "hmac 0.12.1",
+ "parity-scale-codec",
+ "pbkdf2",
+ "regex",
+ "schnorrkel",
+ "scrypt",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sp-crypto-hashing",
+ "subxt-core",
+ "thiserror 2.0.16",
+ "zeroize",
+]
+
+[[package]]
 name = "subxt-utils-fetchmetadata"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4564,6 +4701,15 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ time = "0.3"
 reqwest = "0.12"
 # This crate bumbped MSRV in minor update
 base64ct = "=1.6.0"
+subxt = "0.44"
 
 substrate_parser = { git = "https://github.com/Vovke/substrate-parser" }
 substrate-constructor = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,11 +70,14 @@ reqwest = "0.12"
 # This crate bumbped MSRV in minor update
 base64ct = "=1.6.0"
 subxt = "0.44"
+subxt-signer = "0.44"
 
 substrate_parser = { git = "https://github.com/Vovke/substrate-parser" }
 substrate-constructor = "0.2.0"
 mnemonic-external = "0.1.0"
 substrate-crypto-light = "0.2.0"
+base58 = "0.2.0"
+blake2b_simd = "1.0.3"
 
 [build-dependencies]
 # Don't forget to update me in `[dependencies]`!

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: help
+
+# absolute path to this makefile
+mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+subxt_cli_version := 0.44.0
+
+help: # Show help for each of the Makefile recipes
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+#####################
+### Setup Project ###
+#####################
+
+install-subxt-cli: # Install subxt-cli into the project directory
+	cargo install --root $(mkfile_path) --version $(subxt_cli_version) --locked subxt-cli
+
+# TODO: read URL from json config and/or env var instead of hardcode
+download-node-metadata: # Download metadata of configured Asset Hub node. Required for subxt compilation.
+	PATH="${PWD}/bin:${PATH}" subxt metadata -f bytes --url ws://localhost:9000 > metadata.scale

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -9,10 +9,11 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use subxt::config::{Config, SubstrateConfig, DefaultExtrinsicParams};
 use runtime::runtime_types::staging_xcm::v3::multilocation::MultiLocation;
+use subxt_signer::SecretString;
 
 #[subxt::subxt(
     runtime_metadata_path = "./metadata.scale",
-    // generate_docs,
+    generate_docs,
     // derive_for_all_types = "Clone, PartialEq, Eq",
     derive_for_type(
         path = "staging_xcm::v3::multilocation::MultiLocation",
@@ -75,6 +76,7 @@ impl ChainManager {
     /// - all modules should be restarted, probably.
     #[expect(clippy::too_many_lines)]
     pub fn ignite(
+        seed_secret: SecretString,
         chain_info: Chain,
         state: &State,
         signer: &Signer,
@@ -108,6 +110,7 @@ impl ChainManager {
         }
 
         start_chain_watch(
+            seed_secret,
             chain_info,
             chain_tx.clone(),
             chain_rx,

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -8,6 +8,18 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
+#[subxt::subxt(
+    runtime_metadata_path = "./metadata.scale",
+    // generate_docs,
+    // derive_for_all_types = "Clone, PartialEq, Eq",
+    derive_for_type(
+        path = "staging_xcm::v3::multilocation::MultiLocation",
+        derive = "Clone, codec::Encode",
+        recursive
+    )
+)]
+pub mod runtime {}
+
 use crate::{
     definitions::{api_v2::OrderInfo, Chain},
     error::{ChainError, Error},

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -7,6 +7,8 @@ use tokio::{
     time::{timeout, Duration},
 };
 use tokio_util::sync::CancellationToken;
+use subxt::config::{Config, SubstrateConfig, DefaultExtrinsicParams};
+use runtime::runtime_types::staging_xcm::v3::multilocation::MultiLocation;
 
 #[subxt::subxt(
     runtime_metadata_path = "./metadata.scale",
@@ -19,6 +21,24 @@ use tokio_util::sync::CancellationToken;
     )
 )]
 pub mod runtime {}
+
+// We don't need to construct this at runtime, so an empty enum is appropriate.
+#[derive(Debug)]
+pub enum AssetHubConfig {}
+
+impl Config for AssetHubConfig {
+    type AccountId = <SubstrateConfig as Config>::AccountId;
+    type Address = <SubstrateConfig as Config>::Address;
+    type Signature = <SubstrateConfig as Config>::Signature;
+    type Hasher = <SubstrateConfig as Config>::Hasher;
+    type Header = <SubstrateConfig as Config>::Header;
+    type ExtrinsicParams = DefaultExtrinsicParams<AssetHubConfig>;
+    // Here we use the MultiLocation from the metadata as a part of the config:
+    // The `ChargeAssetTxPayment` signed extension that is part of the ExtrinsicParams above, now uses the type:
+    type AssetId = MultiLocation;
+}
+
+pub type AssetHubOnlineClient = subxt::OnlineClient::<AssetHubConfig>;
 
 use crate::{
     definitions::{api_v2::OrderInfo, Chain},

--- a/src/chain/definitions.rs
+++ b/src/chain/definitions.rs
@@ -3,10 +3,7 @@
 use std::fmt::Display;
 
 use crate::{
-    chain::{
-        rpc::{asset_balance_at_account, system_balance_at_account},
-        tracker::ChainWatcher,
-    },
+    chain::tracker::ChainWatcher, chain::AssetHubOnlineClient,
     definitions::{
         api_v2::{BlockNumber, CurrencyInfo, OrderInfo, RpcInfo, Timestamp},
         Balance,
@@ -14,7 +11,6 @@ use crate::{
     error::{ChainError, NotHexError},
     utils::unhex,
 };
-use jsonrpsee::ws_client::WsClient;
 use primitive_types::H256;
 use substrate_crypto_light::common::{AccountId32, AsBase58};
 use tokio::sync::oneshot;
@@ -123,39 +119,42 @@ impl Invoice {
 
     pub async fn balance(
         &self,
-        client: &WsClient,
+        client: &AssetHubOnlineClient,
         chain_watcher: &ChainWatcher,
-        block: &BlockHash,
     ) -> Result<Balance, ChainError> {
         let currency = chain_watcher
             .assets
             .get(&self.currency.currency)
-            .ok_or(ChainError::InvalidCurrency(self.currency.currency.clone()))?;
-        if let Some(asset_id) = currency.asset_id {
-            let balance = asset_balance_at_account(
-                client,
-                block,
-                &chain_watcher.metadata,
-                &self.address,
-                asset_id,
-            )
-            .await?;
-            Ok(balance)
-        } else {
-            let balance =
-                system_balance_at_account(client, block, &chain_watcher.metadata, &self.address)
-                    .await?;
-            Ok(balance)
-        }
+            .ok_or_else(|| ChainError::InvalidCurrency(self.currency.currency.clone()))?;
+
+        // TODO: asset_id shouldn't be optional, will change in future
+        let Some(asset_id) = currency.asset_id else {
+            return Err(ChainError::InvalidCurrency(self.currency.currency.clone()))
+        };
+
+        let request_data = crate::chain::runtime::storage()
+            .assets()
+            // TODO: change stored type to subxt's account id
+            .account(asset_id, subxt::utils::AccountId32(self.address.0));
+
+        let balance = client
+            .storage()
+            .at_latest()
+            .await?
+            .fetch(&request_data)
+            .await?
+            .map(|result| result.balance)
+            .unwrap_or(0);
+
+        Ok(Balance(balance))
     }
 
     pub async fn check(
         &self,
-        client: &WsClient,
+        client: &AssetHubOnlineClient,
         chain_watcher: &ChainWatcher,
-        block: &BlockHash,
     ) -> Result<bool, ChainError> {
-        Ok(self.balance(client, chain_watcher, block).await?
+        Ok(self.balance(client, chain_watcher).await?
             >= Balance::parse(self.amount, self.currency.decimals))
     }
 }

--- a/src/chain/payout.rs
+++ b/src/chain/payout.rs
@@ -6,180 +6,135 @@
 
 use crate::{
     chain::{
-        definitions::Invoice,
-        rpc::{block_hash, current_block_number, send_stuff},
-        tracker::ChainWatcher,
-        utils::{
-            construct_batch_transaction, construct_single_asset_transfer_call,
-            construct_single_balance_transfer_call, AssetTransferConstructor,
-            BalanceTransferConstructor,
-        },
+        definitions::Invoice, runtime::runtime_types::{staging_xcm::v3::multilocation::MultiLocation, xcm::v3::{junction::Junction, junctions::Junctions}}, tracker::ChainWatcher, AssetHubConfig, AssetHubOnlineClient
     },
     database::{TransactionInfoDb, TransactionInfoDbInner, TxKind},
     definitions::{
-        api_v2::{Amount, TokenKind, TxStatus},
-        Balance,
+        api_v2::{Amount, TxStatus},
     },
     error::ChainError,
-    signer::Signer,
     state::State,
 };
-use frame_metadata::v15::RuntimeMetadataV15;
-use jsonrpsee::ws_client::WsClientBuilder;
-use substrate_constructor::fill_prepare::TypeContentToFill;
+use base58::ToBase58;
 use substrate_crypto_light::common::AsBase58;
+use subxt::config::DefaultExtrinsicParamsBuilder;
+use subxt_signer::{bip39::Mnemonic, sr25519::Keypair, DeriveJunction, ExposeSecret, SecretString};
+
+// TODO: move it out to utils or use something similar from separate crate?
+pub const HASH_512_LEN: usize = 64;
+pub const BASE58_ID: &[u8] = b"SS58PRE";
+
+fn ss58hash(data: &[u8]) -> [u8; HASH_512_LEN] {
+    let mut blake2b_state = blake2b_simd::Params::new()
+        .hash_length(HASH_512_LEN)
+        .to_state();
+    blake2b_state.update(BASE58_ID);
+    blake2b_state.update(data);
+    blake2b_state
+        .finalize()
+        .as_bytes()
+        .try_into()
+        .expect("static length, always fits")
+}
+
+// Same as `to_ss58check_with_version()` method for `Ss58Codec` from `sp_core`, comments from `sp_core`.
+fn to_base58_string(bytes: [u8; 32], base58prefix: u16) -> String {
+    // We mask out the upper two bits of the ident - SS58 Prefix currently only supports 14-bits
+    let ident: u16 = base58prefix & 0b0011_1111_1111_1111;
+    let mut v = match ident {
+        0..=63 => vec![ident as u8],
+        64..=16_383 => {
+            // upper six bits of the lower byte(!)
+            let first = ((ident & 0b0000_0000_1111_1100) as u8) >> 2;
+            // lower two bits of the lower byte in the high pos,
+            // lower bits of the upper byte in the low pos
+            let second = ((ident >> 8) as u8) | ((ident & 0b0000_0000_0000_0011) as u8) << 6;
+            vec![first | 0b0100_0000, second]
+        }
+        _ => unreachable!("masked out the upper two bits; qed"),
+    };
+    v.extend(bytes);
+    let r = ss58hash(&v);
+    v.extend(&r[0..2]);
+    v.to_base58()
+}
 
 /// Single function that should completely handle payout attmept. Just do not call anything else.
 ///
 /// TODO: make this an additional runner independent from chain monitors
 #[expect(clippy::too_many_lines, clippy::arithmetic_side_effects)]
 pub async fn payout(
-    rpc: String,
+    client: AssetHubOnlineClient,
     order: Invoice,
     state: State,
     chain: ChainWatcher,
-    signer: Signer,
+    seed: SecretString,
 ) -> Result<(), ChainError> {
     // TODO: make this retry and rotate RPCs maybe
     //
     // after some retries record a failure
-    if let Ok(client) = WsClientBuilder::default().build(&rpc).await {
-        let block = block_hash(&client, None).await?; // TODO should retry instead
-        let block_number = current_block_number(&client, &chain.metadata, &block).await?;
-        let balance = order.balance(&client, &chain, &block).await?; // TODO same
-        let loss_tolerance = 20000; // TODO: replace with multiple of existential
-                                    // TODO: add upper limit for transactions that would require manual intervention
-                                    // just because it was found to be needed with non-crypto trade, who knows why?
-        let currency = chain
-            .assets
-            .get(&order.currency.currency)
-            .ok_or_else(|| ChainError::InvalidCurrency(order.currency.currency.clone()))?;
-        let order_amount = Balance::parse(order.amount, order.currency.decimals);
+    let currency = chain
+        .assets
+        .get(&order.currency.currency)
+        .ok_or_else(|| ChainError::InvalidCurrency(order.currency.currency.clone()))?;
 
-        // Payout operation logic
-        let (transactions, final_amount) = if balance.0.abs_diff(order_amount.0) <= loss_tolerance
-        // modulus(balance-order.amount) <= loss_tolerance
-        {
-            tracing::info!("Regular withdrawal");
-            (
-                match currency.kind {
-                    TokenKind::Native => {
-                        let balance_transfer_constructor = BalanceTransferConstructor {
-                            amount: order_amount.0,
-                            to_account: &order.recipient,
-                            is_clearing: true,
-                        };
-                        vec![construct_single_balance_transfer_call(
-                            &chain.metadata,
-                            &balance_transfer_constructor,
-                        )?]
-                    }
-                    TokenKind::Asset => {
-                        let asset_transfer_constructor = AssetTransferConstructor {
-                            asset_id: currency.asset_id.ok_or(ChainError::AssetId)?,
-                            amount: order_amount.0 - loss_tolerance,
-                            to_account: &order.recipient,
-                        };
-                        vec![construct_single_asset_transfer_call(
-                            &chain.metadata,
-                            &asset_transfer_constructor,
-                        )?]
-                    }
+    let asset_id = currency.asset_id.ok_or(ChainError::AssetId)?;
+    let dest = subxt::utils::AccountId32::from(order.recipient.0);
+
+    let call = crate::chain::runtime::tx().assets().transfer_all(asset_id, dest.into(), false);
+
+    // TODO: set pallet instance and parents to consts?
+    let location = MultiLocation {
+        parents: 0,
+        interior: Junctions::X2(Junction::PalletInstance(50), Junction::GeneralIndex(asset_id as u128)),
+    };
+
+    let tx_config = DefaultExtrinsicParamsBuilder::<AssetHubConfig>::new()
+        .tip_of(0, location)
+        .mortal(32)
+        .build();
+
+    // TODO: need to validate phrase on start so unwrap here can be safe
+    let mnemonic = Mnemonic::parse(seed.expose_secret()).unwrap();
+    // TODO: add support for password configuration, ensure unwrap here is safe
+    let keypair = Keypair::from_phrase(&mnemonic, None).unwrap();
+
+    let order_keypair = keypair.derive([
+        DeriveJunction::hard(order.recipient.to_base58_string(2)),
+        DeriveJunction::hard(&order.id),
+    ]);
+
+    // TODO: why 42? perhaps store it into constant?
+    let sender = to_base58_string(order_keypair.public_key().0, 42);
+
+    let transaction = client.tx().create_signed(&call, &order_keypair, tx_config).await?;
+    let encoded_extrinsic = const_hex::encode_prefixed(transaction.encoded());
+
+    state
+        .record_transaction(
+            TransactionInfoDb {
+                transaction_bytes: encoded_extrinsic.clone(),
+                inner: TransactionInfoDbInner {
+                    finalized_tx_timestamp: None,
+                    finalized_tx: None,
+                    sender,
+                    recipient: order.recipient.to_base58_string(42),
+                    amount: Amount::All,
+                    currency: order.currency,
+                    status: TxStatus::Pending,
+                    kind: TxKind::Withdrawal,
                 },
-                order_amount.0,
-            )
-        } else {
-            tracing::info!("Overpayment or forced");
-            // We will transfer all the available balance
-            // TODO smarter handling and returns probably
+            },
+            order.id.clone(),
+        )
+        .await
+        .map_err(|_| ChainError::TransactionNotSaved)?;
 
-            (
-                match currency.kind {
-                    TokenKind::Native => {
-                        let balance_transfer_constructor = BalanceTransferConstructor {
-                            amount: balance.0,
-                            to_account: &order.recipient,
-                            is_clearing: true,
-                        };
-                        vec![construct_single_balance_transfer_call(
-                            &chain.metadata,
-                            &balance_transfer_constructor,
-                        )?]
-                    }
-                    TokenKind::Asset => {
-                        let asset_transfer_constructor = AssetTransferConstructor {
-                            asset_id: currency.asset_id.ok_or(ChainError::AssetId)?,
-                            amount: balance.0 - loss_tolerance,
-                            to_account: &order.recipient,
-                        };
-                        vec![construct_single_asset_transfer_call(
-                            &chain.metadata,
-                            &asset_transfer_constructor,
-                        )?]
-                    }
-                },
-                balance.0,
-            )
-        };
+    // send_stuff(&client, &encoded_extrinsic).await?;
+    // TODO: handle result, check transfer details, find our transfer event, store it's details
+    let _result = transaction.submit_and_watch().await?;
 
-        let mut batch_transaction = construct_batch_transaction(
-            &chain.metadata,
-            chain.genesis_hash,
-            order.address,
-            &transactions,
-            block,
-            block_number,
-            0,
-            currency.asset_id,
-        )?;
-
-        let sign_this = batch_transaction
-            .sign_this()
-            .ok_or(ChainError::TransactionNotSignable(format!(
-                "{batch_transaction:?}"
-            )))?;
-
-        let signature = signer.sign(order.id.clone(), sign_this).await?;
-
-        if let TypeContentToFill::Variant(ref mut multisig) = batch_transaction.signature.content {
-            if let TypeContentToFill::ArrayU8(ref mut sr25519) =
-                multisig.selected.fields_to_fill[0].type_to_fill.content
-            {
-                sr25519.content = signature.0.to_vec();
-            }
-        }
-
-        let extrinsic = batch_transaction
-            .send_this_signed::<(), RuntimeMetadataV15>(&chain.metadata)?
-            .ok_or(ChainError::NothingToSend)?;
-        let encoded_extrinsic = const_hex::encode_prefixed(extrinsic);
-
-        state
-            .record_transaction(
-                TransactionInfoDb {
-                    transaction_bytes: encoded_extrinsic.clone(),
-                    inner: TransactionInfoDbInner {
-                        finalized_tx_timestamp: None,
-                        finalized_tx: None,
-                        sender: signer.public(order.id.clone(), 42).await?,
-                        recipient: order.recipient.to_base58_string(42),
-                        amount: Amount::Exact(
-                            Balance(final_amount).format(order.currency.decimals),
-                        ),
-                        currency: order.currency,
-                        status: TxStatus::Pending,
-                        kind: TxKind::Withdrawal,
-                    },
-                },
-                order.id.clone(),
-            )
-            .await
-            .map_err(|_| ChainError::TransactionNotSaved)?;
-
-        send_stuff(&client, &encoded_extrinsic).await?;
-
-        state.order_withdrawn(order.id).await;
-        // TODO obvious
-    }
+    state.order_withdrawn(order.id).await;
+    // TODO obvious
     Ok(())
 }

--- a/src/chain/tracker.rs
+++ b/src/chain/tracker.rs
@@ -4,17 +4,17 @@ use crate::{
     chain::{
         definitions::{BlockHash, ChainTrackerRequest, Invoice}, payout::payout, rpc::{
             block_hash, metadata,
-            specs, transfer_events,
-        }, utils::parse_transfer_event, AssetHubOnlineClient
+            specs,
+        }, AssetHubConfig, AssetHubOnlineClient
     }, database::{FinalizedTxDb, TransactionInfoDb, TransactionInfoDbInner, TxKind}, definitions::{
-        api_v2::{Amount, CurrencyProperties, Health, RpcInfo, TokenKind, TxStatus},
-        Chain,
+        api_v2::{Amount, CurrencyProperties, Health, RpcInfo, TokenKind, TxStatus}, Balance, Chain
     }, error::{ChainError, Error}, signer::Signer, state::State, utils::task_tracker::TaskTracker
 };
 use frame_metadata::v15::RuntimeMetadataV15;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
+use subxt::blocks::FoundExtrinsic;
 use std::{collections::HashMap, time::SystemTime};
-use substrate_crypto_light::common::AsBase58;
+use substrate_crypto_light::common::{AccountId32, AsBase58};
 use substrate_parser::ShortSpecs;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::{
@@ -23,6 +23,60 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use subxt_signer::SecretString;
+
+type Extrinsics = subxt::blocks::Extrinsics<AssetHubConfig, AssetHubOnlineClient>;
+type TransferExtrinsic = crate::chain::runtime::assets::calls::types::Transfer;
+type TransferredEvent = crate::chain::runtime::assets::events::Transferred;
+
+async fn transfer_events(
+    client: &AssetHubOnlineClient,
+    block: &BlockHash,
+) -> Result<(u64, Extrinsics), subxt::Error> {
+    let chain_block = client
+        .blocks()
+        .at(block.0)
+        .await?;
+
+    let timestamp_address= crate::chain::runtime::storage().timestamp().now();
+
+    let timestamp = chain_block
+        .storage()
+        .fetch(&timestamp_address)
+        .await?
+        .ok_or_else(|| subxt::Error::Other("Timestamp is empty".into()))?;
+
+    let extrinsics = chain_block
+        .extrinsics()
+        .await?;
+
+    // TODO: handle extrinsics with failures?
+
+
+    Ok((timestamp, extrinsics))
+}
+
+async fn parse_transfer_event(
+    account_id: &AccountId32,
+    extrinsic: &FoundExtrinsic<AssetHubConfig, AssetHubOnlineClient, TransferExtrinsic>,
+) -> Option<(TxKind, AccountId32, Balance)> {
+    let acc_id = subxt::utils::AccountId32::from(account_id.0);
+    let events = extrinsic.details.events().await.ok()?;
+
+    let mut found_events = events
+        .find::<TransferredEvent>()
+        .filter_map(Result::ok);
+
+    found_events
+        .find_map(|event| {
+            if event.from == acc_id {
+                Some((TxKind::Withdrawal, AccountId32(event.to.0), Balance(event.amount)))
+            } else if event.to == acc_id {
+                Some((TxKind::Payment, AccountId32(event.from.0), Balance(event.amount)))
+            } else {
+                None
+            }
+        })
+}
 
 // TODO: check if it's DEFINITELY won't break something
 #[expect(tail_expr_drop_order)]
@@ -139,34 +193,36 @@ pub fn start_chain_watch(
                                 let mut id_remove_list = Vec::new();
 
                                 match transfer_events(
-                                    &client,
+                                    &subxt_client,
                                     &block,
-                                    &watcher.metadata,
-                                )
-                                    .await {
-                                        Ok((timestamp, events)) => {
-                                        tracing::debug!("Got a block with timestamp {timestamp:?} & events: {events:?}");
+                                ).await {
+                                    Ok((timestamp, extrinsics)) => {
+                                        tracing::debug!("Got a block with timestamp {timestamp:?} & {} extrinsics", extrinsics.len());
 
+                                        // TODO: handle Err results? Log them at least?
+                                        let transfer_extrinsics: Vec<_> = extrinsics.find::<TransferExtrinsic>().filter_map(Result::ok).collect();
+
+                                        // TODO: Current implementation is quite unoptimized for work with subxt, need to be refactored
                                         for (id, invoice) in &watched_accounts {
-                                            for (extrinsic_option, event) in &events {
-                                                if let Some((tx_kind, another_account, transfer_amount)) = parse_transfer_event(&invoice.address, &event.0.fields) {
+                                            for extrinsic in &transfer_extrinsics {
+                                                if let Some((tx_kind, another_account, transfer_amount)) = parse_transfer_event(&invoice.address, extrinsic).await {
                                                     tracing::debug!("Found {tx_kind:?} from/to {another_account:?} with {transfer_amount:?} token(s).");
-
-                                                    let Some((position_in_block, extrinsic)) = extrinsic_option else {
-                                                        return Err(Error::from(ChainError::TransferEventNoExtrinsic));
-                                                    };
+                                                    let position_in_block = extrinsic.details.index();
+                                                    let raw_extrinsic = extrinsic.details.bytes();
 
                                                     #[expect(clippy::arithmetic_side_effects)]
-                                                    let finalized_tx_timestamp = (OffsetDateTime::UNIX_EPOCH + Duration::from_millis(timestamp.0))
+                                                    let finalized_tx_timestamp = (OffsetDateTime::UNIX_EPOCH + Duration::from_millis(timestamp))
                                                         .format(&Rfc3339).unwrap().into();
+
                                                     let finalized_tx = FinalizedTxDb {
-                                                            block_number,
-                                                            position_in_block: *position_in_block
-                                                        }.into();
+                                                        block_number,
+                                                        position_in_block,
+                                                    }.into();
+
                                                     let amount = Amount::Exact(transfer_amount.format(invoice.currency.decimals));
                                                     let status = TxStatus::Finalized;
                                                     let currency = invoice.currency.clone();
-                                                    let transaction_bytes = const_hex::encode_prefixed(extrinsic);
+                                                    let transaction_bytes = const_hex::encode_prefixed(raw_extrinsic);
 
                                                     match tx_kind {
                                                         kind @ TxKind::Payment => {

--- a/src/chain/tracker.rs
+++ b/src/chain/tracker.rs
@@ -2,20 +2,15 @@
 
 use crate::{
     chain::{
-        definitions::{BlockHash, ChainTrackerRequest, Invoice}, payout::payout, rpc::{
-            block_hash, metadata,
-            specs,
-        }, AssetHubConfig, AssetHubOnlineClient
+        definitions::{BlockHash, ChainTrackerRequest, Invoice}, payout::payout, rpc::block_hash, AssetHubConfig, AssetHubOnlineClient
     }, database::{FinalizedTxDb, TransactionInfoDb, TransactionInfoDbInner, TxKind}, definitions::{
         api_v2::{Amount, CurrencyProperties, Health, RpcInfo, TokenKind, TxStatus}, Balance, Chain
-    }, error::{ChainError, Error}, signer::Signer, state::State, utils::task_tracker::TaskTracker
+    }, error::ChainError, signer::Signer, state::State, utils::task_tracker::TaskTracker
 };
-use frame_metadata::v15::RuntimeMetadataV15;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
-use subxt::blocks::FoundExtrinsic;
+use subxt::blocks::{ExtrinsicDetails, FoundExtrinsic};
 use std::{collections::HashMap, time::SystemTime};
 use substrate_crypto_light::common::{AccountId32, AsBase58};
-use substrate_parser::ShortSpecs;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::{
     sync::mpsc,
@@ -26,7 +21,22 @@ use subxt_signer::SecretString;
 
 type Extrinsics = subxt::blocks::Extrinsics<AssetHubConfig, AssetHubOnlineClient>;
 type TransferExtrinsic = crate::chain::runtime::assets::calls::types::Transfer;
+type TransferAllExtrinsic = crate::chain::runtime::assets::calls::types::TransferAll;
 type TransferredEvent = crate::chain::runtime::assets::events::Transferred;
+
+enum AnyTransferExtrinsic {
+    Transfer(FoundExtrinsic<AssetHubConfig, AssetHubOnlineClient, TransferExtrinsic>),
+    TransferAll(FoundExtrinsic<AssetHubConfig, AssetHubOnlineClient, TransferAllExtrinsic>),
+}
+
+impl AnyTransferExtrinsic {
+    pub fn details(&self) -> &ExtrinsicDetails<AssetHubConfig, AssetHubOnlineClient> {
+        match self {
+            AnyTransferExtrinsic::Transfer(e) => &e.details,
+            AnyTransferExtrinsic::TransferAll(e) => &e.details,
+        }
+    }
+}
 
 async fn transfer_events(
     client: &AssetHubOnlineClient,
@@ -49,18 +59,15 @@ async fn transfer_events(
         .extrinsics()
         .await?;
 
-    // TODO: handle extrinsics with failures?
-
-
     Ok((timestamp, extrinsics))
 }
 
-async fn parse_transfer_event(
+async fn parse_transfer_event (
     account_id: &AccountId32,
-    extrinsic: &FoundExtrinsic<AssetHubConfig, AssetHubOnlineClient, TransferExtrinsic>,
+    extrinsic: &AnyTransferExtrinsic,
 ) -> Option<(TxKind, AccountId32, Balance)> {
     let acc_id = subxt::utils::AccountId32::from(account_id.0);
-    let events = extrinsic.details.events().await.ok()?;
+    let events = extrinsic.details().events().await.ok()?;
 
     let mut found_events = events
         .find::<TransferredEvent>()
@@ -99,7 +106,7 @@ pub fn start_chain_watch(
             let mut watched_accounts = HashMap::new();
             let mut shutdown = false;
 
-            for endpoint in &chain.endpoints {
+            for endpoint in chain.endpoints.iter().cycle() {
                 // not restarting chain if shutdown is in progress
                 if shutdown || cancellation_token.is_cancelled() {
                     tracing::info!("Received {} signal, shut down ChainWatch", if shutdown { "shutdown" } else { "task cancellation" });
@@ -143,7 +150,6 @@ pub fn start_chain_watch(
 
                     // prepare chain
                     let watcher = match ChainWatcher::prepare_chain(
-                        &client,
                         &subxt_client,
                         chain.clone(),
                         &mut watched_accounts,
@@ -151,6 +157,7 @@ pub fn start_chain_watch(
                         chain_tx.clone(),
                         state.interface(),
                         task_tracker.clone(),
+                        cancellation_token.clone(),
                     )
                         .await
                     {
@@ -164,6 +171,8 @@ pub fn start_chain_watch(
                             continue;
                         }
                     };
+
+                    tracing::info!("Start monitoring on {} rpc", endpoint);
 
                     // fulfill requests
                     while let Ok(Some(req)) =
@@ -200,15 +209,23 @@ pub fn start_chain_watch(
                                         tracing::debug!("Got a block with timestamp {timestamp:?} & {} extrinsics", extrinsics.len());
 
                                         // TODO: handle Err results? Log them at least?
-                                        let transfer_extrinsics: Vec<_> = extrinsics.find::<TransferExtrinsic>().filter_map(Result::ok).collect();
+                                        let transfer_extrinsics = extrinsics.find::<TransferExtrinsic>()
+                                            .filter_map(Result::ok)
+                                            .map(|e| AnyTransferExtrinsic::Transfer(e));
+
+                                        let transfer_all_extrinsics = extrinsics.find::<TransferAllExtrinsic>()
+                                            .filter_map(Result::ok)
+                                            .map(|e| AnyTransferExtrinsic::TransferAll(e));
+
+                                        let all_transfer_extrinsics: Vec<_> = transfer_extrinsics.chain(transfer_all_extrinsics).collect();
 
                                         // TODO: Current implementation is quite unoptimized for work with subxt, need to be refactored
                                         for (id, invoice) in &watched_accounts {
-                                            for extrinsic in &transfer_extrinsics {
+                                            for extrinsic in &all_transfer_extrinsics {
                                                 if let Some((tx_kind, another_account, transfer_amount)) = parse_transfer_event(&invoice.address, extrinsic).await {
                                                     tracing::debug!("Found {tx_kind:?} from/to {another_account:?} with {transfer_amount:?} token(s).");
-                                                    let position_in_block = extrinsic.details.index();
-                                                    let raw_extrinsic = extrinsic.details.bytes();
+                                                    let position_in_block = extrinsic.details().index();
+                                                    let raw_extrinsic = extrinsic.details().bytes();
 
                                                     #[expect(clippy::arithmetic_side_effects)]
                                                     let finalized_tx_timestamp = (OffsetDateTime::UNIX_EPOCH + Duration::from_millis(timestamp))
@@ -385,9 +402,6 @@ pub fn start_chain_watch(
 #[derive(Debug, Clone)]
 pub struct ChainWatcher {
     pub genesis_hash: BlockHash,
-    pub metadata: RuntimeMetadataV15,
-    #[expect(dead_code)]
-    pub specs: ShortSpecs,
     pub assets: HashMap<String, CurrencyProperties>,
     // TODO: version parameter removed. Earlier it was checked in each block.
     // Subxt docs recommends use updater() for similiar purpose, need to implement
@@ -396,7 +410,6 @@ pub struct ChainWatcher {
 
 impl ChainWatcher {
     pub async fn prepare_chain(
-        old_client: &WsClient,
         client: &AssetHubOnlineClient,
         chain: Chain,
         watched_accounts: &mut HashMap<String, Invoice>,
@@ -404,6 +417,7 @@ impl ChainWatcher {
         chain_tx: mpsc::Sender<ChainTrackerRequest>,
         state: State,
         task_tracker: TaskTracker,
+        cancellation_token: CancellationToken,
     ) -> Result<Self, ChainError> {
         // TODO: !!! THIS METHOD SHOULD BE REFACTORED ASAP !!!
         // Currently it subscribes for full blocks but sends only block's hash to another task
@@ -415,7 +429,6 @@ impl ChainWatcher {
         let full_block = blocks.next().await.ok_or_else(|| ChainError::BlockSubscriptionTerminated)??;
         let block = BlockHash(full_block.hash());
 
-        tracing::info!("Susbcribed, fetch data using old client...");
         // TODO: it doesn't seem necessery and probably will be removed or should be rewritten otherwise
         // let name = <RuntimeMetadataV15 as AsMetadata<()>>::spec_name_version(&metadata)?.spec_name;
         // if name != chain.name {
@@ -425,11 +438,6 @@ impl ChainWatcher {
         //         rpc: rpc_url.to_string(),
         //     });
         // }
-
-        // TODO: seems like we'll be able to get rid of this metadata and specs when we'll completely move to subxt.
-        // Leave as is for some time but later should be either removed or refactored
-        let metadata = metadata(&old_client, &block).await?;
-        let specs = specs(old_client, &metadata, &block).await?;
 
         // TODO: in future we plan to use single asset, won't need to iterate over all of them.
         // It can be optimized using futures::iter and request values concurrently.
@@ -469,8 +477,6 @@ impl ChainWatcher {
 
         let chain_watcher = ChainWatcher {
             genesis_hash,
-            metadata,
-            specs,
             assets,
         };
 
@@ -496,28 +502,39 @@ impl ChainWatcher {
 
         let rpc = rpc_url.to_string();
         task_tracker.spawn(format!("watching blocks at {rpc}"), async move {
+            tracing::info!("Start watching blocks task for {:?}", rpc);
+
+            // TODO: task doesn't terminate cause not listen for the termination signal
             loop {
-                let next_block_number = {
-                    blocks.next().await.ok_or_else(|| ChainError::BlockSubscriptionTerminated)?.map(|block| block.number())
-                };
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        tracing::info!("Received task cancellation signal, shut down ChainWatch");
+                        break
+                    },
+                    block = blocks.next() => {
+                        let next_block_number = {
+                            block.ok_or_else(|| ChainError::BlockSubscriptionTerminated)?.map(|block| block.number())
+                        };
 
-                match next_block_number {
-                    Ok(block_number) => {
-                        tracing::debug!("received block {block_number} from {rpc}");
-                        let result = chain_tx
-                            .send(ChainTrackerRequest::NewBlock(block_number))
-                            .await;
+                        match next_block_number {
+                            Ok(block_number) => {
+                                tracing::debug!("received block {block_number} from {rpc}");
+                                let result = chain_tx
+                                    .send(ChainTrackerRequest::NewBlock(block_number))
+                                    .await;
 
-                        if let Err(e) = result {
-                            tracing::warn!(
-                                "Block watch internal communication error: {e} at {rpc}"
-                            );
-                            break;
+                                if let Err(e) = result {
+                                    tracing::warn!(
+                                        "Block watch internal communication error: {e} at {rpc}"
+                                    );
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn! {"Block watch error: {e} at {rpc}"};
+                                break;
+                            }
                         }
-                    }
-                    Err(e) => {
-                        tracing::warn! {"Block watch error: {e} at {rpc}"};
-                        break;
                     }
                 }
             }

--- a/src/chain/tracker.rs
+++ b/src/chain/tracker.rs
@@ -2,17 +2,14 @@
 
 use crate::{
     chain::{
-        definitions::{BlockHash, ChainTrackerRequest, Invoice},
-        payout::payout,
-        rpc::{
+        definitions::{BlockHash, ChainTrackerRequest, Invoice}, payout::payout, rpc::{
             assets_set_at_block, block_hash, genesis_hash, metadata, next_block, next_block_number,
             runtime_version_identifier, specs, subscribe_blocks, transfer_events,
-        },
-        utils::parse_transfer_event,
+        }, utils::parse_transfer_event, AssetHubOnlineClient
     },
     database::{FinalizedTxDb, TransactionInfoDb, TransactionInfoDbInner, TxKind},
     definitions::{
-        api_v2::{Amount, CurrencyProperties, Health, RpcInfo, TxStatus},
+        api_v2::{Amount, CurrencyProperties, Health, RpcInfo, TokenKind, TxStatus},
         Chain,
     },
     error::{ChainError, Error},
@@ -71,6 +68,21 @@ pub fn start_chain_watch(
                 tracing::info!("Trying to establish connection to endpoint {:?}...", endpoint);
                 let client_result = WsClientBuilder::default().build(endpoint).await;
 
+                let subxt_client = match AssetHubOnlineClient::from_url(endpoint).await {
+                    Ok(client) => client,
+                    Err(error) => {
+                        tracing::error!("Error while initialize subxt WS client for endpoint {:?}: {:?}", endpoint, error);
+
+                        drop(rpc_update_tx.send(RpcInfo {
+                            chain_name: chain.name.clone(),
+                            rpc_url: endpoint.clone(),
+                            status: Health::Critical,
+                        }).await);
+
+                        continue
+                    }
+                };
+
                 // TODO: rewrite to match. SKip for now to avoid large diff in git because of spacing
                 if let Ok(client) = client_result {
                     tracing::info!("Connection to endpoint {:?} established, start watching", endpoint);
@@ -84,6 +96,7 @@ pub fn start_chain_watch(
                     // prepare chain
                     let watcher = match ChainWatcher::prepare_chain(
                         &client,
+                        &subxt_client,
                         chain.clone(),
                         &mut watched_accounts,
                         endpoint,
@@ -124,12 +137,6 @@ pub fn start_chain_watch(
                                 };
 
                                 tracing::debug!("Block hash {} from {}", block.to_string(), chain.name);
-
-                                if watcher.version != runtime_version_identifier(&client, &block).await? {
-                                    tracing::info!("Different runtime version reported! Restarting connection...");
-                                    break;
-                                }
-
                                 tracing::debug!("Watched accounts: {watched_accounts:?}");
 
                                 #[expect(clippy::cast_possible_truncation)]
@@ -317,13 +324,16 @@ pub struct ChainWatcher {
     #[expect(dead_code)]
     pub specs: ShortSpecs,
     pub assets: HashMap<String, CurrencyProperties>,
-    version: Value,
+    // TODO: version parameter removed. Earlier it was checked in each block.
+    // Subxt docs recommends use updater() for similiar purpose, need to implement
+    // https://docs.rs/subxt/latest/subxt/client/struct.OnlineClient.html#method.updater
 }
 
 impl ChainWatcher {
     #[expect(clippy::too_many_lines)]
     pub async fn prepare_chain(
-        client: &WsClient,
+        old_client: &WsClient,
+        client: &AssetHubOnlineClient,
         chain: Chain,
         watched_accounts: &mut HashMap<String, Invoice>,
         rpc_url: &str,
@@ -331,54 +341,61 @@ impl ChainWatcher {
         state: State,
         task_tracker: TaskTracker,
     ) -> Result<Self, ChainError> {
-        let genesis_hash = genesis_hash(client).await?;
-        let mut blocks = subscribe_blocks(client).await?;
-        let block = next_block(client, &mut blocks).await?;
-        let version = runtime_version_identifier(client, &block).await?;
-        let metadata = metadata(client, &block).await?;
-        let name = <RuntimeMetadataV15 as AsMetadata<()>>::spec_name_version(&metadata)?.spec_name;
-        if name != chain.name {
-            return Err(ChainError::WrongNetwork {
-                expected: chain.name,
-                actual: name,
-                rpc: rpc_url.to_string(),
-            });
-        }
-        let specs = specs(client, &metadata, &block).await?;
-        let mut assets =
-            assets_set_at_block(client, &block, &metadata, rpc_url, specs.clone()).await?;
+        // TODO: !!! THIS METHOD SHOULD BE REFACTORED ASAP !!!
+        // Currently it subscribes for full blocks but sends only block's hash to another task
+        // which fetch this block again. It's a legacy of previous implementation. Leave it as is
+        // for now to avoid too large code diffs in commits.
+        // Probably this method should only perform some checks but not subscribe on anything
+        let genesis_hash = BlockHash(client.genesis_hash());
+        let mut blocks = client.blocks().subscribe_finalized().await?;
+        let full_block = blocks.next().await.ok_or_else(|| ChainError::BlockSubscriptionTerminated)??;
+        let block = BlockHash(full_block.hash());
 
-        // Remove unwanted assets
-        assets = assets
-            .into_iter()
-            .filter_map(|(asset_name, properties)| {
-                tracing::info!(
-                    "chain {} has token {} with properties {:?}",
-                    &chain.name,
-                    &asset_name,
-                    &properties
-                );
+        // TODO: it doesn't seem necessery and probably will be removed or should be rewritten otherwise
+        // let name = <RuntimeMetadataV15 as AsMetadata<()>>::spec_name_version(&metadata)?.spec_name;
+        // if name != chain.name {
+        //     return Err(ChainError::WrongNetwork {
+        //         expected: chain.name,
+        //         actual: name,
+        //         rpc: rpc_url.to_string(),
+        //     });
+        // }
 
-                chain
-                    .assets
-                    .iter()
-                    .find(|a| Some(a.id) == properties.asset_id)
-                    .map(|a| (a.name.clone(), properties))
-            })
-            .collect();
+        // TODO: seems like we'll be able to get rid of this metadata and specs when we'll completely move to subxt.
+        // Leave as is for some time but later should be either removed or refactored
+        let metadata = metadata(&old_client, &block).await?;
+        let specs = specs(old_client, &metadata, &block).await?;
 
-        // Deduplication is done on chain manager level;
-        // Check that we have same number of assets as requested (we've checked that we have only
-        // wanted ones and performed deduplication before)
-        //
-        // This is probably an optimisation, but I don't have time to analyse perfirmance right
-        // now, it's just simpler to implement
-        //
-        // TODO: maybe check if at least one endpoint responds with proper assets and if not, shut
-        // down
-        #[expect(clippy::arithmetic_side_effects)]
-        if assets.len() != chain.assets.len() {
-            return Err(ChainError::AssetsInvalid(chain.name));
+        // TODO: in future we plan to use single asset, won't need to iterate over all of them.
+        // It can be optimized using futures::iter and request values concurrently though.
+        // Also if we'll need to fetch many assets (or even all available on chain)
+        // it's gonna be easier to use `metadata_iter` storage method
+        let mut assets = HashMap::new();
+
+        // TODO: add check that there is at least one asset? Seems to be better have that check on config validation
+        for asset in chain.assets {
+            let request_data = crate::chain::runtime::storage().assets().metadata(asset.id.into());
+
+            let Some(response) = client
+                .storage()
+                .at_latest()
+                .await?
+                .fetch(&request_data)
+                .await?
+                else {
+                    panic!("Asset {} with id {} not found on chain {}", asset.name, asset.id, chain.endpoint)
+                };
+
+            let properties = CurrencyProperties {
+                chain_name: "statemint".to_string(),  // TODO: this field can be removed in future as long as we support only Asset Hub chain
+                kind: TokenKind::Asset,               // TODO: this field can be removed in future as long as we work only with assets on Asset Hub
+                decimals: response.decimals,
+                rpc_url: chain.endpoint.clone(),      // TODO: this property seems to be unused
+                asset_id: Some(asset.id),
+                ss58: 0,                              // TODO: this property seems to be unused
+            };
+
+            assets.insert(asset.name, properties);
         }
         // this MUST assert that assets match exactly before reporting it
 
@@ -389,13 +406,12 @@ impl ChainWatcher {
             metadata,
             specs,
             assets,
-            version,
         };
 
         // check monitored accounts
         let mut id_remove_list = Vec::new();
         for (id, account) in watched_accounts.iter() {
-            let result = account.check(client, &chain_watcher, &block).await;
+            let result = account.check(old_client, &chain_watcher, &block).await;
 
             match result {
                 Ok(true) => {
@@ -415,7 +431,10 @@ impl ChainWatcher {
         let rpc = rpc_url.to_string();
         task_tracker.spawn(format!("watching blocks at {rpc}"), async move {
             loop {
-                let next_block_number = next_block_number(&mut blocks).await;
+                let next_block_number = {
+                    blocks.next().await.ok_or_else(|| ChainError::BlockSubscriptionTerminated)?.map(|block| block.number())
+                };
+
                 match next_block_number {
                     Ok(block_number) => {
                         tracing::debug!("received block {block_number} from {rpc}");

--- a/src/chain/tracker.rs
+++ b/src/chain/tracker.rs
@@ -3,37 +3,32 @@
 use crate::{
     chain::{
         definitions::{BlockHash, ChainTrackerRequest, Invoice}, payout::payout, rpc::{
-            assets_set_at_block, block_hash, genesis_hash, metadata, next_block, next_block_number,
-            runtime_version_identifier, specs, subscribe_blocks, transfer_events,
+            block_hash, metadata,
+            specs, transfer_events,
         }, utils::parse_transfer_event, AssetHubOnlineClient
-    },
-    database::{FinalizedTxDb, TransactionInfoDb, TransactionInfoDbInner, TxKind},
-    definitions::{
+    }, database::{FinalizedTxDb, TransactionInfoDb, TransactionInfoDbInner, TxKind}, definitions::{
         api_v2::{Amount, CurrencyProperties, Health, RpcInfo, TokenKind, TxStatus},
         Chain,
-    },
-    error::{ChainError, Error},
-    signer::Signer,
-    state::State,
-    utils::task_tracker::TaskTracker,
+    }, error::{ChainError, Error}, signer::Signer, state::State, utils::task_tracker::TaskTracker
 };
 use frame_metadata::v15::RuntimeMetadataV15;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
-use serde_json::Value;
 use std::{collections::HashMap, time::SystemTime};
 use substrate_crypto_light::common::AsBase58;
-use substrate_parser::{AsMetadata, ShortSpecs};
+use substrate_parser::ShortSpecs;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::{
     sync::mpsc,
     time::{timeout, Duration},
 };
 use tokio_util::sync::CancellationToken;
+use subxt_signer::SecretString;
 
 // TODO: check if it's DEFINITELY won't break something
 #[expect(tail_expr_drop_order)]
 #[expect(clippy::too_many_lines, clippy::too_many_arguments)]
 pub fn start_chain_watch(
+    seed_secret: SecretString,
     chain: Chain,
     chain_tx: mpsc::Sender<ChainTrackerRequest>,
     mut chain_rx: mpsc::Receiver<ChainTrackerRequest>,
@@ -226,7 +221,7 @@ pub fn start_chain_watch(
                                 // accounts, every time. Please submit a PR or an issue if you
                                 // figure out a reliable optimization for this.
                                 for (id, invoice) in &watched_accounts {
-                                    match invoice.check(&client, &watcher, &block).await {
+                                    match invoice.check(&subxt_client, &watcher).await {
                                         Ok(true) => {
                                             state.order_paid(id.clone()).await;
                                         },
@@ -240,7 +235,7 @@ pub fn start_chain_watch(
                                         match state.is_order_paid(id.clone()).await {
                                             Ok(paid_db) => {
                                                 if !paid_db {
-                                                    match invoice.check(&client, &watcher, &block).await {
+                                                    match invoice.check(&subxt_client, &watcher).await {
                                                         Ok(paid) => {
                                                             if paid {
                                                                 state.order_paid(id.clone()).await;
@@ -273,24 +268,39 @@ pub fn start_chain_watch(
                             }
                             ChainTrackerRequest::Reap(request) => {
                                 let id = request.id.clone();
-                                let rpc = endpoint.clone();
                                 let reap_state_handle = state.interface();
                                 let watcher_for_reaper = watcher.clone();
-                                let signer_for_reaper = signer.interface();
+                                let seed = seed_secret.clone();
+                                let client_cloned = subxt_client.clone();
 
                                 task_tracker.clone().spawn(format!("Initiate payout for order {}", id.clone()), async move {
-                                    drop(payout(rpc, Invoice::from_request(request), reap_state_handle, watcher_for_reaper, signer_for_reaper).await);
+                                    let _ = payout(
+                                        client_cloned,
+                                        Invoice::from_request(request),
+                                        reap_state_handle,
+                                        watcher_for_reaper,
+                                        seed,
+                                    ).await?;
+
                                     Ok(format!("Payout attempt for order {id} terminated"))
                                 });
                             }
                             ChainTrackerRequest::ForceReap(request) => {
                                 let id = request.id.clone();
-                                let rpc = endpoint.clone();
                                 let reap_state_handle = state.interface();
                                 let watcher_for_reaper = watcher.clone();
-                                let signer_for_reaper = signer.interface();
+                                let client_cloned = subxt_client.clone();
+                                let seed = seed_secret.clone();
+
                                 task_tracker.clone().spawn(format!("Initiate forced payout for order {}", id.clone()), async move {
-                                    drop(payout(rpc, Invoice::from_request(request), reap_state_handle, watcher_for_reaper, signer_for_reaper).await);
+                                    let _ = payout(
+                                        client_cloned,
+                                        Invoice::from_request(request),
+                                        reap_state_handle,
+                                        watcher_for_reaper,
+                                        seed,
+                                    ).await?;
+
                                     Ok(format!("Forced payout attempt for order {id} terminated"))
                                 });
                             }
@@ -349,6 +359,7 @@ impl ChainWatcher {
         let full_block = blocks.next().await.ok_or_else(|| ChainError::BlockSubscriptionTerminated)??;
         let block = BlockHash(full_block.hash());
 
+        tracing::info!("Susbcribed, fetch data using old client...");
         // TODO: it doesn't seem necessery and probably will be removed or should be rewritten otherwise
         // let name = <RuntimeMetadataV15 as AsMetadata<()>>::spec_name_version(&metadata)?.spec_name;
         // if name != chain.name {
@@ -365,7 +376,7 @@ impl ChainWatcher {
         let specs = specs(old_client, &metadata, &block).await?;
 
         // TODO: in future we plan to use single asset, won't need to iterate over all of them.
-        // It can be optimized using futures::iter and request values concurrently though.
+        // It can be optimized using futures::iter and request values concurrently.
         // Also if we'll need to fetch many assets (or even all available on chain)
         // it's gonna be easier to use `metadata_iter` storage method
         let mut assets = HashMap::new();
@@ -381,6 +392,7 @@ impl ChainWatcher {
                 .fetch(&request_data)
                 .await?
                 else {
+                    // TODO: panic or work without this asset? Need to notify user about error somehow
                     panic!("Asset {} with id {} not found on chain {}", asset.name, asset.id, chain.name)
                 };
 
@@ -409,7 +421,7 @@ impl ChainWatcher {
         // check monitored accounts
         let mut id_remove_list = Vec::new();
         for (id, account) in watched_accounts.iter() {
-            let result = account.check(old_client, &chain_watcher, &block).await;
+            let result = account.check(client, &chain_watcher).await;
 
             match result {
                 Ok(true) => {

--- a/src/database.rs
+++ b/src/database.rs
@@ -626,7 +626,7 @@ pub enum TxKind {
     Withdrawal,
 }
 
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, Debug)]
 pub struct FinalizedTxDb {
     pub block_number: BlockNumber,
     pub position_in_block: ExtrinsicIndex,

--- a/src/error.rs
+++ b/src/error.rs
@@ -313,6 +313,9 @@ pub enum ChainError {
 
     #[error("transfer event has no matching extrinsic")]
     TransferEventNoExtrinsic,
+
+    #[error("subxt error")]
+    Subxt(#[from] subxt::Error)
 }
 
 #[derive(Debug, Error)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use subxt_signer::SecretString;
 use std::process::ExitCode;
 use substrate_crypto_light::common::{AccountId32, AsBase58};
 use tokio::{runtime::Runtime, sync::oneshot};
@@ -126,7 +127,10 @@ async fn async_try_main(
         .map_err(|e| Error::RecipientAccount(e.to_string()))?
         .0;
 
-    let signer = Signer::init(recipient, &task_tracker, seed_env_vars.seed);
+    // TODO: quite dirty hack to make it work right now. Should be refactored ASAP.
+    // Spawn separate task for handling payouts. This task should replace Signer and store seed phrase
+    let signer = Signer::init(recipient, &task_tracker, seed_env_vars.seed.clone());
+    let seed_secret = SecretString::from(seed_env_vars.seed);
 
     let db = database::Database::init(database_path, &task_tracker, config.account_lifetime)?;
 
@@ -151,6 +155,7 @@ async fn async_try_main(
 
     cm_tx
         .send(ChainManager::ignite(
+            seed_secret,
             config.chain,
             &state,
             &signer,


### PR DESCRIPTION
This PR was branched out from [refactor: use only asset-hub (statemint) chain](https://github.com/Kalapaja/Kalatori/pull/214) and contains it's changes, please review this one only after merge of previous PR