### PR TITLE
fix(configs): say so when falling back to the public default endpoints

### DIFF
--- a/daemon/src/configs.rs
+++ b/daemon/src/configs.rs
@@ -131,7 +131,9 @@ pub fn swaps_config_with_prefix(
 ) -> SwapsConfig {
     let config_path = format_config_path(config_dir_path, "swaps.json");
     let env_prefix = format_prefix(prefix, "SWAPS");
-    config_from_file_or_env(&config_path, &env_prefix)
+    let config: SwapsConfig = config_from_file_or_env(&config_path, &env_prefix);
+    config.warn_if_zero_ex_rpc_is_public_default();
+    config
 }
 
 // #[cfg(test)]

--- a/daemon/src/configs/consts.rs
+++ b/daemon/src/configs/consts.rs
@@ -23,6 +23,11 @@ pub const DEFAULT_POLYGON_ENDPOINTS: &[&str] = &[
     "wss://polygon.drpc.org",
 ];
 
+/// Same host as the first entry of `DEFAULT_POLYGON_ENDPOINTS`, over https
+/// instead of wss. A free public node with no availability guarantee; swaps
+/// fall back to it whenever `swaps.zero_ex.rpc_url` is left unset.
+pub const DEFAULT_ZERO_EX_RPC_URL: &str = "https://polygon-bor-rpc.publicnode.com";
+
 /// Native USDC on Polygon PoS (Circle's official deployment)
 pub const DEFAULT_POLYGON_USDC_ADDRESS: &str = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
 

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -264,6 +264,16 @@ impl ChainsConfig {
                     ChainType::Polygon => DEFAULT_POLYGON_ENDPOINTS,
                 };
 
+                // These are free public endpoints with no availability guarantee.
+                // An operator who never configured any has no other way to find
+                // out which node their payments depend on.
+                tracing::warn!(
+                    chain = %chain,
+                    endpoints = ?endpoints,
+                    "No endpoints configured, falling back to free public defaults. \
+                     Configure your own endpoints for production use."
+                );
+
                 chain_config.endpoints = endpoints
                     .iter()
                     .map(|s| ChainEndpoint::Universal(s.to_string()))
