### PR TITLE
fix: balance checker invoice finder

### DIFF
--- a/daemon/src/balance_checker.rs
+++ b/daemon/src/balance_checker.rs
@@ -29,6 +29,7 @@ pub enum BalanceCheckerError {
     InvoiceNotFound { invoice_id: Uuid },
     FetchBalanceFailed,
     FetchTransfersFailed,
+    DatabaseError,
 }
 
 #[derive(Clone)]
@@ -37,6 +38,7 @@ pub struct BalanceChecker<
     AH: BlockChainClient<AssetHubChainConfig> + 'static = AssetHubClient,
     PG: BlockChainClient<PolygonChainConfig> + 'static = PolygonClient,
 > {
+    dao: D,
     registry: InvoiceRegistry,
     asset_hub_client: AH,
     polygon_client: PG,
@@ -51,6 +53,7 @@ impl<
 > BalanceChecker<D, AH, PG>
 {
     pub fn new(
+        dao: D,
         registry: InvoiceRegistry,
         asset_hub_client: AH,
         polygon_client: PG,
@@ -58,6 +61,7 @@ impl<
         transactions_recorder: TransactionsRecorder<D>,
     ) -> Self {
         Self {
+            dao,
             registry,
             asset_hub_client,
             polygon_client,
@@ -212,20 +216,40 @@ impl<
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn check_invoice_balance(
         &self,
         invoice_id: Uuid,
     ) -> Result<InvoiceWithReceivedAmount, BalanceCheckerError> {
-        let Some(mut invoice) = self
+        let mut invoice = if let Some(invoice) = self
             .registry
             .get_invoice(&invoice_id)
             .await
-        else {
-            // TODO: in that case we probably should try to fetch invoice with amounts from
-            // database
-            return Err(BalanceCheckerError::InvoiceNotFound {
-                invoice_id,
-            })
+        {
+            tracing::trace!(
+                ?invoice,
+                "Invoice for balance checking is found in registry"
+            );
+            invoice
+        } else {
+            self.dao
+                .get_invoice_with_received_amount_by_id(invoice_id)
+                .await
+                .map_err(|e| {
+                    tracing::warn!(
+                        error = ?e,
+                        "Failed to get invoice with received amounts from database"
+                    );
+
+                    BalanceCheckerError::DatabaseError
+                })?
+                .inspect(|invoice| tracing::trace!(
+                    ?invoice,
+                    "Invoice for balance checking wasn't found in registry but is found in database"
+                ))
+                .ok_or(BalanceCheckerError::InvoiceNotFound {
+                    invoice_id,
+                })?
         };
 
         let received_amount = invoice.total_received_amount;
@@ -240,6 +264,11 @@ impl<
         if received_amount != balance {
             self.get_and_store_transactions(&mut invoice, balance)
                 .await?;
+        } else {
+            tracing::trace!(
+                ?balance,
+                "Invoice received amount is equal to payment address balance"
+            )
         }
 
         Ok(invoice)

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -328,6 +328,7 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
     );
 
     let balance_checker = BalanceChecker::new(
+        dao.clone(),
         invoice_registry.clone(),
         asset_hub_client.clone(),
         polygon_client.clone(),

--- a/daemon/src/swaps/tracker.rs
+++ b/daemon/src/swaps/tracker.rs
@@ -135,6 +135,8 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
                         .await
                         .map_err(|_| SwapsTrackerError::DatabaseError)?;
 
+                    // TODO: check error, if it's Invoice not found, skip monitoring (shouldn't
+                    // happen though)
                     let invoice = self
                         .balance_checker
                         .check_invoice_balance(swap.request.invoice_id)
@@ -252,6 +254,8 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
                         .await
                         .map_err(|_| SwapsTrackerError::DatabaseError)?;
 
+                    // TODO: check error, if it's Invoice not found, skip monitoring (shouldn't
+                    // happen though)
                     let invoice = self
                         .balance_checker
                         .check_invoice_balance(swap.request.invoice_id)
@@ -360,6 +364,8 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
                         .await
                         .map_err(|_| SwapsTrackerError::DatabaseError)?;
 
+                    // TODO: check error, if it's Invoice not found, skip monitoring (shouldn't
+                    // happen though)
                     let invoice = self
                         .balance_checker
                         .check_invoice_balance(swap.request.invoice_id)


### PR DESCRIPTION
In balance checker fetch invoice from database if it's not found in local registry. It's useful in case when the daemon detected transaction on chain and marked invoice as paid (and removed from registry) earlier then swap executor returned swap status as finished