### PR TITLE
feat: add default slippage params for default assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6414,9 +6414,20 @@ dependencies = [
  "num-traits",
  "rand 0.8.6",
  "rkyv",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "rust_decimal_macros"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a5a6f027e892c7a035c6fddb50435a1fbf5a734ffc0c2a9fed4d0221440519"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -18,7 +18,7 @@ kalatori-client = { path = "../client", features = ["axum-middleware", "sqlx-typ
 
 # Types and data serialization utils
 uuid = { version = "1", features = ["v4", "serde"] }
-rust_decimal = { version = "1", features = ["serde"] }
+rust_decimal = { version = "1", features = ["serde", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }

--- a/daemon/src/configs/consts.rs
+++ b/daemon/src/configs/consts.rs
@@ -4,6 +4,11 @@ use std::net::{
 };
 use std::num::NonZeroU32;
 
+use rust_decimal::{
+    Decimal,
+    dec,
+};
+
 use kalatori_client::types::ChainType;
 
 pub const DEFAULT_CONFIG_DIR_PATH: &str = "configs";
@@ -20,6 +25,10 @@ pub const DEFAULT_POLYGON_ENDPOINTS: &[&str] = &[
 
 /// Native USDC on Polygon PoS (Circle's official deployment)
 pub const DEFAULT_POLYGON_USDC_ADDRESS: &str = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
+
+pub const DEFAULT_UNDERPAYMENT_TOLERANCE: Decimal = dec!(0.1);
+
+pub const DEFAULT_OVERPAYMENT_TOLERANCE: Decimal = dec!(0.1);
 
 pub const DEFAULT_INVOICE_LIFETIME_MILLIS: u64 = 86_400_000; // 24 hours
 

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -30,11 +30,13 @@ use super::consts::{
     DEFAULT_HOST,
     DEFAULT_INVOICE_LIFETIME_MILLIS,
     DEFAULT_LOG_DIRECTIVES,
+    DEFAULT_OVERPAYMENT_TOLERANCE,
     DEFAULT_POLKADOT_ASSET_HUB_ENDPOINTS,
     DEFAULT_POLYGON_ENDPOINTS,
     DEFAULT_POLYGON_USDC_ADDRESS,
     DEFAULT_PORT,
     DEFAULT_SIGNATURE_MAX_AGE_SECS,
+    DEFAULT_UNDERPAYMENT_TOLERANCE,
 };
 
 #[derive(Deserialize)]
@@ -254,6 +256,15 @@ impl PaymentsConfig {
             self.default_asset_id
                 .entry(chain)
                 .or_insert(default.to_string());
+
+            self.slippage_params
+                .entry(chain)
+                .or_default()
+                .entry(default.to_string())
+                .or_insert(SlippageParams {
+                    underpayment_tolerance: DEFAULT_UNDERPAYMENT_TOLERANCE,
+                    overpayment_tolerance: DEFAULT_OVERPAYMENT_TOLERANCE,
+                });
         }
     }
 


### PR DESCRIPTION
add default slippage params for default assets (0.1 USD equivalent for both overpayment and underpayment)