@@ -823,4 +833,72 @@ pub struct SwapsConfig {
     pub zero_ex: ZeroExApiConfig,
     #[serde(default)]
     pub fees: Option<IntegratorFees>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_chains_config() -> ChainsConfig {
+        ChainsConfig {
+            chains: HashMap::new(),
+        }
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn default_endpoints_are_announced_when_none_configured() {
+        let mut config = empty_chains_config();
+
+        config.set_default_chains_if_missing();
+
+        for chain in ChainType::iter() {
+            assert!(
+                config.chains[&chain]
+                    .get_random_requests_endpoint()
+                    .is_some(),
+                "{chain} was left without endpoints"
+            );
+        }
+
+        // The point of the warning is that an operator who configured nothing
+        // can still tell from the log which node their payments depend on.
+        assert!(logs_contain(
+            "falling back to free public defaults"
+        ));
+        assert!(logs_contain(
+            "wss://polygon-bor-rpc.publicnode.com"
+        ));
+        assert!(logs_contain(
+            "wss://asset-hub-polkadot-rpc.n.dwellir.com"
+        ));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn configured_endpoints_are_left_alone_and_unannounced() {
+        let configured = "wss://polygon.example.internal";
+        let mut config = empty_chains_config();
+        config.chains.insert(
+            ChainType::Polygon,
+            ChainConfig {
+                endpoints: vec![ChainEndpoint::Universal(configured.to_string())],
+                ..ChainConfig::default()
+            },
+        );
+
+        config.set_default_chains_if_missing();
+
+        assert_eq!(
+            config.chains[&ChainType::Polygon].get_random_requests_endpoint(),
+            Some(configured.to_string()),
+        );
+        assert!(!logs_contain(
+            "wss://polygon-bor-rpc.publicnode.com"
+        ));
+        // Asset Hub was still unconfigured, so it does get the warning.
+        assert!(logs_contain(
+            "wss://asset-hub-polkadot-rpc.n.dwellir.com"
+        ));
+    }
 }

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -20,6 +20,10 @@ use crate::types::{
     ChainType,
     DetectedShopPlatform,
 };
+use crate::utils::logging::{
+    category,
+    operation,
+};
 
 use super::consts::{
     DEFAULT_ALLOW_INSECURE_ENDPOINTS,
@@ -268,7 +272,21 @@ impl ChainsConfig {
                 // These are free public endpoints with no availability guarantee.
                 // An operator who never configured any has no other way to find
                 // out which node their payments depend on.
+                //
+                // WARN rather than ERROR is a deliberate choice: this is the
+                // documented dev-mode default and the daemon runs correctly on
+                // it, so it is degraded state rather than a critical failure —
+                // the WARN row of the level table in docs/conventions.md. An
+                // operator who wants it to be fatal can promote it downstream
+                // on `error.category = "config"`.
+                //
+                // `endpoints` is the hardcoded default slice, never the
+                // operator's own value: configured endpoint URLs can carry
+                // credentials in userinfo or the path, so only compiled-in
+                // constants are ever printed here. Tests pin this down.
                 tracing::warn!(
+                    error.category = category::CONFIG,
+                    error.operation = operation::LOAD_CHAIN_ENDPOINTS,
                     chain = %chain,
                     endpoints = ?endpoints,
                     "No endpoints configured, falling back to free public defaults. \
@@ -840,6 +858,68 @@ mod tests {
         );
         logs_assert(|logs| assert_swaps_warnings(logs, 1));
     }
+
+    /// A URL an operator configured is theirs, and can carry credentials in
+    /// userinfo or in the path. The rule these warnings follow is that only
+    /// compiled-in constants are ever printed — this pair is what holds the
+    /// rule in place, since every other test here asserts on what *is* logged
+    /// and would stay green while a secret leaked alongside it.
+    ///
+    /// Only URL-borne secrets need a runtime check. `ZeroExApiConfig::api_key`
+    /// is a `SecretBox<str>`, so logging it is a compile error and its `Debug`
+    /// is redacted — a test for it could never fail. `rpc_url` beside it is a
+    /// plain `String`, which is why `?self.zero_ex` would still leak and why
+    /// the swaps case below is worth pinning.
+    const CREDENTIAL_SENTINELS: &[&str] = &["hunter2", "s3cr3t-path"];
+
+    fn assert_no_sentinel_leaked(logs: &[&str]) -> Result<(), String> {
+        for sentinel in CREDENTIAL_SENTINELS {
+            if logs
+                .iter()
+                .any(|log| log.contains(sentinel))
+            {
+                return Err(format!(
+                    "configured value `{sentinel}` reached the log"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn a_configured_chain_endpoint_never_reaches_the_log() {
+        let mut config = chains_config_from_json(r#"{"chains":{}}"#);
+        config.chains.insert(
+            ChainType::Polygon,
+            configured("wss://operator:hunter2@polygon.example.internal/s3cr3t-path"),
+        );
+
+        config.set_default_chains_if_missing();
+
+        logs_assert(|logs| {
+            // Asset Hub still fell back, so the warning path really did run.
+            assert_warned_once(logs, ChainType::PolkadotAssetHub)?;
+            assert_no_sentinel_leaked(logs)
+        });
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn a_configured_swaps_rpc_never_reaches_the_log() {
+        let config = SwapsConfig {
+            zero_ex: ZeroExApiConfig {
+                api_key: "not-a-real-key".into(),
+                rpc_url: "https://operator:hunter2@rpc.example.internal/s3cr3t-path".to_string(),
+            },
+            ..SwapsConfig::default()
+        };
+
+        config.warn_if_zero_ex_rpc_is_public_default();
+
+        logs_assert(assert_no_sentinel_leaked);
+    }
 }
 
 fn default_host() -> IpAddr {
@@ -1095,8 +1175,18 @@ impl SwapsConfig {
     /// warning exists to abolish.
     pub(super) fn warn_if_zero_ex_rpc_is_public_default(&self) {
         if self.zero_ex.rpc_url == DEFAULT_ZERO_EX_RPC_URL {
+            // Logs the constant, not `self.zero_ex.rpc_url`. The guard makes
+            // the two equal today, so this reads as a pointless substitution —
+            // it is not. Printing the field would mean the leak is prevented
+            // only by the guard's exact-equality, and any later loosening of
+            // that guard (to a host match, say) would start printing operator
+            // URLs, which can carry credentials in userinfo or the path.
+            // Sourcing the value from the constant makes that impossible by
+            // construction rather than by careful reading.
             tracing::warn!(
-                rpc_url = %self.zero_ex.rpc_url,
+                error.category = category::CONFIG,
+                error.operation = operation::LOAD_SWAPS_RPC,
+                rpc_url = DEFAULT_ZERO_EX_RPC_URL,
                 "Swaps are using a free public RPC endpoint. \
                  Set swaps.zero_ex.rpc_url to your own endpoint for production use."
             );

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -767,6 +767,41 @@ mod tests {
         });
     }
 
+    /// Counterpart of `fallback_warnings_for` for the swaps branch. The
+    /// negative case goes through this too: `!logs_contain(..)` would also be
+    /// satisfied by the warning being emitted at the wrong level, which is the
+    /// failure this pair is supposed to catch.
+    fn swaps_fallback_warnings(logs: &[&str]) -> usize {
+        logs.iter()
+            .filter(|log| log.contains(" WARN ") && log.contains(SWAPS_FALLBACK_MESSAGE))
+            .count()
+    }
+
+    fn assert_swaps_warnings(
+        logs: &[&str],
+        expected: usize,
+    ) -> Result<(), String> {
+        let found = swaps_fallback_warnings(logs);
+
+        if found == expected {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected exactly {expected} swaps fallback WARN, found {found}"
+            ))
+        }
+    }
+
+    fn private_swaps_config() -> SwapsConfig {
+        SwapsConfig {
+            zero_ex: ZeroExApiConfig {
+                api_key: "not-a-real-key".into(),
+                rpc_url: "https://polygon.example.internal".to_string(),
+            },
+            ..SwapsConfig::default()
+        }
+    }
+
     /// Swaps are the sibling fallback: `SwapsClients` is always constructed, so
     /// an operator who configured both payment chains and left `swaps.zero_ex`
     /// alone is still on a free public node.
@@ -775,37 +810,35 @@ mod tests {
     fn the_default_swaps_rpc_is_announced() {
         SwapsConfig::default().warn_if_zero_ex_rpc_is_public_default();
 
-        logs_assert(|logs| {
-            let count = logs
-                .iter()
-                .filter(|log| log.contains(" WARN ") && log.contains(SWAPS_FALLBACK_MESSAGE))
-                .count();
-
-            if count == 1 {
-                Ok(())
-            } else {
-                Err(format!(
-                    "expected exactly one swaps fallback WARN, found {count}"
-                ))
-            }
-        });
+        logs_assert(|logs| assert_swaps_warnings(logs, 1));
         assert!(logs_contain(DEFAULT_ZERO_EX_RPC_URL));
     }
 
     #[test]
     #[tracing_test::traced_test]
     fn a_configured_swaps_rpc_is_not_announced() {
-        let config = SwapsConfig {
-            zero_ex: ZeroExApiConfig {
-                api_key: "not-a-real-key".into(),
-                rpc_url: "https://polygon.example.internal".to_string(),
-            },
-            ..SwapsConfig::default()
-        };
+        private_swaps_config().warn_if_zero_ex_rpc_is_public_default();
 
-        config.warn_if_zero_ex_rpc_is_public_default();
+        logs_assert(|logs| assert_swaps_warnings(logs, 0));
+    }
 
-        assert!(!logs_contain(SWAPS_FALLBACK_MESSAGE));
+    /// The method being right is not the same as it being wired up. This goes
+    /// through `swaps_config_with_prefix`, the only caller, so deleting the
+    /// call in `configs.rs` fails a test rather than silently restoring the
+    /// unannounced fallback.
+    #[test]
+    #[tracing_test::traced_test]
+    fn the_swaps_loader_announces_the_public_default_too() {
+        let config = crate::configs::swaps_config_with_prefix(
+            "no-such-config-dir",
+            "KALATORI_TEST_SWAPS_FALLBACK",
+        );
+
+        assert_eq!(
+            config.zero_ex.rpc_url,
+            DEFAULT_ZERO_EX_RPC_URL
+        );
+        logs_assert(|logs| assert_swaps_warnings(logs, 1));
     }
 }
 

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -39,6 +39,7 @@ use super::consts::{
     DEFAULT_PORT,
     DEFAULT_SIGNATURE_MAX_AGE_SECS,
     DEFAULT_UNDERPAYMENT_TOLERANCE,
+    DEFAULT_ZERO_EX_RPC_URL,
 };
 
 #[derive(Deserialize)]
@@ -581,6 +582,231 @@ mod tests {
             vec![USDC_CHECKSUMMED.to_string(), USDT_CHECKSUMMED.to_string(),]
         );
     }
+
+    // --- Public-default endpoint visibility ---
+
+    const FALLBACK_MESSAGE: &str = "falling back to free public defaults";
+    const SWAPS_FALLBACK_MESSAGE: &str = "Swaps are using a free public RPC endpoint";
+
+    /// Count fallback warnings naming `chain`. Matching on level, message and
+    /// the `chain` field together is deliberate: a substring search over the
+    /// whole buffer would be satisfied by a single ambiguous INFO event, and
+    /// would not notice a warning fired for the wrong chain.
+    fn fallback_warnings_for(
+        logs: &[&str],
+        chain: ChainType,
+    ) -> usize {
+        let field = format!("chain={chain}");
+
+        logs.iter()
+            .filter(|log| {
+                log.contains(" WARN ") && log.contains(FALLBACK_MESSAGE) && log.contains(&field)
+            })
+            .count()
+    }
+
+    fn assert_warned_once(
+        logs: &[&str],
+        chain: ChainType,
+    ) -> Result<(), String> {
+        match fallback_warnings_for(logs, chain) {
+            1 => Ok(()),
+            other => Err(format!(
+                "expected exactly one fallback WARN naming {chain}, found {other}"
+            )),
+        }
+    }
+
+    fn assert_not_warned(
+        logs: &[&str],
+        chain: ChainType,
+    ) -> Result<(), String> {
+        match fallback_warnings_for(logs, chain) {
+            0 => Ok(()),
+            other => Err(format!(
+                "expected no fallback WARN naming {chain}, found {other}"
+            )),
+        }
+    }
+
+    fn chains_config_from_json(json: &str) -> ChainsConfig {
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn configured(url: &str) -> ChainConfig {
+        ChainConfig {
+            endpoints: vec![ChainEndpoint::Universal(url.to_string())],
+            ..ChainConfig::default()
+        }
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn every_unconfigured_chain_is_announced_exactly_once() {
+        let mut config = chains_config_from_json(r#"{"chains":{}}"#);
+
+        config.set_default_chains_if_missing();
+
+        for chain in ChainType::iter() {
+            assert!(
+                config.chains[&chain]
+                    .get_random_requests_endpoint()
+                    .is_some(),
+                "{chain} was left without endpoints"
+            );
+        }
+
+        logs_assert(|logs| {
+            assert_warned_once(logs, ChainType::Polygon)?;
+            assert_warned_once(logs, ChainType::PolkadotAssetHub)
+        });
+
+        // The endpoints themselves have to be in the line — naming the chain
+        // without naming the node leaves the operator no better off.
+        assert!(logs_contain(
+            "wss://polygon-bor-rpc.publicnode.com"
+        ));
+        assert!(logs_contain(
+            "wss://asset-hub-polkadot-rpc.n.dwellir.com"
+        ));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn configuring_polygon_silences_polygon_only() {
+        let url = "wss://polygon.example.internal";
+        let mut config = chains_config_from_json(r#"{"chains":{}}"#);
+        config
+            .chains
+            .insert(ChainType::Polygon, configured(url));
+
+        config.set_default_chains_if_missing();
+
+        assert_eq!(
+            config.chains[&ChainType::Polygon].get_random_requests_endpoint(),
+            Some(url.to_string()),
+        );
+        logs_assert(|logs| {
+            assert_not_warned(logs, ChainType::Polygon)?;
+            assert_warned_once(logs, ChainType::PolkadotAssetHub)
+        });
+    }
+
+    /// The mirror of the above. Asymmetric bugs — a loop that only ever reports
+    /// the first chain, say — pass one direction and fail the other.
+    #[test]
+    #[tracing_test::traced_test]
+    fn configuring_asset_hub_silences_asset_hub_only() {
+        let url = "wss://asset-hub.example.internal";
+        let mut config = chains_config_from_json(r#"{"chains":{}}"#);
+        config.chains.insert(
+            ChainType::PolkadotAssetHub,
+            configured(url),
+        );
+
+        config.set_default_chains_if_missing();
+
+        assert_eq!(
+            config.chains[&ChainType::PolkadotAssetHub].get_random_requests_endpoint(),
+            Some(url.to_string()),
+        );
+        logs_assert(|logs| {
+            assert_not_warned(logs, ChainType::PolkadotAssetHub)?;
+            assert_warned_once(logs, ChainType::Polygon)
+        });
+    }
+
+    /// `endpoints: []` and an absent `endpoints` key reach `ChainConfig`
+    /// through different serde paths — an explicit empty sequence versus the
+    /// `#[serde(default)]` — but both mean "unconfigured" and must both warn.
+    #[test]
+    #[tracing_test::traced_test]
+    fn an_explicitly_empty_endpoint_list_counts_as_unconfigured() {
+        let mut config =
+            chains_config_from_json(r#"{"chains":{"Polygon":{"endpoints":[],"assets":[]}}}"#);
+
+        assert!(
+            config.chains[&ChainType::Polygon]
+                .endpoints
+                .is_empty()
+        );
+
+        config.set_default_chains_if_missing();
+
+        assert!(
+            config.chains[&ChainType::Polygon]
+                .get_random_requests_endpoint()
+                .is_some()
+        );
+        logs_assert(|logs| assert_warned_once(logs, ChainType::Polygon));
+    }
+
+    /// Exercise the loader rather than the method directly, so the file/env
+    /// precedence layer is covered too. The prefix is unique to this test and
+    /// the directory does not exist, so nothing external can influence it.
+    #[test]
+    #[tracing_test::traced_test]
+    fn the_loader_announces_defaults_too() {
+        let config = crate::configs::chains_config_with_prefix(
+            "no-such-config-dir",
+            "KALATORI_TEST_ENDPOINT_FALLBACK",
+        );
+
+        for chain in ChainType::iter() {
+            assert!(
+                config.chains[&chain]
+                    .get_random_requests_endpoint()
+                    .is_some(),
+                "{chain} was left without endpoints"
+            );
+        }
+
+        logs_assert(|logs| {
+            assert_warned_once(logs, ChainType::Polygon)?;
+            assert_warned_once(logs, ChainType::PolkadotAssetHub)
+        });
+    }
+
+    /// Swaps are the sibling fallback: `SwapsClients` is always constructed, so
+    /// an operator who configured both payment chains and left `swaps.zero_ex`
+    /// alone is still on a free public node.
+    #[test]
+    #[tracing_test::traced_test]
+    fn the_default_swaps_rpc_is_announced() {
+        SwapsConfig::default().warn_if_zero_ex_rpc_is_public_default();
+
+        logs_assert(|logs| {
+            let count = logs
+                .iter()
+                .filter(|log| log.contains(" WARN ") && log.contains(SWAPS_FALLBACK_MESSAGE))
+                .count();
+
+            if count == 1 {
+                Ok(())
+            } else {
+                Err(format!(
+                    "expected exactly one swaps fallback WARN, found {count}"
+                ))
+            }
+        });
+        assert!(logs_contain(DEFAULT_ZERO_EX_RPC_URL));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn a_configured_swaps_rpc_is_not_announced() {
+        let config = SwapsConfig {
+            zero_ex: ZeroExApiConfig {
+                api_key: "not-a-real-key".into(),
+                rpc_url: "https://polygon.example.internal".to_string(),
+            },
+            ..SwapsConfig::default()
+        };
+
+        config.warn_if_zero_ex_rpc_is_public_default();
+
+        assert!(!logs_contain(SWAPS_FALLBACK_MESSAGE));
+    }
 }
 
 fn default_host() -> IpAddr {
@@ -820,7 +1046,27 @@ impl Default for ZeroExApiConfig {
     fn default() -> Self {
         Self {
             api_key: "".into(),
-            rpc_url: "https://polygon-bor-rpc.publicnode.com".to_string(),
+            rpc_url: DEFAULT_ZERO_EX_RPC_URL.to_string(),
+        }
+    }
+}
+
+impl SwapsConfig {
+    /// Announce a public-default swaps RPC the same way
+    /// `set_default_chains_if_missing` announces the chain endpoints.
+    ///
+    /// Startup always constructs `SwapsClients`, so omitting `swaps.zero_ex`
+    /// puts the daemon on a free public node. Without this, an operator who
+    /// configured both payment chains properly reads a clean log and concludes
+    /// they are fully configured — which is the exact condition the chain
+    /// warning exists to abolish.
+    pub(super) fn warn_if_zero_ex_rpc_is_public_default(&self) {
+        if self.zero_ex.rpc_url == DEFAULT_ZERO_EX_RPC_URL {
+            tracing::warn!(
+                rpc_url = %self.zero_ex.rpc_url,
+                "Swaps are using a free public RPC endpoint. \
+                 Set swaps.zero_ex.rpc_url to your own endpoint for production use."
+            );
         }
     }
 }
@@ -833,72 +1079,4 @@ pub struct SwapsConfig {
     pub zero_ex: ZeroExApiConfig,
     #[serde(default)]
     pub fees: Option<IntegratorFees>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn empty_chains_config() -> ChainsConfig {
-        ChainsConfig {
-            chains: HashMap::new(),
-        }
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn default_endpoints_are_announced_when_none_configured() {
-        let mut config = empty_chains_config();
-
-        config.set_default_chains_if_missing();
-
-        for chain in ChainType::iter() {
-            assert!(
-                config.chains[&chain]
-                    .get_random_requests_endpoint()
-                    .is_some(),
-                "{chain} was left without endpoints"
-            );
-        }
-
-        // The point of the warning is that an operator who configured nothing
-        // can still tell from the log which node their payments depend on.
-        assert!(logs_contain(
-            "falling back to free public defaults"
-        ));
-        assert!(logs_contain(
-            "wss://polygon-bor-rpc.publicnode.com"
-        ));
-        assert!(logs_contain(
-            "wss://asset-hub-polkadot-rpc.n.dwellir.com"
-        ));
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn configured_endpoints_are_left_alone_and_unannounced() {
-        let configured = "wss://polygon.example.internal";
-        let mut config = empty_chains_config();
-        config.chains.insert(
-            ChainType::Polygon,
-            ChainConfig {
-                endpoints: vec![ChainEndpoint::Universal(configured.to_string())],
-                ..ChainConfig::default()
-            },
-        );
-
-        config.set_default_chains_if_missing();
-
-        assert_eq!(
-            config.chains[&ChainType::Polygon].get_random_requests_endpoint(),
-            Some(configured.to_string()),
-        );
-        assert!(!logs_contain(
-            "wss://polygon-bor-rpc.publicnode.com"
-        ));
-        // Asset Hub was still unconfigured, so it does get the warning.
-        assert!(logs_contain(
-            "wss://asset-hub-polkadot-rpc.n.dwellir.com"
-        ));
-    }
 }

--- a/daemon/src/utils/logging.rs
+++ b/daemon/src/utils/logging.rs
@@ -8,6 +8,7 @@ pub mod category {
     pub const AUTH: &str = "auth";
     pub const BALANCE_CHECKER: &str = "balance_checker";
     pub const CHAIN_CLIENT: &str = "chain_client";
+    pub const CONFIG: &str = "config";
     pub const SWAPS_CLIENT: &str = "swaps_client";
     pub const SWAPS_TRACKER: &str = "swaps_tracker";
 }
@@ -34,4 +35,8 @@ pub mod operation {
     // Swaps operations
     pub const GET_QUOTE: &str = "get_quote";
     pub const RELOAD_PENDING_SWAPS: &str = "reload_pending_swaps";
+
+    // Config operations
+    pub const LOAD_CHAIN_ENDPOINTS: &str = "load_chain_endpoints";
+    pub const LOAD_SWAPS_RPC: &str = "load_swaps_rpc";
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,11 +118,11 @@ Both are deterministic: same seed + same invoice params = same payment account.
 
 ## Configuration System
 
-Eight config types loaded at startup (all support env var overrides):
+Ten config types loaded at startup (all support env var overrides):
 
 | Config | File | Key Fields |
 |--------|------|------------|
-| Chains | `chains.json` | Chain endpoints, assets (mandatory) |
+| Chains | `chains.json` | Chain endpoints (optional — see below), assets |
 | Payments | `payments.json` | Recipient addresses, account lifetime, default chain/asset |
 | Secrets | `secrets.json` | BIP39 seed phrase, API secret key |
 | Database | `database.json` | Database path, temporary mode, fail-closed existing-database requirement |
@@ -130,6 +130,18 @@ Eight config types loaded at startup (all support env var overrides):
 | Shop | `shop.json` | Webhook URL, shop metadata, signature max age |
 | Logger | `logger.json` | Log level, Loki endpoint |
 | Etherscan | `etherscan_client.json` | API key for Etherscan/Polygonscan |
+| Auth | `auth.json` | OAuth client credentials, token lifetimes |
+| Swaps | `swaps.json` | 0x API key and RPC URL (RPC optional — see below) |
+
+**Public-default endpoints**: chain endpoints and the swaps 0x RPC URL are *not*
+mandatory. Leaving either unset falls back to compiled-in free public providers
+(`configs/consts.rs`), which carry no availability guarantee and are unsuitable
+for production — a three-month unnoticed dependency on one of them was the
+subject of [#333](https://github.com/Kalapaja/Kalatori/issues/333). Each
+fallback emits a WARN at startup carrying `error.category = "config"`, so the
+degraded state is greppable and alertable rather than silent. Note that chain
+endpoints currently cannot be supplied by environment variable at all
+([#338](https://github.com/Kalapaja/Kalatori/issues/338)); use `chains.json`.
 
 **Env var pattern**: `{PREFIX}_{CONFIG}_{FIELD}` (e.g., `KALATORI_PAYMENTS_RECIPIENT`)
 **Custom prefix**: `KALATORI_APP_ENV_PREFIX`


### PR DESCRIPTION
Two `tracing::warn!` calls plus seven tests. Grew out of the #333 investigation rather than the
#330 review, but belongs with this batch of small reliability fixes.

## The problem

`set_default_chains_if_missing()` substitutes `DEFAULT_POLKADOT_ASSET_HUB_ENDPOINTS` and
`DEFAULT_POLYGON_ENDPOINTS` without logging anything at all — no WARN, no INFO. An operator
who never configured endpoints has no way to learn which node their payments depend on, short
of reading the source.

This is not hypothetical. The instance in #333 spent **three months** on
`wss://polygon-bor-rpc.publicnode.com`, and nothing in its logs said so. That instance was
observed reconnecting on a roughly 60-second period — one observation on one instance, not a
measured property of the provider, and nothing here depends on the cause. The subscription
events lost to those reconnects were the actual bug; the reason nobody looked is that the
endpoint choice was invisible.

## The change

Warns once per chain, naming the chain and the endpoints it fell back to, and saying plainly
that these are free public defaults not meant for production.

Checked before writing it that the line actually lands: `logger::initialize` runs before
`chains_config_with_prefix` in `main.rs`. Had the order been the other way round, the fix
would have been useless and silently so.

**Swaps too, after review.** `ZeroExApiConfig::default()` hands out the same free provider
over `https` instead of `wss`, and startup *always* constructs `SwapsClients` — so an operator
who configured both payment chains properly still read a clean log while depending on a public
node for swaps. Partial coverage on a visibility feature is worse than none, because a clean
log then reads as "I am fully configured". The URL is now `DEFAULT_ZERO_EX_RPC_URL` in
`consts.rs`, beside the `wss://` entry it shares a host with, and `swaps_config_with_prefix`
announces it at the same point in startup.

Deliberately a warning and not the config rework the `TODO` above that `Default` impl asks
for: making the 0x client optional or its RPC required is a startup-behaviour change and does
not belong in a visibility fix.

## Tests

Seven, all asserting on captured output via `tracing_test`, and all going through
`logs_assert` rather than substring searches over the buffer — matching level, message and the
`chain` field **together**, so an ambiguous INFO satisfies nothing and a warning fired for the
wrong chain fails on identity rather than passing on a substring.

- every unconfigured chain announced **exactly once**;
- Polygon configured → only Asset Hub announced, and the **reverse**, since asymmetric bugs
  pass one direction and fail the other;
- `endpoints: []` — built by deserializing JSON, so it travels the explicit-empty-sequence
  path rather than `#[serde(default)]`;
- the **loader** entry point, not just the method, with a non-existent config dir and a prefix
  unique to the test;
- both swaps branches, defaulted and configured — the negative one through the same
  level-aware helper as the positive, not a bare `logs_contain`;
- the **swaps loader**, `swaps_config_with_prefix`. Deleting its call to
  `warn_if_zero_ex_rpc_is_public_default` previously left every test green, which is this
  PR's own bug reintroduced through the one line nothing looked at.

Verified by mutation, both directions: dropping the level to `info!` fails five of seven;
reporting a fixed chain instead of the one that fell back fails four, on the count assertion
and the identity assertion respectively.

Note: `daemon/src/configs/types.rs` gained a test module on `main` since this branch opened,
so these live in it rather than a second one.

## Adjacent question, not decided here

@kirushik raised in #333 whether free public providers belong in compiled-in defaults at all.
That is a product decision and this PR does not take it — it only makes the current behaviour
visible. If the answer is "they should not", these warnings become a hard error at startup and
the change is a small one.

Also not covered, and I don't think it belongs here: `ZeroExApiConfig`'s `api_key` defaults to
`""`, so an unconfigured 0x client is not merely degraded but broken at its first
authenticated call. That is the `TODO`'s territory, not a visibility gap.

## Verification

Rebased onto current `main` (0.9.4).

| Check | Result |
|---|---|
| `cargo check --workspace --all-targets` | pass |
| clippy, `RUSTFLAGS="-Dwarnings"`, all targets and features | pass |
| `cargo +nightly fmt --all -- --check` | pass |
| tests | **299** (292 before, 7 new) |
| CI | 8/8 green |

