### PR TITLE
feat: fail-closed database startup gate and integrity check

### DIFF
--- a/configs/database.json.example
+++ b/configs/database.json.example
@@ -1,0 +1,5 @@
+{
+  "dir": "./database",
+  "temporary": false,
+  "require_existing": false
+}

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -378,6 +378,8 @@ pub struct DatabaseConfig {
     pub dir: String,
     #[serde(default)]
     pub temporary: bool,
+    #[serde(default)]
+    pub require_existing: bool,
 }
 
 fn default_signature_max_age_secs() -> u64 {

--- a/daemon/src/dao.rs
+++ b/daemon/src/dao.rs
@@ -26,6 +26,7 @@ use sqlx::{
 use tokio::sync::Mutex;
 
 use crate::configs::DatabaseConfig;
+use crate::error::DaoError;
 
 // Export domain-specific errors
 pub use changes::DaoChangesError;
@@ -169,7 +170,17 @@ pub struct DAO {
 }
 
 impl DAO {
-    pub async fn new(config: DatabaseConfig) -> DaoResult<Self> {
+    pub async fn new(config: DatabaseConfig) -> Result<Self, DaoError> {
+        if config.require_existing && config.temporary {
+            return Err(DaoError::IncompatibleDatabaseConfig);
+        }
+
+        let database_path = if config.temporary {
+            ":memory:".to_string()
+        } else {
+            format!("{}/{}", config.dir, SQLITE_FILE_NAME)
+        };
+
         let (pool_options, connection_options) = if config.temporary {
             tracing::info!("Using in-memory temporary database");
             let pool_opts = sqlx::sqlite::SqlitePoolOptions::new().max_connections(1);
@@ -178,8 +189,17 @@ impl DAO {
                 .in_memory(true);
             (pool_opts, conn_opts)
         } else {
-            if !std::fs::exists(&config.dir)? {
-                std::fs::create_dir_all(&config.dir)?;
+            if config.require_existing {
+                let is_nonempty_file = std::fs::metadata(&database_path)
+                    .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0);
+                if !is_nonempty_file {
+                    return Err(DaoError::RequiredDatabaseMissing {
+                        path: database_path,
+                    });
+                }
+            }
+            if !std::fs::exists(&config.dir).map_err(sqlx::Error::Io)? {
+                std::fs::create_dir_all(&config.dir).map_err(sqlx::Error::Io)?;
                 tracing::warn!(
                     "Failed to find sqlite3 database directory at {}. Created new directory at {} with database file {} inside.",
                     config.dir,
@@ -189,18 +209,18 @@ impl DAO {
             }
             let pool_opts = sqlx::sqlite::SqlitePoolOptions::new();
             let conn_opts = sqlx::sqlite::SqliteConnectOptions::new()
-                .create_if_missing(true)
-                .filename(format!(
-                    "{}/{}",
-                    config.dir, SQLITE_FILE_NAME,
-                ));
+                .create_if_missing(!config.require_existing)
+                .filename(&database_path);
             (pool_opts, conn_opts)
         };
 
         let pool = pool_options
             .connect_with(connection_options)
             .await
-            .expect("Failed to create database connection pool");
+            .map_err(|source| DaoError::DatabaseOpen {
+                path: database_path.clone(),
+                source,
+            })?;
 
         let dao = Self {
             pool,
@@ -211,6 +231,25 @@ impl DAO {
             "Current SQLite version: {}",
             sqlite_version
         );
+
+        let integrity_rows: Vec<String> = sqlx::query_scalar("PRAGMA integrity_check")
+            .fetch_all(&dao.pool)
+            .await
+            .map_err(|source| DaoError::DatabaseOpen {
+                path: database_path.clone(),
+                source,
+            })?;
+        if integrity_rows.as_slice() != ["ok"] {
+            for row in integrity_rows {
+                tracing::error!(
+                    database_path,
+                    sqlite_integrity_check = row
+                );
+            }
+            return Err(DaoError::IntegrityCheckFailed {
+                path: database_path,
+            });
+        }
 
         tracing::info!("Run database migrations...");
 
@@ -301,9 +340,154 @@ async fn create_test_dao() -> DAO {
     let config = DatabaseConfig {
         dir: String::new(),
         temporary: true,
+        require_existing: false,
     };
 
     DAO::new(config)
         .await
         .expect("Failed to create test DAO")
+}
+
+#[cfg(test)]
+mod startup_tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "kalatori-dao-test-{}",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir(&path).expect("Failed to create test directory");
+            Self(path)
+        }
+
+        fn database_path(&self) -> PathBuf {
+            self.0.join(SQLITE_FILE_NAME)
+        }
+
+        fn config(
+            &self,
+            require_existing: bool,
+        ) -> DatabaseConfig {
+            DatabaseConfig {
+                dir: self.0.to_string_lossy().into_owned(),
+                temporary: false,
+                require_existing,
+            }
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.0).expect("Failed to remove test directory");
+        }
+    }
+
+    #[tokio::test]
+    async fn require_existing_rejects_missing_database() {
+        let directory = TestDirectory::new();
+        let database_path = directory.database_path();
+
+        let error = DAO::new(directory.config(true))
+            .await
+            .err()
+            .expect("Missing database must fail");
+
+        assert!(matches!(
+            error,
+            DaoError::RequiredDatabaseMissing { .. }
+        ));
+        assert!(
+            error.to_string().contains(
+                &database_path
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn require_existing_rejects_zero_length_database() {
+        let directory = TestDirectory::new();
+        std::fs::File::create(directory.database_path())
+            .expect("Failed to create empty database file");
+
+        let error = DAO::new(directory.config(true))
+            .await
+            .err()
+            .expect("Empty database must fail");
+
+        assert!(matches!(
+            error,
+            DaoError::RequiredDatabaseMissing { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn require_existing_accepts_initialized_database() {
+        let directory = TestDirectory::new();
+        drop(
+            DAO::new(directory.config(false))
+                .await
+                .expect("Initial database creation failed"),
+        );
+
+        DAO::new(directory.config(true))
+            .await
+            .expect("Existing database must start");
+    }
+
+    #[tokio::test]
+    async fn require_existing_is_incompatible_with_temporary_database() {
+        let error = DAO::new(DatabaseConfig {
+            dir: String::new(),
+            temporary: true,
+            require_existing: true,
+        })
+        .await
+        .err()
+        .expect("Contradictory database config must fail");
+
+        assert!(matches!(
+            error,
+            DaoError::IncompatibleDatabaseConfig
+        ));
+    }
+
+    #[tokio::test]
+    async fn garbage_database_fails_with_its_path() {
+        let directory = TestDirectory::new();
+        let database_path = directory.database_path();
+        std::fs::write(&database_path, b"not a sqlite database")
+            .expect("Failed to create corrupt database file");
+
+        let error = DAO::new(directory.config(true))
+            .await
+            .err()
+            .expect("Corrupt database must fail");
+
+        assert!(
+            error.to_string().contains(
+                &database_path
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn default_mode_creates_and_migrates_fresh_database() {
+        let directory = TestDirectory::new();
+
+        DAO::new(directory.config(false))
+            .await
+            .expect("Fresh database must start");
+
+        assert!(directory.database_path().is_file());
+    }
 }

--- a/daemon/src/dao.rs
+++ b/daemon/src/dao.rs
@@ -245,7 +245,8 @@ impl DAO {
             for row in integrity_rows {
                 tracing::error!(
                     database_path,
-                    sqlite_integrity_check = row
+                    sqlite_integrity_check = row,
+                    "SQLite integrity check reported a problem"
                 );
             }
             return Err(DaoError::IntegrityCheckFailed {

--- a/daemon/src/dao.rs
+++ b/daemon/src/dao.rs
@@ -190,8 +190,16 @@ impl DAO {
             (pool_opts, conn_opts)
         } else {
             if config.require_existing {
-                let is_nonempty_file = std::fs::metadata(&database_path)
-                    .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0);
+                let is_nonempty_file = match std::fs::metadata(&database_path) {
+                    Ok(metadata) => metadata.is_file() && metadata.len() > 0,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                    Err(source) => {
+                        return Err(DaoError::DatabaseMetadata {
+                            path: database_path,
+                            source,
+                        });
+                    },
+                };
                 if !is_nonempty_file {
                     return Err(DaoError::RequiredDatabaseMissing {
                         path: database_path,
@@ -226,16 +234,10 @@ impl DAO {
             pool,
         };
 
-        let sqlite_version = dao.sqlite_version().await?;
-        tracing::info!(
-            "Current SQLite version: {}",
-            sqlite_version
-        );
-
         let integrity_rows: Vec<String> = sqlx::query_scalar("PRAGMA integrity_check")
             .fetch_all(&dao.pool)
             .await
-            .map_err(|source| DaoError::DatabaseOpen {
+            .map_err(|source| DaoError::IntegrityCheckQuery {
                 path: database_path.clone(),
                 source,
             })?;
@@ -250,6 +252,12 @@ impl DAO {
                 path: database_path,
             });
         }
+
+        let sqlite_version = dao.sqlite_version().await?;
+        tracing::info!(
+            "Current SQLite version: {}",
+            sqlite_version
+        );
 
         tracing::info!("Run database migrations...");
 
@@ -384,7 +392,8 @@ mod startup_tests {
 
     impl Drop for TestDirectory {
         fn drop(&mut self) {
-            std::fs::remove_dir_all(&self.0).expect("Failed to remove test directory");
+            #[expect(let_underscore_drop)]
+            let _ = std::fs::remove_dir_all(&self.0);
         }
     }
 
@@ -471,6 +480,10 @@ mod startup_tests {
             .err()
             .expect("Corrupt database must fail");
 
+        assert!(matches!(
+            error,
+            DaoError::IntegrityCheckQuery { .. }
+        ));
         assert!(
             error.to_string().contains(
                 &database_path
@@ -478,6 +491,45 @@ mod startup_tests {
                     .into_owned()
             )
         );
+    }
+
+    #[tokio::test]
+    async fn garbage_database_is_rejected_without_require_existing() {
+        let directory = TestDirectory::new();
+        let database_path = directory.database_path();
+        std::fs::write(&database_path, b"not a sqlite database")
+            .expect("Failed to create corrupt database file");
+
+        let error = DAO::new(directory.config(false))
+            .await
+            .err()
+            .expect("Corrupt database must fail in default mode");
+
+        assert!(matches!(
+            error,
+            DaoError::IntegrityCheckQuery { .. }
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn require_existing_reports_metadata_errors_honestly() {
+        let directory = TestDirectory::new();
+        std::os::unix::fs::symlink(
+            SQLITE_FILE_NAME,
+            directory.database_path(),
+        )
+        .expect("Failed to create symlink loop");
+
+        let error = DAO::new(directory.config(true))
+            .await
+            .err()
+            .expect("Uninspectable database must fail");
+
+        assert!(matches!(
+            error,
+            DaoError::DatabaseMetadata { .. }
+        ));
     }
 
     #[tokio::test]

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -357,6 +357,27 @@ pub enum DaoError {
     #[error("SQLite database error")]
     Sqlx(#[from] sqlx::Error),
 
+    #[error("database migration failed")]
+    Migration(#[from] sqlx::migrate::MigrateError),
+
+    #[error(
+        "database.require_existing is set but no existing database was found at {path}; refusing to initialize an empty database (was the Litestream restore skipped?)"
+    )]
+    RequiredDatabaseMissing { path: String },
+
+    #[error("database.require_existing and database.temporary are incompatible")]
+    IncompatibleDatabaseConfig,
+
+    #[error("failed to open database at {path}")]
+    DatabaseOpen {
+        path: String,
+        #[source]
+        source: sqlx::Error,
+    },
+
+    #[error("database integrity check failed at {path}")]
+    IntegrityCheckFailed { path: String },
+
     #[error("invoice not found")]
     InvoiceNotFound,
 

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -365,6 +365,13 @@ pub enum DaoError {
     )]
     RequiredDatabaseMissing { path: String },
 
+    #[error("failed to inspect database file at {path}")]
+    DatabaseMetadata {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("database.require_existing and database.temporary are incompatible")]
     IncompatibleDatabaseConfig,
 
@@ -375,7 +382,14 @@ pub enum DaoError {
         source: sqlx::Error,
     },
 
-    #[error("database integrity check failed at {path}")]
+    #[error("database integrity check could not run at {path}")]
+    IntegrityCheckQuery {
+        path: String,
+        #[source]
+        source: sqlx::Error,
+    },
+
+    #[error("database integrity check did not pass at {path}")]
     IntegrityCheckFailed { path: String },
 
     #[error("invoice not found")]

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -236,9 +236,7 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
     );
 
     // Initialize DAO for SQLite database operations
-    let dao = DAO::new(database_config.clone())
-        .await
-        .map_err(error::DaoError::Sqlx)?;
+    let dao = DAO::new(database_config.clone()).await?;
 
     let invoice_registry = init_invoice_registry(&dao).await?;
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,7 @@ Eight config types loaded at startup (all support env var overrides):
 | Chains | `chains.json` | Chain endpoints, assets (mandatory) |
 | Payments | `payments.json` | Recipient addresses, account lifetime, default chain/asset |
 | Secrets | `secrets.json` | BIP39 seed phrase, API secret key |
-| Database | (defaults) | Database path, temporary mode |
+| Database | `database.json` | Database path, temporary mode, fail-closed existing-database requirement |
 | Web Server | (defaults) | Host, port (default 0.0.0.0:16726) |
 | Shop | `shop.json` | Webhook URL, shop metadata, signature max age |
 | Logger | `logger.json` | Log level, Loki endpoint |
@@ -136,6 +136,10 @@ Eight config types loaded at startup (all support env var overrides):
 **Security**: Seed phrase and API secret key are zeroized from env/memory after loading.
 
 Example configs in `configs/` directory.
+
+At startup, the daemon always runs SQLite's `PRAGMA integrity_check` before migrations. Set
+`require_existing` (or `KALATORI_DATABASE_REQUIRE_EXISTING`) to refuse startup when the configured
+database file is missing or empty; this is incompatible with temporary in-memory mode.
 
 ## Background Task Management
 


### PR DESCRIPTION
Add database.require_existing (KALATORI_DATABASE_REQUIRE_EXISTING, default off): when set, a missing or zero-length kalatori_db.sqlite is a fatal startup error instead of a silently created empty database, and create_if_missing is disabled. This lets orchestrators (kapitan) fail closed when a Litestream restore is skipped due to bucket/credentials misconfiguration — previously the daemon would boot empty and the replication sidecar would push the empty database over the real replica. Combining require_existing with temporary in-memory mode is rejected as a configuration contradiction.

Unconditionally run PRAGMA integrity_check after connecting and before migrations; any result other than a single "ok" row aborts startup with sqlite's findings logged. A non-zero exit surfaces as CrashLoopBackOff under Kubernetes, gating readiness without a health endpoint.

DAO::new failure paths now return typed DaoError variants (missing database, config contradiction, open failure, integrity failure, migration failure) instead of panicking or collapsing into Sqlx.