### PR TITLE
fix: restore the arithmetic safety net this daemon claimed to have

### DIFF
--- a/.github/workflows/_job-integration-test.yml
+++ b/.github/workflows/_job-integration-test.yml
@@ -43,12 +43,19 @@ jobs:
       - name: Start chopsticks
         run: make start-chopsticks
 
-      - name: Wait for chopsticks to accept connections
+      # `system_chain` is answered from static metadata while the fork is still
+      # loading, so it went green ~10s in and the daemon then met a WebSocket
+      # reset. `chain_getBlockHash` can only answer once a block exists, which
+      # is the condition the daemon actually depends on. Note the daemon dials
+      # `ws://`, and this probe is HTTP on the same port — chopsticks serves
+      # both, but that is why the check must assert real chain state rather
+      # than mere reachability.
+      - name: Wait for chopsticks to serve the forked chain
         run: |
-          timeout 300 bash -c 'until curl -sf -o /dev/null \
+          timeout 300 bash -c 'until curl -sf \
             -H "Content-Type: application/json" \
-            -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"system_chain\",\"params\":[]}" \
-            http://localhost:9000; do sleep 2; done'
+            -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"chain_getBlockHash\",\"params\":[]}" \
+            http://localhost:9000 | grep -q "\"result\":\"0x"; do sleep 2; done'
 
       # Redirected rather than backgrounded bare: `make run &` sends the
       # daemon's output nowhere the job can reach, so a daemon that fails to

--- a/.github/workflows/_job-integration-test.yml
+++ b/.github/workflows/_job-integration-test.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Build daemon
         run: cargo build --bin kalatori
 
+      # Chopsticks builds its own image (it npm-installs the binary) and then
+      # forks Asset Hub from a live RPC. Both belong outside the readiness poll
+      # below, for the same reason the build does — the poll is there to catch a
+      # stuck daemon, and it cannot do that while it is really timing docker.
+      - name: Start chopsticks
+        run: make start-chopsticks
+
+      - name: Wait for chopsticks to accept connections
+        run: |
+          timeout 300 bash -c 'until curl -sf -o /dev/null \
+            -H "Content-Type: application/json" \
+            -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"system_chain\",\"params\":[]}" \
+            http://localhost:9000; do sleep 2; done'
+
       - name: Run daemon and chopsticks in background
         run: make run &
 

--- a/.github/workflows/_job-integration-test.yml
+++ b/.github/workflows/_job-integration-test.yml
@@ -50,8 +50,12 @@ jobs:
             -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"system_chain\",\"params\":[]}" \
             http://localhost:9000; do sleep 2; done'
 
-      - name: Run daemon and chopsticks in background
-        run: make run &
+      # Redirected rather than backgrounded bare: `make run &` sends the
+      # daemon's output nowhere the job can reach, so a daemon that fails to
+      # start is indistinguishable from one that is merely slow, and the poll
+      # below just times out with nothing to show for it.
+      - name: Run daemon in background
+        run: make run > daemon.log 2>&1 &
 
       # Poll the public /info endpoint until the daemon answers, capped at 5
       # minutes so a stuck daemon still fails the job in bounded time. Replaces
@@ -63,3 +67,9 @@ jobs:
 
       - name: Run integration tests
         run: make run-test-examples
+
+      # Whatever went wrong, the daemon's own output is the first thing anyone
+      # will want, and it is otherwise lost with the runner.
+      - name: Daemon log
+        if: failure()
+        run: tail -n 200 daemon.log || echo "daemon.log was never created"

--- a/.github/workflows/_job-integration-test.yml
+++ b/.github/workflows/_job-integration-test.yml
@@ -28,12 +28,21 @@ jobs:
       - name: Create database directory
         run: mkdir database
 
+      # Compile before the readiness poll below, so the build does not race its
+      # timeout. `make run` is `cargo run`, which builds first; with the
+      # workspace-root profiles now actually applying, `[profile.dev.package."*"]
+      # opt-level = 3` rebuilds the whole dependency graph optimised, and on a
+      # cold cache that alone exceeds the poll's budget.
+      - name: Build daemon
+        run: cargo build --bin kalatori
+
       - name: Run daemon and chopsticks in background
         run: make run &
 
       # Poll the public /info endpoint until the daemon answers, capped at 5
       # minutes so a stuck daemon still fails the job in bounded time. Replaces
-      # an unconditional `sleep 300`.
+      # an unconditional `sleep 300`. The binary is already built by the step
+      # above, so this measures startup, not compilation.
       - name: Wait for daemon to be ready
         run: |
           timeout 300 bash -c 'until curl -sf http://localhost:8080/public/info >/dev/null; do sleep 2; done'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ Self-hosted, non-custodial blockchain payment gateway daemon for Polkadot Asset 
 - **Metadata regen required** when updating subxt or connecting to new chain version: `make setup-utils && make download-node-metadata`
 - **Version sync**: subxt-cli must match subxt in Cargo.toml (both 0.44), sqlx-cli must match sqlx (both 0.8) — versions pinned in `[workspace.metadata.bin]` in the root `Cargo.toml` (subxt-cli is pinned a *second* time in the `Dockerfile`; keep both in step)
 - **Clippy**: the PR clippy job — and only that job — runs `RUSTFLAGS="-Dwarnings"`, so every *enabled* lint fails it. The enabled set is small and **`pedantic` is not in it**. See [docs/conventions.md](docs/conventions.md) before assuming a lint protects you
+- **Checked arithmetic**: `clippy::arithmetic_side_effects` is enabled workspace-wide. `Decimal`'s operators panic on overflow — money/fee/gas paths must use `checked_*`/`saturating_*` and return a domain error, not `#[expect]`
+- **Profiles live in the root manifest**: Cargo silently ignores `[profile.*]` in non-root workspace members. Never put them in `daemon/Cargo.toml`; verify with `cargo build --release -vv`
 - **Never use `mod.rs`** — self-named modules only (enforced by `mod_module_files` clippy lint)
 - **Nightly rustfmt**: `cargo +nightly fmt --all`
 - **SQLite >= 3.47.0** required at runtime (see README.md for build-from-source instructions)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ unused = "warn"
 
 [workspace.lints.clippy]
 allow_attributes = "deny"
+# This is a payment daemon: a silent wrap or truncation in an amount, fee or
+# token-unit conversion is a money bug. Every `+`/`-`/`*`/`/` on a numeric or
+# `Decimal` type must be explicitly checked, saturating, or justified with an
+# `#[expect(..., reason = "...")]` that says why it cannot overflow.
+arithmetic_side_effects = "warn"
 cargo_common_metadata = "warn"
 cast_possible_truncation = "warn"
 ignored_unit_patterns = "warn"
@@ -60,6 +65,22 @@ unwrap_used = "deny"
 # prone to poorly handle the file renaming that can result in their history erasure.
 mod_module_files = "warn"
 # TODO: we'll add docs and remove this later
+
+# Build profiles. These MUST live in the workspace root manifest: Cargo silently
+# ignores `[profile.*]` tables declared in non-root workspace members, which is
+# how `overflow-checks` quietly stopped applying to the release binary.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+opt-level = 3
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+panic = "abort"
+overflow-checks = true
 
 [workspace.metadata.bin]
 # Please keep in sync with subxt version in daemon/Cargo.toml and in subxt-cli version in Dockerfile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,13 @@ mod_module_files = "warn"
 [profile.dev]
 debug = "line-tables-only"
 
-[profile.dev.package."*"]
-opt-level = 3
+# There is deliberately no `[profile.dev.package."*"] opt-level = 3` here. It sat
+# in the daemon manifest, where Cargo ignored it, so nothing has ever actually
+# built that way; switching it on with this move cost about nine minutes per cold
+# build — every CI run, every clean checkout — to speed up a daemon that spends
+# its time waiting on chains and a database. Nothing above depends on it, and no
+# check loses fidelity without it: `overflow-checks` and the rest of the release
+# profile below are what this move exists for.
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,15 @@ debug = "line-tables-only"
 strip = true
 lto = true
 codegen-units = 1
-panic = "abort"
 overflow-checks = true
+# Deliberately no `panic = "abort"`. It was added in 2024 when this was a single
+# crate, went inert in `18728dfd` when the workspace split moved the profile into
+# `daemon/Cargo.toml`, and would be revived — not introduced — by moving it back.
+# `set_panic_hook` (daemon/src/utils/shutdown.rs) cancels the shutdown token so
+# the executor, chain trackers, webhook sender and keyring can drain; abort runs
+# the hook and then kills the process before anything observes the token, and it
+# also removes Tokio's per-task panic containment, so a panic in one spawned task
+# takes the daemon down instead of surfacing as a `JoinError`.
 
 [workspace.metadata.bin]
 # Please keep in sync with subxt version in daemon/Cargo.toml and in subxt-cli version in Dockerfile

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -171,18 +171,9 @@ insta = { version = "1", features = ["json", "yaml", "redactions"] }
 default = []
 dev_api = []
 
-[profile.dev]
-debug = "line-tables-only"
-
-[profile.dev.package."*"]
-opt-level = 3
-
-[profile.release]
-strip = true
-lto = true
-codegen-units = 1
-panic = "abort"
-overflow-checks = true
+# NOTE: `[profile.*]` tables MUST live in the workspace root `Cargo.toml`.
+# Cargo silently ignores profile tables declared in non-root workspace members,
+# so they are intentionally absent here. See the root manifest.
 
 [lints]
 workspace = true

--- a/daemon/src/api/admin.rs
+++ b/daemon/src/api/admin.rs
@@ -419,6 +419,10 @@ mod tests {
         "/settings",
     ];
 
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "fixed one-hour offset from `Utc::now()`, which is ~250_000 years from `DateTime`'s range limit"
+    )]
     fn user(role: Role) -> AuthenticatedUser {
         let now = Utc::now();
         AuthenticatedUser {

--- a/daemon/src/api/dev.rs
+++ b/daemon/src/api/dev.rs
@@ -22,7 +22,10 @@ use serde::{
 };
 use uuid::Uuid;
 
-use kalatori_client::types::ApiResultStructured;
+use kalatori_client::types::{
+    ApiError,
+    ApiResultStructured,
+};
 
 use crate::auth::session::COOKIE_NAME;
 use crate::auth::token::{
@@ -121,17 +124,26 @@ async fn mint_token_handler(
     );
 
     let now = Utc::now();
-    // `exp_minutes` is request-controlled: `Duration::minutes` panics outside
-    // `TimeDelta`'s range and `DateTime + Duration` panics on date overflow, so
-    // an absurd value would take the handler down. Fall back to the default.
+    // `exp_minutes` is request-controlled: fail the request when it cannot be
+    // represented instead of silently minting a token with a different expiry.
     let exp = i64::try_from(req.exp_minutes)
         .ok()
         .and_then(chrono::TimeDelta::try_minutes)
-        .and_then(|d| now.checked_add_signed(d))
-        .unwrap_or_else(|| {
-            now.checked_add_signed(chrono::TimeDelta::minutes(60))
-                .unwrap_or(now)
-        });
+        .and_then(|duration| now.checked_add_signed(duration));
+    let Some(exp) = exp else {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            axum::Json(ApiResultStructured::<()>::Err {
+                error: ApiError {
+                    category: "INVALID_REQUEST".to_string(),
+                    code: "INVALID_TOKEN_EXPIRY".to_string(),
+                    message: "exp_minutes is outside the supported range".to_string(),
+                    details: None,
+                },
+            }),
+        )
+            .into_response()
+    };
 
     let claims = TokenClaims {
         iss: dev_auth.issuer.clone(),
@@ -190,4 +202,51 @@ pub fn routes(dev_auth: Option<Arc<DevAuthState>>) -> axum::Router<ApiState> {
     }
 
     router
+}
+
+#[cfg(test)]
+mod tests {
+    use pasetors::keys::{
+        AsymmetricKeyPair,
+        Generate,
+    };
+    use pasetors::version4::V4;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_requested_expiry_returns_structured_bad_request() {
+        let dev_auth = Arc::new(DevAuthState {
+            secret_key: AsymmetricKeyPair::<V4>::generate()
+                .unwrap()
+                .secret,
+            issuer: "test-issuer".to_string(),
+            audience: "test-audience".to_string(),
+        });
+        let request = MintTokenRequest {
+            role: default_role(),
+            email: default_email(),
+            sub: default_sub(),
+            exp_minutes: u64::MAX,
+        };
+
+        let response = mint_token_handler(
+            State(dev_auth),
+            Some(axum::Json(request)),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json["error"]["code"],
+            "INVALID_TOKEN_EXPIRY"
+        );
+    }
 }

--- a/daemon/src/api/dev.rs
+++ b/daemon/src/api/dev.rs
@@ -121,7 +121,17 @@ async fn mint_token_handler(
     );
 
     let now = Utc::now();
-    let exp = now + chrono::Duration::minutes(i64::try_from(req.exp_minutes).unwrap_or(60));
+    // `exp_minutes` is request-controlled: `Duration::minutes` panics outside
+    // `TimeDelta`'s range and `DateTime + Duration` panics on date overflow, so
+    // an absurd value would take the handler down. Fall back to the default.
+    let exp = i64::try_from(req.exp_minutes)
+        .ok()
+        .and_then(chrono::TimeDelta::try_minutes)
+        .and_then(|d| now.checked_add_signed(d))
+        .unwrap_or_else(|| {
+            now.checked_add_signed(chrono::TimeDelta::minutes(60))
+                .unwrap_or(now)
+        });
 
     let claims = TokenClaims {
         iss: dev_auth.issuer.clone(),

--- a/daemon/src/api/public.rs
+++ b/daemon/src/api/public.rs
@@ -89,6 +89,10 @@ async fn invoice<D: DaoInterface + 'static>(
         .await;
 
     // TODO: rename var, move value to const
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "`Utc::now()` minus a fixed 30 days is nowhere near DateTime<Utc>'s ~262000-year bounds; no runtime input is involved"
+    )]
     let response_if = Utc::now() - TimeDelta::days(30);
 
     match invoice {

--- a/daemon/src/auth/state_encryption.rs
+++ b/daemon/src/auth/state_encryption.rs
@@ -73,6 +73,10 @@ pub fn encrypt_state(
         .encrypt(&nonce, code_verifier.as_bytes())
         .expect("XChaCha20-Poly1305 encryption should not fail");
 
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "NONCE_LEN is 24 and `ciphertext` is a PKCE verifier (<= 128 bytes) plus a 16-byte tag; the sum cannot approach usize::MAX, and it only sizes a Vec"
+    )]
     let mut output = Vec::with_capacity(NONCE_LEN + ciphertext.len());
     output.extend_from_slice(&nonce);
     output.extend_from_slice(&ciphertext);

--- a/daemon/src/auth/token.rs
+++ b/daemon/src/auth/token.rs
@@ -189,31 +189,57 @@ fn get_string_claim(
 }
 
 /// Check if a token is expired, accounting for clock tolerance.
+///
+/// `exp` comes from the token and `clock_tolerance_secs` from configuration, so
+/// neither is bounded here. `Duration::seconds` panics outside `TimeDelta`'s
+/// range and `DateTime + Duration` panics on date overflow; both now fail
+/// closed — an unrepresentable deadline is treated as expired rather than
+/// crashing the request or granting an eternally valid token.
 pub fn is_expired(
     claims: &TokenClaims,
     clock_tolerance_secs: u64,
 ) -> bool {
     let now = Utc::now();
-    let tolerance =
-        chrono::Duration::seconds(i64::try_from(clock_tolerance_secs).unwrap_or(i64::MAX));
-    now > claims.exp + tolerance
+    let Some(tolerance) = i64::try_from(clock_tolerance_secs)
+        .ok()
+        .and_then(chrono::TimeDelta::try_seconds)
+    else {
+        return true
+    };
+
+    claims
+        .exp
+        .checked_add_signed(tolerance)
+        .is_none_or(|deadline| now > deadline)
 }
 
 /// Check if a token is past its midpoint (should trigger opportunistic
 /// refresh). Midpoint = iat + (exp - iat) / 2, adapting to clipped support
 /// session tokens per spec §7.2.
+///
+/// `exp`/`iat` come straight from the token. The plain `-`, `/` and `+` this
+/// used to use all panic on overflow; the checked chain below cannot, and fails
+/// towards refreshing if a midpoint is somehow not representable.
 pub fn is_past_midpoint(claims: &TokenClaims) -> bool {
-    let lifetime = claims.exp - claims.iat;
-    let midpoint = claims.iat + lifetime / 2;
-    Utc::now() > midpoint
+    claims
+        .exp
+        .signed_duration_since(claims.iat)
+        .checked_div(2)
+        .and_then(|half| claims.iat.checked_add_signed(half))
+        .is_none_or(|midpoint| Utc::now() > midpoint)
 }
 
 /// Check if an expired token is within the 5-minute refresh grace window
 /// (auth server will still accept it for refresh).
+///
+/// Fails closed: an `exp` so large that adding five minutes overflows gets no
+/// grace window.
 pub fn is_within_refresh_grace(claims: &TokenClaims) -> bool {
     let now = Utc::now();
-    let grace_end = claims.exp + chrono::Duration::minutes(5);
-    now <= grace_end
+    claims
+        .exp
+        .checked_add_signed(chrono::TimeDelta::minutes(5))
+        .is_some_and(|grace_end| now <= grace_end)
 }
 
 // ============================================================================
@@ -371,6 +397,72 @@ mod tests {
             raw_token: String::new(),
         };
         assert!(!is_past_midpoint(&claims2));
+    }
+
+    fn claims_at(
+        iat: DateTime<Utc>,
+        exp: DateTime<Utc>,
+    ) -> TokenClaims {
+        TokenClaims {
+            iss: String::new(),
+            sub: String::new(),
+            email: String::new(),
+            picture: None,
+            aud: String::new(),
+            role: Role::Owner,
+            iat,
+            exp,
+            raw_token: String::new(),
+        }
+    }
+
+    #[test]
+    fn is_expired_fails_closed_on_absurd_clock_tolerance() {
+        // `chrono::Duration::seconds(i64::MAX)` panics, and the old code fed
+        // exactly that value in whenever the configured tolerance exceeded
+        // `i64`. Fail closed instead of crashing the request.
+        let claims = claims_at(Utc::now(), Utc::now());
+        assert!(is_expired(&claims, u64::MAX));
+    }
+
+    #[test]
+    fn is_expired_fails_closed_when_deadline_overflows() {
+        // `exp` at the far end of the representable range: `exp + tolerance`
+        // has no answer, so the token must not be treated as valid forever.
+        let claims = claims_at(Utc::now(), DateTime::<Utc>::MAX_UTC);
+        assert!(is_expired(&claims, 86_400));
+    }
+
+    #[test]
+    fn is_past_midpoint_handles_extreme_claims_without_panicking() {
+        // Maximal lifetime: midpoint lands in the distant past, so the token
+        // reads as past its midpoint. The point is that the arithmetic returns
+        // instead of panicking on the widest representable span.
+        assert!(is_past_midpoint(&claims_at(
+            DateTime::<Utc>::MIN_UTC,
+            DateTime::<Utc>::MAX_UTC,
+        )));
+
+        // Both bounds at the maximum: zero lifetime, midpoint == exp, far in
+        // the future.
+        assert!(!is_past_midpoint(&claims_at(
+            DateTime::<Utc>::MAX_UTC,
+            DateTime::<Utc>::MAX_UTC,
+        )));
+
+        // Malformed token with `exp` before `iat`: the lifetime is negative and
+        // the halving must not trip `Sub`'s overflow panic.
+        assert!(is_past_midpoint(&claims_at(
+            DateTime::<Utc>::MAX_UTC,
+            DateTime::<Utc>::MIN_UTC,
+        )));
+    }
+
+    #[test]
+    fn is_within_refresh_grace_fails_closed_on_overflow() {
+        // `exp + 5 minutes` overflows, so there is no grace window.
+        let claims = claims_at(Utc::now(), DateTime::<Utc>::MAX_UTC);
+        assert!(!is_within_refresh_grace(&claims));
     }
 
     #[test]

--- a/daemon/src/balance_checker.rs
+++ b/daemon/src/balance_checker.rs
@@ -31,12 +31,44 @@ use crate::utils::logging::{
     operation,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum BalanceCheckerError {
+    #[error("Invoice {invoice_id} was not found")]
     InvoiceNotFound { invoice_id: Uuid },
+    #[error("Failed to fetch account balance")]
     FetchBalanceFailed,
+    #[error("Failed to fetch incoming transfers")]
     FetchTransfersFailed,
+    #[error("Incoming transfer total overflowed for invoice {invoice_id}")]
+    AmountOverflow { invoice_id: Uuid },
+    #[error("Failed to record incoming transfer for invoice {invoice_id}")]
+    RecordTransferFailed { invoice_id: Uuid },
+    #[error("Database operation failed")]
     DatabaseError,
+}
+
+fn checked_incoming_total(
+    invoice_id: Uuid,
+    transactions: &[IncomingTransaction],
+) -> Result<Decimal, BalanceCheckerError> {
+    transactions
+        .iter()
+        .try_fold(Decimal::ZERO, |total, transaction| {
+            total
+                .checked_add(transaction.transfer_info.amount)
+                .ok_or_else(|| {
+                    tracing::error!(
+                        %invoice_id,
+                        transaction_id = ?transaction.transaction_id,
+                        accumulated_amount = %total,
+                        transaction_amount = %transaction.transfer_info.amount,
+                        "Incoming transfer total overflowed during balance reconciliation"
+                    );
+                    BalanceCheckerError::AmountOverflow {
+                        invoice_id,
+                    }
+                })
+        })
 }
 
 #[derive(Clone)]
@@ -344,10 +376,7 @@ impl<
                 BalanceCheckerError::FetchTransfersFailed
             })?;
 
-        let total_amount: Decimal = incoming_transactions
-            .iter()
-            .map(|trans| trans.transfer_info.amount)
-            .sum();
+        let total_amount = checked_incoming_total(invoice_id, &incoming_transactions)?;
 
         if total_amount != balance {
             // TODO: build event and send it as a webhook. It'll be a way to
@@ -370,6 +399,7 @@ impl<
                 // period) so we probably need to handle that case and initiate
                 // refund. Perhaps it will happen on the next iteration
                 // automatically? Need to check it out when refunds will be implemented
+                let transaction_id = transaction.transaction_id.clone();
                 match self
                     .transactions_recorder
                     .process_invoice_transaction(invoice, transaction)
@@ -379,9 +409,19 @@ impl<
                     Err(TransactionsRecorderError::TransactionDuplication {
                         ..
                     }) => tracing::debug!("Transaction is already presented in the database"),
-                    Err(_) => tracing::warn!(
-                        "Database error occurred while trying to record potentially missing transaction"
-                    ),
+                    Err(error) => {
+                        tracing::error!(
+                            %invoice_id,
+                            ?transaction_id,
+                            error = ?error,
+                            "Failed to record reconciled transaction; invoice remains eligible for a later reconciliation pass"
+                        );
+                        return Err(
+                            BalanceCheckerError::RecordTransferFailed {
+                                invoice_id,
+                            },
+                        )
+                    },
                 };
             }
         }
@@ -465,6 +505,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::types::default_incoming_transaction;
 
     fn balance_checker() -> BalanceChecker<
         MockDaoInterface,
@@ -669,6 +710,22 @@ mod tests {
         assert_eq!(
             stale_invoice.total_received_amount,
             balance
+        );
+    }
+
+    #[test]
+    fn incoming_transfer_total_overflow_is_an_error() {
+        let invoice_id = Uuid::new_v4();
+        let mut first = default_incoming_transaction(invoice_id);
+        first.transfer_info.amount = Decimal::MAX;
+        let mut second = default_incoming_transaction(invoice_id);
+        second.transfer_info.amount = Decimal::ONE;
+
+        assert_eq!(
+            checked_incoming_total(invoice_id, &[first, second]),
+            Err(BalanceCheckerError::AmountOverflow {
+                invoice_id,
+            })
         );
     }
 }

--- a/daemon/src/chain/executor.rs
+++ b/daemon/src/chain/executor.rs
@@ -75,6 +75,10 @@ pub enum ChainExecutorError {
         from_chain: SwapChainType,
         to_chain: SwapChainType,
     },
+    /// Scaling a `Decimal` amount into integer token base units overflowed.
+    /// Previously this was `.unwrap()`, which crashed the executor task.
+    #[error("Amount {amount} cannot be converted to token base units")]
+    AmountConversion { amount: Decimal },
 }
 
 impl ChainExecutorError {
@@ -92,8 +96,30 @@ impl ChainExecutorError {
             UnsupportedSwapDirection {
                 ..
             } => false,
+            // Deterministic in the amount: retrying produces the same failure.
+            AmountConversion {
+                ..
+            } => false,
         }
     }
+}
+
+/// Scale a `Decimal` amount into integer token base units.
+///
+/// `amount / Decimal::new(1, precision)` is really a multiplication by
+/// `10^precision`, which panics on `Decimal` overflow, and `.to_u128()` returns
+/// `None` for negative or oversized results. Both used to be unhandled.
+fn to_base_units(
+    amount: Decimal,
+    precision: u32,
+) -> Result<u128, ChainExecutorError> {
+    Decimal::try_new(1, precision)
+        .ok()
+        .and_then(|unit| amount.checked_div(unit))
+        .and_then(|scaled| scaled.to_u128())
+        .ok_or(ChainExecutorError::AmountConversion {
+            amount,
+        })
 }
 
 const MAX_CONCURRENT_TRANSFERS: u32 = 10;
@@ -567,15 +593,12 @@ impl<
             )
         };
 
-        // TODO: make it more normally. Add some helpers for such operation, get
-        // precision from prestored values
+        // TODO: get precision from prestored values instead of hardcoding 6
         #[expect(
             clippy::unwrap_used,
             reason = "pre-existing panic site, grandfathered when the panic gate landed; see the panic-gate backlog in docs/conventions.md"
         )]
-        let from_amount_units = (request.amount / Decimal::new(1, 6))
-            .to_u128()
-            .unwrap();
+        let from_amount_units = to_base_units(request.amount, 6)?;
 
         let data = CreateSwapData {
             invoice_id: request.invoice_id,
@@ -783,7 +806,11 @@ impl<
             .collect_pending_payout_requests(limit)
             .await?;
 
-        let remaining_limit = limit - u32::try_from(payout_requests.len()).unwrap_or(0);
+        // `collect_pending_payout_requests` is expected to honour `limit`, but a
+        // DAO that returns more rows must not underflow this counter into ~4
+        // billion and defeat the concurrency cap.
+        let remaining_limit =
+            limit.saturating_sub(u32::try_from(payout_requests.len()).unwrap_or(u32::MAX));
 
         let refund_requests = self
             .collect_pending_refund_requests(remaining_limit)
@@ -1156,6 +1183,50 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn to_base_units_scales_by_precision() {
+        assert_eq!(
+            to_base_units(Decimal::from_str("1.5").unwrap(), 6).unwrap(),
+            1_500_000
+        );
+        assert_eq!(
+            to_base_units(Decimal::ZERO, 6).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn to_base_units_rejects_overflowing_amount() {
+        // Scaling `Decimal::MAX` by 10^6 overflows `Decimal`; the old code did
+        // this with a bare `/` and `.unwrap()`, panicking the executor task.
+        let err = to_base_units(Decimal::MAX, 6).unwrap_err();
+        assert!(matches!(
+            err,
+            ChainExecutorError::AmountConversion { .. }
+        ));
+        assert!(!err.is_retriable());
+    }
+
+    #[test]
+    fn to_base_units_rejects_negative_amount() {
+        // `to_u128` returns None for negatives; that used to be an `unwrap`.
+        let err = to_base_units(Decimal::from_str("-1").unwrap(), 6).unwrap_err();
+        assert!(matches!(
+            err,
+            ChainExecutorError::AmountConversion { .. }
+        ));
+    }
+
+    #[test]
+    fn to_base_units_rejects_precision_beyond_decimal_scale() {
+        // `Decimal::new(1, 29)` panics; the fallible path must return an error.
+        let err = to_base_units(Decimal::ONE, 29).unwrap_err();
+        assert!(matches!(
+            err,
+            ChainExecutorError::AmountConversion { .. }
+        ));
+    }
 
     fn setup_executor() -> TransfersExecutor<
         MockDaoInterface,

--- a/daemon/src/chain/executor.rs
+++ b/daemon/src/chain/executor.rs
@@ -594,10 +594,6 @@ impl<
         };
 
         // TODO: get precision from prestored values instead of hardcoding 6
-        #[expect(
-            clippy::unwrap_used,
-            reason = "pre-existing panic site, grandfathered when the panic gate landed; see the panic-gate backlog in docs/conventions.md"
-        )]
         let from_amount_units = to_base_units(request.amount, 6)?;
 
         let data = CreateSwapData {

--- a/daemon/src/chain/executor.rs
+++ b/daemon/src/chain/executor.rs
@@ -56,7 +56,10 @@ use crate::types::{
     TransferDestinationParams,
     TransferInfo,
 };
-use crate::utils::RefundDestinationDetector;
+use crate::utils::{
+    RefundDestinationDetector,
+    decimal_to_base_units,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum ChainExecutorError {
@@ -79,6 +82,8 @@ pub enum ChainExecutorError {
     /// Previously this was `.unwrap()`, which crashed the executor task.
     #[error("Amount {amount} cannot be converted to token base units")]
     AmountConversion { amount: Decimal },
+    #[error("Amount {amount} is invalid for an asset with {decimals} decimals")]
+    InvalidAmountPrecision { amount: Decimal, decimals: u32 },
 }
 
 impl ChainExecutorError {
@@ -99,6 +104,9 @@ impl ChainExecutorError {
             // Deterministic in the amount: retrying produces the same failure.
             AmountConversion {
                 ..
+            }
+            | InvalidAmountPrecision {
+                ..
             } => false,
         }
     }
@@ -113,13 +121,9 @@ fn to_base_units(
     amount: Decimal,
     precision: u32,
 ) -> Result<u128, ChainExecutorError> {
-    Decimal::try_new(1, precision)
-        .ok()
-        .and_then(|unit| amount.checked_div(unit))
-        .and_then(|scaled| scaled.to_u128())
-        .ok_or(ChainExecutorError::AmountConversion {
-            amount,
-        })
+    decimal_to_base_units(amount, precision).ok_or(ChainExecutorError::AmountConversion {
+        amount,
+    })
 }
 
 const MAX_CONCURRENT_TRANSFERS: u32 = 10;
@@ -321,6 +325,9 @@ async fn send_transfer_request<T: ChainConfig, C: BlockChainClient<T>>(
         )]
         Err(TransactionError::BuildFailed {
             ..
+        })
+        | Err(TransactionError::InvalidAmountPrecision {
+            ..
         }) => unreachable!(),
     };
 
@@ -426,8 +433,17 @@ impl<
                     "Failed to build transfer transaction",
                 );
 
-                ChainExecutorError::BuildTransfer {
-                    reason: format!("Failed to build transfer transaction: {e}"),
+                match e {
+                    TransactionError::InvalidAmountPrecision {
+                        amount,
+                        decimals,
+                    } => ChainExecutorError::InvalidAmountPrecision {
+                        amount,
+                        decimals,
+                    },
+                    error => ChainExecutorError::BuildTransfer {
+                        reason: format!("Failed to build transfer transaction: {error}"),
+                    },
                 }
             })?;
 
@@ -1224,6 +1240,20 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn to_base_units_rejects_sub_base_unit_dust() {
+        let amount = Decimal::from_str("1.0000001").unwrap();
+        let error = to_base_units(amount, 6).unwrap_err();
+
+        assert_eq!(
+            error,
+            ChainExecutorError::AmountConversion {
+                amount,
+            }
+        );
+        assert!(!error.is_retriable());
+    }
+
     fn setup_executor() -> TransfersExecutor<
         MockDaoInterface,
         MockBlockChainClient<AssetHubChainConfig>,
@@ -1382,6 +1412,38 @@ mod tests {
                             .to_string()
                 }
             );
+        }
+
+        // A deterministic amount/precision failure must retain its domain
+        // classification so the worker marks it terminal instead of retrying.
+        {
+            let mut polygon_client = MockBlockChainClient::<PolygonChainConfig>::default();
+            let amount = request.amount;
+
+            polygon_client
+                .expect_build_transfer()
+                .returning(move |_, _, _, _| {
+                    Err(
+                        TransactionError::InvalidAmountPrecision {
+                            amount,
+                            decimals: 6,
+                        },
+                    )
+                });
+
+            let error = executor
+                .build_and_sign_transfer(&Arc::new(polygon_client), &request)
+                .await
+                .unwrap_err();
+
+            assert_eq!(
+                error,
+                ChainExecutorError::InvalidAmountPrecision {
+                    amount,
+                    decimals: 6,
+                }
+            );
+            assert!(!error.is_retriable());
         }
 
         // Test case 3:

--- a/daemon/src/chain/transactions_recorder.rs
+++ b/daemon/src/chain/transactions_recorder.rs
@@ -33,6 +33,12 @@ pub enum TransactionsRecorderError {
         chain: ChainType,
         general_transaction_id: GeneralTransactionId,
     },
+    /// A payment-amount computation overflowed `Decimal`'s range. Recording a
+    /// wrapped total — or panicking, which `Decimal`'s `+`/`-` do on overflow —
+    /// would mean paying out or refunding the wrong sum, so the whole DB
+    /// transaction is abandoned instead and the transfer is retried.
+    #[error("Amount computation overflowed while {operation}")]
+    AmountOverflow { operation: &'static str },
 }
 
 #[derive(Clone)]
@@ -196,7 +202,13 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             // In case when invoice is overpaid and refund is required, we schedule payout
             // with original invoice amount and refund with the rest amount
             let payout_amount = invoice.amount;
-            let refund_amount = total_received_amount - payout_amount;
+            let refund_amount = total_received_amount
+                .checked_sub(payout_amount)
+                .ok_or(
+                    TransactionsRecorderError::AmountOverflow {
+                        operation: "computing overpayment refund",
+                    },
+                )?;
 
             self.add_payout_to_dao_transaction(
                 dao_transaction,
@@ -256,8 +268,12 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
         invoice: &InvoiceWithReceivedAmount,
         transaction: IncomingTransaction,
     ) -> Result<(InvoiceWithReceivedAmount, Decimal), TransactionsRecorderError> {
-        let updated_received_amount =
-            invoice.total_received_amount + transaction.transfer_info.amount;
+        let updated_received_amount = invoice
+            .total_received_amount
+            .checked_add(transaction.transfer_info.amount)
+            .ok_or(TransactionsRecorderError::AmountOverflow {
+                operation: "accumulating received amount",
+            })?;
 
         let underpayment_tolerance = self
             .config
@@ -265,7 +281,13 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
                 invoice.invoice.chain,
                 &invoice.invoice.asset_id,
             );
-        let min_paid_amount = invoice.invoice.amount - underpayment_tolerance;
+        let min_paid_amount = invoice
+            .invoice
+            .amount
+            .checked_sub(underpayment_tolerance)
+            .ok_or(TransactionsRecorderError::AmountOverflow {
+                operation: "applying underpayment tolerance",
+            })?;
 
         let overpayment_tolerance = self
             .config
@@ -273,7 +295,13 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
                 invoice.invoice.chain,
                 &invoice.invoice.asset_id,
             );
-        let max_paid_amount = invoice.invoice.amount + overpayment_tolerance;
+        let max_paid_amount = invoice
+            .invoice
+            .amount
+            .checked_add(overpayment_tolerance)
+            .ok_or(TransactionsRecorderError::AmountOverflow {
+                operation: "applying overpayment tolerance",
+            })?;
 
         let is_underpaid = updated_received_amount < min_paid_amount;
         let is_overpaid = updated_received_amount > max_paid_amount;
@@ -399,6 +427,22 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
                 );
 
                 return Err(TransactionsRecorderError::DaoTransactionError);
+            },
+            Err(TransactionsRecorderError::AmountOverflow {
+                operation,
+            }) => {
+                tracing::error!(
+                    invoice_id = %invoice.id,
+                    filled_amount = %updated_received_amount,
+                    operation,
+                    "Amount overflow while storing transaction for invoice; nothing was committed"
+                );
+
+                return Err(
+                    TransactionsRecorderError::AmountOverflow {
+                        operation,
+                    },
+                );
             },
         };
 

--- a/daemon/src/chain/transactions_recorder.rs
+++ b/daemon/src/chain/transactions_recorder.rs
@@ -36,7 +36,8 @@ pub enum TransactionsRecorderError {
     /// A payment-amount computation overflowed `Decimal`'s range. Recording a
     /// wrapped total — or panicking, which `Decimal`'s `+`/`-` do on overflow —
     /// would mean paying out or refunding the wrong sum, so the whole DB
-    /// transaction is abandoned instead and the transfer is retried.
+    /// transaction is abandoned instead. Callers surface the transfer for
+    /// reconciliation/manual recovery because no durable replay queue exists.
     #[error("Amount computation overflowed while {operation}")]
     AmountOverflow { operation: &'static str },
 }
@@ -149,6 +150,7 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
         total_received_amount: Decimal,
     ) -> Result<(), TransactionsRecorderError> {
         let invoice_id = transaction.invoice_id;
+        let incoming_transaction_id = transaction.transaction_id.clone();
 
         dao_transaction
             .create_transaction(transaction.into())
@@ -204,11 +206,19 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             let payout_amount = invoice.amount;
             let refund_amount = total_received_amount
                 .checked_sub(payout_amount)
-                .ok_or(
+                .ok_or_else(|| {
+                    tracing::error!(
+                        %invoice_id,
+                        transaction_id = ?incoming_transaction_id,
+                        lhs = %total_received_amount,
+                        rhs = %payout_amount,
+                        operation = "computing overpayment refund",
+                        "Amount operation overflowed; database transaction will be abandoned"
+                    );
                     TransactionsRecorderError::AmountOverflow {
                         operation: "computing overpayment refund",
-                    },
-                )?;
+                    }
+                })?;
 
             self.add_payout_to_dao_transaction(
                 dao_transaction,
@@ -268,14 +278,24 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
         invoice: &InvoiceWithReceivedAmount,
         transaction: IncomingTransaction,
     ) -> Result<(InvoiceWithReceivedAmount, Decimal), TransactionsRecorderError> {
-        let updated_received_amount = invoice
-            .total_received_amount
-            .checked_add(transaction.transfer_info.amount)
-            .ok_or(
+        let transaction_id = transaction.transaction_id.clone();
+        let transaction_amount = transaction.transfer_info.amount;
+        let total_received_amount = invoice.total_received_amount;
+        let updated_received_amount = total_received_amount
+            .checked_add(transaction_amount)
+            .ok_or_else(|| {
+                tracing::error!(
+                    invoice_id = %invoice.invoice.id,
+                    ?transaction_id,
+                    lhs = %total_received_amount,
+                    rhs = %transaction_amount,
+                    operation = "accumulating received amount",
+                    "Amount operation overflowed; incoming transfer was not recorded"
+                );
                 TransactionsRecorderError::AmountOverflow {
                     operation: "accumulating received amount",
-                },
-            )?;
+                }
+            })?;
 
         let underpayment_tolerance = self
             .config
@@ -287,11 +307,19 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             .invoice
             .amount
             .checked_sub(underpayment_tolerance)
-            .ok_or(
+            .ok_or_else(|| {
+                tracing::error!(
+                    invoice_id = %invoice.invoice.id,
+                    ?transaction_id,
+                    lhs = %invoice.invoice.amount,
+                    rhs = %underpayment_tolerance,
+                    operation = "applying underpayment tolerance",
+                    "Amount operation overflowed; incoming transfer was not recorded"
+                );
                 TransactionsRecorderError::AmountOverflow {
                     operation: "applying underpayment tolerance",
-                },
-            )?;
+                }
+            })?;
 
         let overpayment_tolerance = self
             .config
@@ -303,11 +331,19 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             .invoice
             .amount
             .checked_add(overpayment_tolerance)
-            .ok_or(
+            .ok_or_else(|| {
+                tracing::error!(
+                    invoice_id = %invoice.invoice.id,
+                    ?transaction_id,
+                    lhs = %invoice.invoice.amount,
+                    rhs = %overpayment_tolerance,
+                    operation = "applying overpayment tolerance",
+                    "Amount operation overflowed; incoming transfer was not recorded"
+                );
                 TransactionsRecorderError::AmountOverflow {
                     operation: "applying overpayment tolerance",
-                },
-            )?;
+                }
+            })?;
 
         let is_underpaid = updated_received_amount < min_paid_amount;
         let is_overpaid = updated_received_amount > max_paid_amount;

--- a/daemon/src/chain/transactions_recorder.rs
+++ b/daemon/src/chain/transactions_recorder.rs
@@ -271,9 +271,11 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
         let updated_received_amount = invoice
             .total_received_amount
             .checked_add(transaction.transfer_info.amount)
-            .ok_or(TransactionsRecorderError::AmountOverflow {
-                operation: "accumulating received amount",
-            })?;
+            .ok_or(
+                TransactionsRecorderError::AmountOverflow {
+                    operation: "accumulating received amount",
+                },
+            )?;
 
         let underpayment_tolerance = self
             .config
@@ -285,9 +287,11 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             .invoice
             .amount
             .checked_sub(underpayment_tolerance)
-            .ok_or(TransactionsRecorderError::AmountOverflow {
-                operation: "applying underpayment tolerance",
-            })?;
+            .ok_or(
+                TransactionsRecorderError::AmountOverflow {
+                    operation: "applying underpayment tolerance",
+                },
+            )?;
 
         let overpayment_tolerance = self
             .config
@@ -299,9 +303,11 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             .invoice
             .amount
             .checked_add(overpayment_tolerance)
-            .ok_or(TransactionsRecorderError::AmountOverflow {
-                operation: "applying overpayment tolerance",
-            })?;
+            .ok_or(
+                TransactionsRecorderError::AmountOverflow {
+                    operation: "applying overpayment tolerance",
+                },
+            )?;
 
         let is_underpaid = updated_received_amount < min_paid_amount;
         let is_overpaid = updated_received_amount > max_paid_amount;
@@ -432,8 +438,7 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
                 operation,
             }) => {
                 tracing::error!(
-                    invoice_id = %invoice.id,
-                    filled_amount = %updated_received_amount,
+                    invoice_id = %invoice.invoice.id,
                     operation,
                     "Amount overflow while storing transaction for invoice; nothing was committed"
                 );

--- a/daemon/src/chain/transfer_tracker.rs
+++ b/daemon/src/chain/transfer_tracker.rs
@@ -25,6 +25,14 @@ const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(60);
 const DEGRADED_WARNING_INTERVAL: Duration = Duration::from_secs(60);
 
+#[derive(Debug, thiserror::Error)]
+enum TransferTrackerError {
+    #[error(transparent)]
+    Subscription(#[from] SubscriptionError),
+    #[error(transparent)]
+    Recorder(#[from] TransactionsRecorderError),
+}
+
 struct RetryState {
     delay: Duration,
     degraded_since: Option<tokio::time::Instant>,
@@ -157,7 +165,7 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
     async fn process_transfer(
         &self,
         transfer: GeneralChainTransfer,
-    ) {
+    ) -> Result<(), TransactionsRecorderError> {
         if let Some(mut invoice) = self
             .registry
             .find_invoice_by_address(
@@ -175,6 +183,7 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
             );
 
             let transaction = IncomingTransaction::from_chain_transfer(invoice_id, transfer);
+            let transaction_id = transaction.transaction_id.clone();
 
             match self
                 .transactions_recorder
@@ -193,24 +202,30 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
                     %invoice_id,
                     "Transfer is already presented in database, invoice hasn't been updated"
                 ),
-                Err(e) => tracing::warn!(
-                    %invoice_id,
-                    error = ?e,
-                    "Error while trying to store transfer in database, invoice hasn't been updated"
-                ),
+                Err(error) => {
+                    tracing::error!(
+                        %invoice_id,
+                        ?transaction_id,
+                        error = ?error,
+                        "Incoming transfer was not recorded; durable replay is required for guaranteed recovery"
+                    );
+                    return Err(error)
+                },
             };
         }
+
+        Ok(())
     }
 
     async fn handle_subscription_event(
         &self,
         event: Option<Result<Vec<ChainTransfer<T>>, SubscriptionError>>,
-    ) -> Result<(), SubscriptionError> {
+    ) -> Result<(), TransferTrackerError> {
         match event {
             Some(Ok(transfers)) => {
                 for transfer in transfers {
                     self.process_transfer(transfer.into())
-                        .await;
+                        .await?;
                 }
 
                 Ok(())
@@ -222,11 +237,11 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
                     error.source = ?e,
                     "Error receiving transfer event"
                 );
-                Err(e)
+                Err(e.into())
             },
             None => {
                 tracing::debug!("Transfer event subscription ended");
-                Err(SubscriptionError::StreamClosed)
+                Err(SubscriptionError::StreamClosed.into())
             },
         }
     }
@@ -292,12 +307,23 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
                     match subscription_event {
                         Some(Ok(transfers)) => {
                             retry_state.record_health();
-                            let _result = self
+                            if let Err(error) = self
                                 .handle_subscription_event(Some(Ok(transfers)))
-                                .await;
+                                .await
+                            {
+                                tracing::error!(
+                                    error = ?error,
+                                    "Transfer subscription event was not fully processed"
+                                );
+                            }
                         },
                         failed_event => {
-                            let _result = self.handle_subscription_event(failed_event).await;
+                            if let Err(error) = self.handle_subscription_event(failed_event).await {
+                                tracing::warn!(
+                                    error = ?error,
+                                    "Transfer subscription failed"
+                                );
+                            }
                             subscription = None;
                             let retry_delay = retry_state.record_failure();
                             tokio::select! {
@@ -747,7 +773,10 @@ mod tests {
         //   - No recorder calls
         let transfer = default_general_chain_transfer();
 
-        tracker.process_transfer(transfer).await;
+        tracker
+            .process_transfer(transfer)
+            .await
+            .unwrap();
         tracker
             .transactions_recorder
             .checkpoint();
@@ -793,7 +822,8 @@ mod tests {
 
         tracker
             .process_transfer(transfer.clone())
-            .await;
+            .await
+            .unwrap();
         tracker
             .transactions_recorder
             .checkpoint();
@@ -832,7 +862,8 @@ mod tests {
 
         tracker
             .process_transfer(transfer.clone())
-            .await;
+            .await
+            .unwrap();
         tracker
             .transactions_recorder
             .checkpoint();
@@ -853,18 +884,47 @@ mod tests {
             .transactions_recorder
             .expect_process_invoice_transaction()
             .with(
-                eq(invoice),
+                eq(invoice.clone()),
                 eq(expected_transaction.clone()),
             )
             .once()
             .returning(|_, _| Err(TransactionsRecorderError::DaoTransactionError));
 
-        tracker.process_transfer(transfer).await;
+        assert!(matches!(
+            tracker
+                .process_transfer(transfer.clone())
+                .await,
+            Err(TransactionsRecorderError::DaoTransactionError)
+        ));
         tracker
             .transactions_recorder
             .checkpoint();
         assert!(logs_contain(
-            "Error while trying to store transfer in database, invoice hasn't been updated"
+            "Incoming transfer was not recorded"
+        ));
+
+        // An amount overflow must propagate through the live-tracking caller;
+        // logging it and returning Ok would permanently forget the event.
+        tracker
+            .transactions_recorder
+            .expect_process_invoice_transaction()
+            .with(eq(invoice), eq(expected_transaction))
+            .once()
+            .returning(|_, _| {
+                Err(
+                    TransactionsRecorderError::AmountOverflow {
+                        operation: "accumulating received amount",
+                    },
+                )
+            });
+
+        assert!(matches!(
+            tracker.process_transfer(transfer).await,
+            Err(
+                TransactionsRecorderError::AmountOverflow {
+                    operation: "accumulating received amount",
+                }
+            )
         ));
     }
 
@@ -916,7 +976,7 @@ mod tests {
         let result = tracker
             .handle_subscription_event(Some(Ok(transfers)))
             .await;
-        assert_eq!(result, Ok(()));
+        assert!(result.is_ok());
 
         // Test case 2:
         // - Unsuccessful case
@@ -927,10 +987,12 @@ mod tests {
         let result = tracker
             .handle_subscription_event(None)
             .await;
-        assert_eq!(
+        assert!(matches!(
             result,
-            Err(SubscriptionError::StreamClosed)
-        );
+            Err(TransferTrackerError::Subscription(
+                SubscriptionError::StreamClosed
+            ))
+        ));
 
         // Test case 3:
         // - Unsuccessful case
@@ -943,9 +1005,11 @@ mod tests {
                 SubscriptionError::SubscriptionFailed,
             )))
             .await;
-        assert_eq!(
+        assert!(matches!(
             result,
-            Err(SubscriptionError::SubscriptionFailed)
-        );
+            Err(TransferTrackerError::Subscription(
+                SubscriptionError::SubscriptionFailed
+            ))
+        ));
     }
 }

--- a/daemon/src/chain/transfer_tracker.rs
+++ b/daemon/src/chain/transfer_tracker.rs
@@ -528,6 +528,10 @@ mod tests {
         assert_stream_failure_drops_subscription_and_backs_off(Box::pin(stream::empty())).await;
     }
 
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "test-only: subtracting 1ms from the INITIAL_RETRY_DELAY constant on tokio's paused clock"
+    )]
     async fn assert_stream_failure_drops_subscription_and_backs_off(
         first_stream: TransfersStream<PolygonChainConfig>
     ) {
@@ -650,6 +654,10 @@ mod tests {
 
     #[test]
     #[tracing_test::traced_test]
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "test-only: offsetting a tokio paused-clock Instant by fixed second-scale Durations"
+    )]
     fn degraded_warnings_are_rate_limited() {
         let started_at = tokio::time::Instant::now();
         let mut retry_state = RetryState::new();
@@ -678,6 +686,10 @@ mod tests {
 
     #[test]
     #[tracing_test::traced_test]
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "test-only: offsetting a tokio paused-clock Instant by fixed second-scale Durations"
+    )]
     fn successful_event_resets_backoff_after_recovery() {
         let started_at = tokio::time::Instant::now();
         let mut retry_state = RetryState::new();

--- a/daemon/src/chain_client/asset_hub.rs
+++ b/daemon/src/chain_client/asset_hub.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 
-use rust_decimal::prelude::{
-    Decimal,
-    ToPrimitive,
-};
+use rust_decimal::prelude::Decimal;
 use subxt::blocks::Block;
 use subxt::config::{
     DefaultExtrinsicParams,
@@ -23,6 +20,7 @@ use tracing::{
 };
 
 use crate::types::ChainType;
+use crate::utils::decimal_to_base_units;
 
 use super::{
     AssetInfo,
@@ -719,20 +717,16 @@ impl BlockChainClient<AssetHubChainConfig> for AssetHubClient {
         // `10^decimals`. `Decimal::new` panics for `decimals` above 28 and the
         // division panics on `Decimal` overflow, both on values derived from
         // on-chain asset metadata and a merchant-supplied payout amount.
-        let transaction_amount = Decimal::try_new(1, decimals.into())
-            .ok()
-            .and_then(|unit| amount.checked_div(unit))
-            .and_then(|normalized| normalized.to_u128())
-            .ok_or_else(|| {
+        let transaction_amount =
+            decimal_to_base_units(amount, decimals.into()).ok_or_else(|| {
                 tracing::error!(
                     amount = %amount,
                     decimals,
                     "Amount cannot be normalized into u128 base units"
                 );
-                TransactionError::BuildFailed {
-                    reason: format!(
-                        "Amount {amount} cannot be normalized into u128 base units with {decimals} decimals"
-                    ),
+                TransactionError::InvalidAmountPrecision {
+                    amount,
+                    decimals: u32::from(decimals),
                 }
             })?;
 

--- a/daemon/src/chain_client/asset_hub.rs
+++ b/daemon/src/chain_client/asset_hub.rs
@@ -715,19 +715,24 @@ impl BlockChainClient<AssetHubChainConfig> for AssetHubClient {
             })?
             .decimals;
 
-        #[expect(clippy::arithmetic_side_effects)]
-        let normalized_amount = amount / Decimal::new(1, decimals.into());
-
-        let transaction_amount = normalized_amount
-            .to_u128()
+        // Dividing by `Decimal::new(1, decimals)` is really a multiplication by
+        // `10^decimals`. `Decimal::new` panics for `decimals` above 28 and the
+        // division panics on `Decimal` overflow, both on values derived from
+        // on-chain asset metadata and a merchant-supplied payout amount.
+        let transaction_amount = Decimal::try_new(1, decimals.into())
+            .ok()
+            .and_then(|unit| amount.checked_div(unit))
+            .and_then(|normalized| normalized.to_u128())
             .ok_or_else(|| {
                 tracing::error!(
                     amount = %amount,
-                    normalized = %normalized_amount,
-                    "Amount exceeds u128::MAX after normalization"
+                    decimals,
+                    "Amount cannot be normalized into u128 base units"
                 );
                 TransactionError::BuildFailed {
-                    reason: format!("Amount {amount} exceeds u128::MAX after normalization"),
+                    reason: format!(
+                        "Amount {amount} cannot be normalized into u128 base units with {decimals} decimals"
+                    ),
                 }
             })?;
 

--- a/daemon/src/chain_client/errors.rs
+++ b/daemon/src/chain_client/errors.rs
@@ -1,3 +1,4 @@
+use rust_decimal::Decimal;
 use thiserror::Error;
 
 use crate::utils::logging::category::CHAIN_CLIENT;
@@ -94,6 +95,11 @@ pub enum TransactionError<T: ChainConfig> {
     /// Transaction building failed (invalid parameters, signing failure, etc.)
     #[error("Transaction building failed: {reason}")]
     BuildFailed { reason: String },
+
+    /// The requested transfer amount cannot be represented exactly in the
+    /// asset's base units. This is deterministic and must not be retried.
+    #[error("Amount {amount} is invalid for an asset with {decimals} decimals")]
+    InvalidAmountPrecision { amount: Decimal, decimals: u32 },
 
     /// Transaction was submitted but final status is unknown
     #[error("Transaction submission status unknown")]

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -1021,6 +1021,8 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
                 decimals,
                 "Balance is not representable as a Decimal"
             );
+            // The balance was fetched successfully; it is the conversion that
+            // failed, so this must not be reported as missing data.
             QueryError::DecodeFailed {
                 data_type: format!("ERC-20 balance {balance} with {decimals} decimals"),
             }
@@ -2062,5 +2064,13 @@ mod tests {
             WEI_PER_ETHER,
             U256::from(10u8).pow(U256::from(18u8))
         );
+    }
+
+    #[test]
+    fn decimal_to_u256_rejects_negative_amounts() {
+        // The sign check is what `to_u128` provides. Without it a negative
+        // payout amount would scale into an unsigned base-unit value and move
+        // real funds; the existing cases here all use positive inputs.
+        assert_eq!(decimal_to_u256(Decimal::try_new(-1, 0).unwrap(), 6), None);
     }
 }

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -37,14 +37,15 @@ use alloy::sol_types::{
 };
 use chrono::Utc;
 use futures::StreamExt;
-use rust_decimal::prelude::{
-    Decimal,
-    ToPrimitive,
-};
+use rust_decimal::prelude::Decimal;
 use tracing::instrument;
 
 use crate::types::ChainType;
 use crate::utils::logging::category::CHAIN_CLIENT;
+use crate::utils::{
+    decimal_from_base_units,
+    decimal_to_base_units,
+};
 
 use super::{
     AssetInfo,
@@ -387,14 +388,7 @@ fn u256_to_decimal(
     value: U256,
     decimals: u8,
 ) -> Option<Decimal> {
-    // Convert U256 to string and parse as Decimal. `from_str_exact` (unlike
-    // `from_str`) refuses to silently round away significant digits.
-    let raw_decimal = Decimal::from_str_exact(&value.to_string()).ok()?;
-
-    // Apply decimal places. `Decimal::new` panics for scale > 28, so go through
-    // the fallible constructor.
-    let scale = Decimal::try_new(1, u32::from(decimals)).ok()?;
-    raw_decimal.checked_mul(scale)
+    decimal_from_base_units(&value.to_string(), u32::from(decimals))
 }
 
 /// Convert a `Decimal` amount to U256 base units with the given number of
@@ -407,18 +401,7 @@ fn decimal_to_u256(
     value: Decimal,
     decimals: u8,
 ) -> Option<U256> {
-    // Scale up by decimals. `10_i64.pow` overflows for decimals > 18.
-    let multiplier = Decimal::try_new(
-        10_i64.checked_pow(u32::from(decimals))?,
-        0,
-    )
-    .ok()?;
-
-    // Convert to U256
-    value
-        .checked_mul(multiplier)?
-        .to_u128()
-        .map(U256::from)
+    decimal_to_base_units(value, u32::from(decimals)).map(U256::from)
 }
 
 /// Compute the paymaster's maximum charge, denominated in the fee token.
@@ -1225,12 +1208,12 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
             })?
             .decimals;
 
-        let amount_wei =
-            decimal_to_u256(amount, decimals).ok_or_else(|| TransactionError::BuildFailed {
-                reason: format!(
-                    "Amount {amount} with {decimals} decimals does not fit u128 base units"
-                ),
-            })?;
+        let amount_wei = decimal_to_u256(amount, decimals).ok_or(
+            TransactionError::InvalidAmountPrecision {
+                amount,
+                decimals: u32::from(decimals),
+            },
+        )?;
 
         let contract = IERC20::new(asset_id, self.provider.clone());
         let entrypoint_contract = IERC20::new(ENTRYPOINT, self.provider.clone());
@@ -1922,14 +1905,16 @@ mod tests {
     }
 
     #[test]
-    fn u256_to_decimal_rejects_values_beyond_decimal_range() {
-        // Decimal's mantissa is 96 bits (~7.9e28); 1e30 base units cannot be
-        // represented. The old code returned `Decimal::ZERO`, silently turning
-        // a huge payment into "nothing received".
+    fn u256_to_decimal_accepts_scaled_values_with_large_base_unit_mantissas() {
+        // 1e30 base units at 18 decimals is exactly 1e12 tokens. Constructing
+        // Decimal from the raw base-unit integer first incorrectly rejected it.
         let value = U256::from(10u8).pow(U256::from(30u8));
-        assert_eq!(u256_to_decimal(value, 18), None);
+        assert_eq!(
+            u256_to_decimal(value, 18),
+            Some(Decimal::from(1_000_000_000_000_u64))
+        );
 
-        // U256::MAX must not panic either.
+        // U256::MAX remains genuinely unrepresentable at this scale.
         assert_eq!(u256_to_decimal(U256::MAX, 18), None);
     }
 
@@ -1944,8 +1929,17 @@ mod tests {
 
     #[test]
     fn decimal_to_u256_rejects_unrepresentable_values() {
-        // `10_i64.pow(19)` overflows i64.
-        assert_eq!(decimal_to_u256(Decimal::ONE, 19), None);
+        assert_eq!(
+            decimal_to_u256(Decimal::ONE, 19),
+            Some(U256::from(
+                10_000_000_000_000_000_000_u128
+            ))
+        );
+
+        assert_eq!(
+            decimal_to_u256(Decimal::ONE, 28),
+            Some(U256::from(10u8).pow(U256::from(28u8)))
+        );
 
         // Scaled value beyond u128 must not silently become zero.
         assert_eq!(decimal_to_u256(Decimal::MAX, 18), None);
@@ -2071,6 +2065,20 @@ mod tests {
         // The sign check is what `to_u128` provides. Without it a negative
         // payout amount would scale into an unsigned base-unit value and move
         // real funds; the existing cases here all use positive inputs.
-        assert_eq!(decimal_to_u256(Decimal::try_new(-1, 0).unwrap(), 6), None);
+        assert_eq!(
+            decimal_to_u256(Decimal::try_new(-1, 0).unwrap(), 6),
+            None
+        );
+    }
+
+    #[test]
+    fn decimal_to_u256_rejects_sub_base_unit_dust() {
+        assert_eq!(
+            decimal_to_u256(
+                Decimal::from_str_exact("1.0000001").unwrap(),
+                6
+            ),
+            None
+        );
     }
 }

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -614,14 +614,13 @@ impl PolygonClient {
 
     /// Convert a log entry to a ChainTransfer
     async fn log_to_transfer(
-        &self,
+        asset_info_store: &AssetInfoStore<PolygonChainConfig>,
         log: &Log,
         event: &IERC20::Transfer,
     ) -> Result<ChainTransfer<PolygonChainConfig>, SubscriptionError> {
         let asset_id = log.address();
 
-        let asset_info = self
-            .asset_info_store
+        let asset_info = asset_info_store
             .get_asset_info(&asset_id)
             .await
             .ok_or_else(|| {
@@ -636,6 +635,12 @@ impl PolygonClient {
             })?;
 
         let tx_hash = log.transaction_hash.ok_or(
+            SubscriptionError::BlockProcessingFailed {
+                block_number: 0,
+            },
+        )?;
+
+        let block_number = log.block_number.ok_or(
             SubscriptionError::BlockProcessingFailed {
                 block_number: 0,
             },
@@ -657,19 +662,12 @@ impl PolygonClient {
         #[expect(clippy::cast_sign_loss)]
         let timestamp = chrono::Utc::now().timestamp_millis() as u64;
 
-        let amount = u256_to_decimal(event.value, asset_info.decimals).ok_or_else(|| {
-            tracing::warn!(
-                error.category = CHAIN_CLIENT,
-                error.operation = "log_to_transfer",
-                asset_id = %asset_id,
-                value = %event.value,
-                decimals = asset_info.decimals,
-                "Transfer amount is not representable as a Decimal; skipping block"
-            );
+        let error_block_number = u32::try_from(block_number).unwrap_or(u32::MAX);
+        let amount = u256_to_decimal(event.value, asset_info.decimals).ok_or(
             SubscriptionError::BlockProcessingFailed {
-                block_number: 0,
-            }
-        })?;
+                block_number: error_block_number,
+            },
+        )?;
 
         Ok(ChainTransfer {
             asset_id,
@@ -680,6 +678,44 @@ impl PolygonClient {
             transaction_id: const_hex::encode_prefixed(tx_hash),
             timestamp,
         })
+    }
+
+    async fn buffer_transfer_log(
+        asset_info_store: &AssetInfoStore<PolygonChainConfig>,
+        buffer: &mut ConfirmationBuffer,
+        log: &Log,
+        event: &IERC20::Transfer,
+        block_number: u64,
+        transaction_hash: TxHash,
+        log_index: u64,
+    ) {
+        match Self::log_to_transfer(asset_info_store, log, event).await {
+            Ok(transfer) => {
+                tracing::trace!(
+                    from = %transfer.sender,
+                    to = %transfer.recipient,
+                    amount = %transfer.amount,
+                    asset = %transfer.asset_name,
+                    block_number,
+                    "Detected ERC-20 transfer, waiting for confirmations"
+                );
+                buffer.insert(
+                    block_number,
+                    transaction_hash,
+                    log_index,
+                    transfer,
+                );
+            },
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    %transaction_hash,
+                    block_number,
+                    raw_value = %event.value,
+                    "Failed to process transfer event, skipping it"
+                );
+            },
+        }
     }
 
     // Takes no `self`: the digest depends only on its arguments and the module
@@ -985,8 +1021,8 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
                 decimals,
                 "Balance is not representable as a Decimal"
             );
-            QueryError::NotFound {
-                query_type: "erc20_balance".to_string(),
+            QueryError::DecodeFailed {
+                data_type: format!("ERC-20 balance {balance} with {decimals} decimals"),
             }
         })?;
 
@@ -1111,30 +1147,15 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
                         match log.log_decode::<IERC20::Transfer>() {
                             Ok(decoded) => {
                                 let event = decoded.inner.data;
-                                match client.log_to_transfer(&log, &event).await {
-                                    Ok(transfer) => {
-                                        tracing::trace!(
-                                            from = %transfer.sender,
-                                            to = %transfer.recipient,
-                                            amount = %transfer.amount,
-                                            asset = %transfer.asset_name,
-                                            block_number,
-                                            "Detected ERC-20 transfer, waiting for confirmations"
-                                        );
-                                        buffer.insert(block_number, transaction_hash, log_index, transfer);
-                                    },
-                                    Err(e) => {
-                                        // The log decoded, so this is one of our Transfer
-                                        // events: failing to record it means a payment we
-                                        // will not see again until the invoice expires.
-                                        tracing::error!(
-                                            error = ?e,
-                                            tx_hash = ?log.transaction_hash,
-                                            "Failed to process transfer event, skipping it"
-                                        );
-                                        continue
-                                    },
-                                }
+                                Self::buffer_transfer_log(
+                                    &client.asset_info_store,
+                                    &mut buffer,
+                                    &log,
+                                    &event,
+                                    block_number,
+                                    transaction_hash,
+                                    log_index,
+                                ).await;
                             },
                             Err(e) => {
                                 // One log we cannot decode must not take down tracking for
@@ -1661,7 +1682,8 @@ mod tests {
             PolygonClient::compute_user_op_hash(
                 &default_polygon_unsigned_transaction(),
                 &[0xde, 0xad, 0xbe, 0xef],
-            ),
+            )
+            .unwrap(),
             b256!("0xadcbc48bfdb2401ec19ac83775527235c635fa609de423e3130c436a35dc1853"),
         );
     }
@@ -1784,6 +1806,67 @@ mod tests {
         assert_eq!(released[1].amount, Decimal::new(2, 6));
     }
 
+    #[tokio::test]
+    async fn unrepresentable_log_does_not_drop_other_transfers_in_batch() {
+        let asset_id = address!("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359");
+        let store = AssetInfoStore::new();
+        store.assets.write().await.insert(
+            asset_id,
+            AssetInfo {
+                name: "USDC".to_string(),
+                id: asset_id,
+                decimals: 6,
+            },
+        );
+
+        let mut buffer = ConfirmationBuffer::default();
+        let mut bad_log = Log::default();
+        bad_log.inner.address = asset_id;
+        bad_log.block_number = Some(100);
+        bad_log.transaction_hash = Some(TxHash::with_last_byte(1));
+        let bad_event = IERC20::Transfer {
+            from: Address::with_last_byte(1),
+            to: Address::with_last_byte(2),
+            value: U256::MAX,
+        };
+
+        let mut good_log = bad_log.clone();
+        good_log.transaction_hash = Some(TxHash::with_last_byte(2));
+        let good_event = IERC20::Transfer {
+            value: U256::from(1_000_000_u64),
+            ..bad_event.clone()
+        };
+
+        PolygonClient::buffer_transfer_log(
+            &store,
+            &mut buffer,
+            &bad_log,
+            &bad_event,
+            100,
+            TxHash::with_last_byte(1),
+            0,
+        )
+        .await;
+        PolygonClient::buffer_transfer_log(
+            &store,
+            &mut buffer,
+            &good_log,
+            &good_event,
+            100,
+            TxHash::with_last_byte(2),
+            1,
+        )
+        .await;
+
+        let delivered = buffer.take_confirmed(112, 12);
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered[0].amount, Decimal::ONE);
+        assert_eq!(
+            delivered[0].transaction_id,
+            const_hex::encode_prefixed(TxHash::with_last_byte(2))
+        );
+    }
+
     /// The budget we hand alloy has to run out while our own supervision is
     /// still waiting, not after it has given up. alloy retries one URL;
     /// `TransfersTracker::recreate()` is the only thing that can rotate to
@@ -1822,6 +1905,7 @@ mod tests {
             "alloy would still be retrying after {worst_case:?}, past our own \
              {WS_MESSAGES_TIMEOUT_DURATION:?} timeout, blocking endpoint rotation",
         );
+    }
 
     #[test]
     fn u256_to_decimal_handles_18_decimal_tokens() {

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -6,7 +6,6 @@
 mod consts;
 mod pimlico_client;
 
-use std::str::FromStr;
 use std::time::Duration;
 
 use alloy::eips::eip7702::Authorization;
@@ -372,35 +371,122 @@ impl From<String> for GeneralTransactionId {
 // Utility Functions
 // ============================================================================
 
-/// Convert a U256 value to Decimal with the given number of decimals
+/// 10^18, the wei-per-ether scaling factor Pimlico denominates exchange rates
+/// in. Built from limbs so it is a `const` and cannot panic at runtime.
+const WEI_PER_ETHER: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+
+/// Convert a U256 amount in base units to `Decimal` with the given number of
+/// decimals.
+///
+/// Returns `None` when the value cannot be represented exactly by `Decimal`
+/// (more than 28 significant digits, or `decimals` above `Decimal`'s maximum
+/// scale of 28). This *must* stay fallible: substituting `Decimal::ZERO` on
+/// failure — as this function used to do — records a real incoming payment as
+/// a zero-amount transfer, i.e. as if the customer had paid nothing.
 fn u256_to_decimal(
     value: U256,
     decimals: u8,
-) -> Decimal {
-    // Convert U256 to string and parse as Decimal
-    let value_str = value.to_string();
-    let raw_decimal = Decimal::from_str(&value_str).unwrap_or(Decimal::ZERO);
+) -> Option<Decimal> {
+    // Convert U256 to string and parse as Decimal. `from_str_exact` (unlike
+    // `from_str`) refuses to silently round away significant digits.
+    let raw_decimal = Decimal::from_str_exact(&value.to_string()).ok()?;
 
-    // Apply decimal places
-    let scale = Decimal::new(1, u32::from(decimals));
-    raw_decimal * scale
+    // Apply decimal places. `Decimal::new` panics for scale > 28, so go through
+    // the fallible constructor.
+    let scale = Decimal::try_new(1, u32::from(decimals)).ok()?;
+    raw_decimal.checked_mul(scale)
 }
 
-/// Convert a Decimal to U256 with the given number of decimals
+/// Convert a `Decimal` amount to U256 base units with the given number of
+/// decimals.
+///
+/// Returns `None` when the scaled value does not fit `u128`. Also fallible for
+/// the money-safety reason above: returning `U256::ZERO` here would build a
+/// transfer that moves nothing while the payout is marked as sent.
 fn decimal_to_u256(
     value: Decimal,
     decimals: u8,
-) -> U256 {
-    // Scale up by decimals
-    let multiplier = Decimal::new(10_i64.pow(u32::from(decimals)), 0);
-    #[expect(clippy::arithmetic_side_effects)]
-    let scaled = value * multiplier;
+) -> Option<U256> {
+    // Scale up by decimals. `10_i64.pow` overflows for decimals > 18.
+    let multiplier = Decimal::try_new(
+        10_i64.checked_pow(u32::from(decimals))?,
+        0,
+    )
+    .ok()?;
 
     // Convert to U256
-    scaled
+    value
+        .checked_mul(multiplier)?
         .to_u128()
         .map(U256::from)
-        .unwrap_or(U256::ZERO)
+}
+
+/// Compute the paymaster's maximum charge, denominated in the fee token.
+///
+/// Every input here (`gas_params`, `gas_price`, `quote`) comes verbatim from a
+/// Pimlico bundler JSON-RPC response, so none of it is trusted. A hostile or
+/// buggy bundler can hand back values whose sum or product exceeds `U256::MAX`;
+/// unchecked `+`/`*` would then panic (with overflow checks on) or wrap to a
+/// tiny number that is silently subtracted from the customer's payout. Both are
+/// unacceptable, so overflow is a build failure.
+fn calculate_max_cost_in_token<T: ChainConfig>(
+    gas_params: &GasParams,
+    gas_price: &GasPrice,
+    quote: &TokenQuote,
+) -> Result<U256, TransactionError<T>> {
+    let overflow = || TransactionError::BuildFailed {
+        reason: "Paymaster gas quote overflows U256".to_string(),
+    };
+
+    // Calculate max gas
+    let user_op_max_gas = gas_params
+        .pre_verification_gas
+        .checked_add(gas_params.call_gas_limit)
+        .and_then(|g| g.checked_add(gas_params.verification_gas_limit))
+        .and_then(|g| g.checked_add(gas_params.paymaster_post_op_gas_limit))
+        .and_then(|g| g.checked_add(gas_params.paymaster_verification_gas_limit))
+        .ok_or_else(overflow)?;
+
+    let user_op_max_cost = user_op_max_gas
+        .checked_mul(gas_price.max_fee_per_gas)
+        .ok_or_else(overflow)?;
+    let post_op_cost = quote
+        .post_op_gas
+        .checked_mul(gas_price.max_fee_per_gas)
+        .ok_or_else(overflow)?;
+    let total_cost_wei = user_op_max_cost
+        .checked_add(post_op_cost)
+        .ok_or_else(overflow)?;
+
+    total_cost_wei
+        .checked_mul(quote.exchange_rate)
+        .ok_or_else(overflow)?
+        .checked_div(WEI_PER_ETHER)
+        .ok_or_else(overflow)
+}
+
+/// Narrow a U256 gas/fee field to the `u128` slot that ERC-4337 packs it into.
+///
+/// `U256::to::<u128>()` panics above `u128::MAX`, and every value passed here
+/// originates from an unvalidated Pimlico bundler response, so a malformed or
+/// hostile reply would crash the daemon mid-payout. Report it as a build
+/// failure instead.
+fn u256_to_u128<T: ChainConfig>(
+    value: U256,
+    field: &'static str,
+) -> Result<u128, TransactionError<T>> {
+    u128::try_from(value).map_err(|_| {
+        tracing::warn!(
+            error.category = CHAIN_CLIENT,
+            error.operation = "compute_user_op_hash",
+            field,
+            value = %value,
+            "Bundler returned a gas field that exceeds u128"
+        );
+        TransactionError::BuildFailed {
+            reason: format!("Bundler field `{field}` exceeds u128"),
+        }
+    })
 }
 
 pub(super) fn pack_u128_to_bytes(
@@ -571,7 +657,19 @@ impl PolygonClient {
         #[expect(clippy::cast_sign_loss)]
         let timestamp = chrono::Utc::now().timestamp_millis() as u64;
 
-        let amount = u256_to_decimal(event.value, asset_info.decimals);
+        let amount = u256_to_decimal(event.value, asset_info.decimals).ok_or_else(|| {
+            tracing::warn!(
+                error.category = CHAIN_CLIENT,
+                error.operation = "log_to_transfer",
+                asset_id = %asset_id,
+                value = %event.value,
+                decimals = asset_info.decimals,
+                "Transfer amount is not representable as a Decimal; skipping block"
+            );
+            SubscriptionError::BlockProcessingFailed {
+                block_number: 0,
+            }
+        })?;
 
         Ok(ChainTransfer {
             asset_id,
@@ -626,26 +724,6 @@ impl PolygonClient {
         )
     }
 
-    fn calculate_max_cost_in_token(
-        &self,
-        gas_params: &GasParams,
-        gas_price: &GasPrice,
-        quote: &TokenQuote,
-    ) -> U256 {
-        // Calculate max gas
-        let user_op_max_gas = gas_params.pre_verification_gas
-            + gas_params.call_gas_limit
-            + gas_params.verification_gas_limit
-            + gas_params.paymaster_post_op_gas_limit
-            + gas_params.paymaster_verification_gas_limit;
-
-        let user_op_max_cost = user_op_max_gas * gas_price.max_fee_per_gas;
-        let post_op_cost = quote.post_op_gas * gas_price.max_fee_per_gas;
-        let total_cost_wei = user_op_max_cost + post_op_cost;
-
-        (total_cost_wei * quote.exchange_rate) / U256::from(10).pow(U256::from(18))
-    }
-
     fn build_call(
         &self,
         recipient: Address,
@@ -683,40 +761,48 @@ impl PolygonClient {
     fn compute_user_op_hash(
         transaction: &PolygonUnsignedTransaction,
         paymaster_data: &[u8],
-    ) -> B256 {
+    ) -> Result<B256, TransactionError<PolygonChainConfig>> {
         let type_hash = keccak256(b"PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData)");
 
         let account_gas_limits = pack_u128_to_bytes(
-            transaction
-                .gas_params
-                .verification_gas_limit
-                .to(),
-            transaction
-                .gas_params
-                .call_gas_limit
-                .to(),
+            u256_to_u128(
+                transaction
+                    .gas_params
+                    .verification_gas_limit,
+                "verification_gas_limit",
+            )?,
+            u256_to_u128(
+                transaction.gas_params.call_gas_limit,
+                "call_gas_limit",
+            )?,
         );
 
         let gas_fees = pack_u128_to_bytes(
-            transaction
-                .gas_price
-                .max_priority_fee_per_gas
-                .to(),
-            transaction
-                .gas_price
-                .max_fee_per_gas
-                .to(),
+            u256_to_u128(
+                transaction
+                    .gas_price
+                    .max_priority_fee_per_gas,
+                "max_priority_fee_per_gas",
+            )?,
+            u256_to_u128(
+                transaction.gas_price.max_fee_per_gas,
+                "max_fee_per_gas",
+            )?,
         );
 
         let paymaster_gas_limits = pack_u128_to_bytes(
-            transaction
-                .gas_params
-                .paymaster_verification_gas_limit
-                .to(),
-            transaction
-                .gas_params
-                .paymaster_post_op_gas_limit
-                .to(),
+            u256_to_u128(
+                transaction
+                    .gas_params
+                    .paymaster_verification_gas_limit,
+                "paymaster_verification_gas_limit",
+            )?,
+            u256_to_u128(
+                transaction
+                    .gas_params
+                    .paymaster_post_op_gas_limit,
+                "paymaster_post_op_gas_limit",
+            )?,
         );
 
         let paymaster_and_data = [
@@ -754,14 +840,14 @@ impl PolygonClient {
             verifying_contract: ENTRYPOINT,
         };
 
-        keccak256(
+        Ok(keccak256(
             [
                 &[0x19, 0x01],
                 domain.hash_struct().as_slice(),
                 struct_hash.as_slice(),
             ]
             .concat(),
-        )
+        ))
     }
 }
 
@@ -889,7 +975,20 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
 
         // alloy 1.4 returns the value directly
         let balance = balance_result;
-        let balance_decimal = u256_to_decimal(balance, decimals);
+        let balance_decimal = u256_to_decimal(balance, decimals).ok_or_else(|| {
+            tracing::warn!(
+                error.category = CHAIN_CLIENT,
+                error.operation = "fetch_balance",
+                asset_id = %asset_id,
+                account = %account,
+                balance = %balance,
+                decimals,
+                "Balance is not representable as a Decimal"
+            );
+            QueryError::NotFound {
+                query_type: "erc20_balance".to_string(),
+            }
+        })?;
 
         tracing::trace!(
             ?balance,
@@ -1103,7 +1202,12 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
             })?
             .decimals;
 
-        let amount_wei = decimal_to_u256(amount, decimals);
+        let amount_wei =
+            decimal_to_u256(amount, decimals).ok_or_else(|| TransactionError::BuildFailed {
+                reason: format!(
+                    "Amount {amount} with {decimals} decimals does not fit u128 base units"
+                ),
+            })?;
 
         let contract = IERC20::new(asset_id, self.provider.clone());
         let entrypoint_contract = IERC20::new(ENTRYPOINT, self.provider.clone());
@@ -1271,7 +1375,7 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
         inner.op_hash = Some(Self::compute_user_op_hash(
             &inner,
             &paymaster_data,
-        ));
+        )?);
         let encoded_paymaster_data = const_hex::encode_prefixed(paymaster_data.clone());
         inner.paymaster_data = Some(encoded_paymaster_data.clone());
 
@@ -1338,11 +1442,11 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
                 reason: "Failed to get quote from paymaster".to_string(),
             })?;
 
-        let max_cost_in_usdc_wei = self.calculate_max_cost_in_token(
+        let max_cost_in_usdc_wei = calculate_max_cost_in_token::<PolygonChainConfig>(
             &inner.gas_params,
             &inner.gas_price,
             usdc_quote,
-        );
+        )?;
 
         let amount_wei = inner
             .amount_wei
@@ -1355,7 +1459,7 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
             inner.asset_id,
         );
         inner.call_data = call_data;
-        let op_hash = Self::compute_user_op_hash(&inner, &paymaster_data);
+        let op_hash = Self::compute_user_op_hash(&inner, &paymaster_data)?;
 
         if amount_wei.is_zero() {
             return Err(TransactionError::InsufficientBalance {
@@ -1436,10 +1540,18 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
             // to fill it from saved transaction parameters
             match receipt {
                 Ok(Some(data)) if data.success => {
+                    let amount = u256_to_decimal(unsigned.amount_wei, asset_info.decimals)
+                        .ok_or_else(|| TransactionError::BuildFailed {
+                            reason: format!(
+                                "Transferred amount {} with {} decimals is not representable as a Decimal",
+                                unsigned.amount_wei, asset_info.decimals
+                            ),
+                        })?;
+
                     return Ok(ChainTransfer {
                         asset_id,
                         asset_name: asset_info.name,
-                        amount: u256_to_decimal(unsigned.amount_wei, asset_info.decimals),
+                        amount,
                         sender: data.sender,
                         recipient: data.receipt.to,
                         transaction_id: data.receipt.transaction_hash,
@@ -1558,11 +1670,11 @@ mod tests {
     fn test_u256_decimal_conversion() {
         // 1 USDC = 1_000_000 (6 decimals)
         let value = U256::from(1_000_000_u64);
-        let decimal = u256_to_decimal(value, 6);
+        let decimal = u256_to_decimal(value, 6).unwrap();
         assert_eq!(decimal, Decimal::new(1, 0)); // 1.0
 
         // Convert back
-        let back = decimal_to_u256(decimal, 6);
+        let back = decimal_to_u256(decimal, 6).unwrap();
         assert_eq!(back, value);
     }
 
@@ -1709,6 +1821,162 @@ mod tests {
             worst_case < WS_MESSAGES_TIMEOUT_DURATION,
             "alloy would still be retrying after {worst_case:?}, past our own \
              {WS_MESSAGES_TIMEOUT_DURATION:?} timeout, blocking endpoint rotation",
+        );
+
+    #[test]
+    fn u256_to_decimal_handles_18_decimal_tokens() {
+        // 10 units of an 18-decimal token: 10e18 base units. This exceeds
+        // `i64::MAX` (~9.22e18 is close, 10e18 is over) and used to be the
+        // motivating case for silent corruption.
+        let value = U256::from(10_000_000_000_000_000_000_u128);
+        assert_eq!(
+            u256_to_decimal(value, 18).unwrap(),
+            Decimal::new(10, 0)
+        );
+    }
+
+    #[test]
+    fn u256_to_decimal_rejects_values_beyond_decimal_range() {
+        // Decimal's mantissa is 96 bits (~7.9e28); 1e30 base units cannot be
+        // represented. The old code returned `Decimal::ZERO`, silently turning
+        // a huge payment into "nothing received".
+        let value = U256::from(10u8).pow(U256::from(30u8));
+        assert_eq!(u256_to_decimal(value, 18), None);
+
+        // U256::MAX must not panic either.
+        assert_eq!(u256_to_decimal(U256::MAX, 18), None);
+    }
+
+    #[test]
+    fn u256_to_decimal_rejects_scale_above_decimal_max() {
+        // `Decimal::new(1, 29)` panics; the fallible path must return None.
+        assert_eq!(
+            u256_to_decimal(U256::from(1u8), 29),
+            None
+        );
+    }
+
+    #[test]
+    fn decimal_to_u256_rejects_unrepresentable_values() {
+        // `10_i64.pow(19)` overflows i64.
+        assert_eq!(decimal_to_u256(Decimal::ONE, 19), None);
+
+        // Scaled value beyond u128 must not silently become zero.
+        assert_eq!(decimal_to_u256(Decimal::MAX, 18), None);
+    }
+
+    #[test]
+    fn u256_to_u128_accepts_max_and_rejects_one_over() {
+        let max = U256::from(u128::MAX);
+        assert_eq!(
+            u256_to_u128::<PolygonChainConfig>(max, "call_gas_limit").unwrap(),
+            u128::MAX
+        );
+
+        let over = max
+            .checked_add(U256::from(1u8))
+            .unwrap();
+        let err = u256_to_u128::<PolygonChainConfig>(over, "call_gas_limit").unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionError::BuildFailed { .. }
+        ));
+    }
+
+    fn quote(
+        post_op_gas: U256,
+        exchange_rate: U256,
+    ) -> TokenQuote {
+        TokenQuote {
+            token: Address::ZERO,
+            paymaster: Address::ZERO,
+            exchange_rate,
+            post_op_gas,
+            exchange_rate_native_to_usd: U256::ZERO,
+            balance_slot: U256::ZERO,
+            allowance_slot: U256::ZERO,
+        }
+    }
+
+    #[test]
+    fn calculate_max_cost_in_token_computes_realistic_quote() {
+        // 115_000 total gas * 100 gwei = 1.15e16 wei, + 40_000 * 100 gwei
+        // = 1.55e16 wei; times an exchange rate of 1e18 (1:1), divided by 1e18.
+        let gas_params = GasParams::dummy();
+        let gas_price = GasPrice {
+            max_fee_per_gas: U256::from(100_000_000_000_u64),
+            max_priority_fee_per_gas: U256::from(1_000_000_000_u64),
+        };
+
+        let cost = calculate_max_cost_in_token::<PolygonChainConfig>(
+            &gas_params,
+            &gas_price,
+            &quote(U256::from(40_000), WEI_PER_ETHER),
+        )
+        .unwrap();
+
+        assert_eq!(
+            cost,
+            U256::from(15_500_000_000_000_000_u64)
+        );
+    }
+
+    #[test]
+    fn calculate_max_cost_in_token_rejects_hostile_quote() {
+        // A bundler returning U256::MAX everywhere must produce an error, not
+        // a panic and not a wrapped-around (tiny) fee silently deducted from
+        // the customer's payout.
+        let gas_params = GasParams {
+            pre_verification_gas: U256::MAX,
+            call_gas_limit: U256::MAX,
+            verification_gas_limit: U256::MAX,
+            paymaster_post_op_gas_limit: U256::MAX,
+            paymaster_verification_gas_limit: U256::MAX,
+        };
+        let gas_price = GasPrice {
+            max_fee_per_gas: U256::MAX,
+            max_priority_fee_per_gas: U256::MAX,
+        };
+
+        let err = calculate_max_cost_in_token::<PolygonChainConfig>(
+            &gas_params,
+            &gas_price,
+            &quote(U256::MAX, U256::MAX),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            TransactionError::BuildFailed { .. }
+        ));
+    }
+
+    #[test]
+    fn calculate_max_cost_in_token_rejects_overflowing_exchange_rate() {
+        // Gas sums fine, but the exchange rate multiplication overflows.
+        let gas_price = GasPrice {
+            max_fee_per_gas: U256::from(1u8),
+            max_priority_fee_per_gas: U256::from(1u8),
+        };
+
+        let err = calculate_max_cost_in_token::<PolygonChainConfig>(
+            &GasParams::dummy(),
+            &gas_price,
+            &quote(U256::from(1u8), U256::MAX),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            TransactionError::BuildFailed { .. }
+        ));
+    }
+
+    #[test]
+    fn wei_per_ether_is_ten_to_the_eighteenth() {
+        assert_eq!(
+            WEI_PER_ETHER,
+            U256::from(10u8).pow(U256::from(18u8))
         );
     }
 }

--- a/daemon/src/clients/swaps/zeroex/types.rs
+++ b/daemon/src/clients/swaps/zeroex/types.rs
@@ -135,6 +135,10 @@ impl TryFrom<ZeroExGetQuoteResponse> for SwapQuote {
             // leave placeholder for now but in future probably it'll be better
             // to make this field optional
             estimated_to_amount: Decimal::ZERO,
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "`Utc::now()` plus a fixed 5 minutes cannot approach DateTime<Utc>'s bounds"
+            )]
             valid_till: Utc::now() + TimeDelta::minutes(5),
             quote_details: RawSwapDetails::ZeroEx(details),
         })
@@ -191,6 +195,10 @@ impl TryFrom<ZeroExGaslessGetQuoteResponse> for SwapQuote {
             // leave placeholder for now but in future probably it'll be better
             // to make this field optional
             estimated_to_amount: Decimal::ZERO,
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "`Utc::now()` plus a fixed 5 minutes cannot approach DateTime<Utc>'s bounds"
+            )]
             valid_till: Utc::now() + TimeDelta::minutes(5),
             quote_details: RawSwapDetails::ZeroExGasless(details),
         })

--- a/daemon/src/configs.rs
+++ b/daemon/src/configs.rs
@@ -42,12 +42,13 @@ pub fn chains_config_with_prefix(
 pub fn payments_config_with_prefix(
     config_dir_path: &str,
     prefix: &str,
-) -> PaymentsConfig {
+) -> Result<PaymentsConfig, PaymentsConfigError> {
     let config_path = format_config_path(config_dir_path, "payments.json");
     let env_prefix = format_prefix(prefix, "PAYMENTS");
     let mut config: PaymentsConfig = config_from_file_or_env(&config_path, &env_prefix);
     config.set_default_asset_id_if_missing();
-    config
+    config.validate()?;
+    Ok(config)
 }
 
 pub fn web_server_config_with_prefix(

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -6,6 +6,7 @@ use std::net::IpAddr;
 use std::num::NonZeroU32;
 use std::str::FromStr;
 
+use chrono::Utc;
 use kalatori_client::strum::IntoEnumIterator;
 use rand::prelude::*;
 use rust_decimal::Decimal;
@@ -355,7 +356,33 @@ pub struct PaymentsConfig {
     pub slippage_params: HashMap<ChainType, HashMap<String, SlippageParams>>,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum PaymentsConfigError {
+    #[error(
+        "invalid configuration: invoice_lifetime_millis={value} cannot produce a valid expiry timestamp"
+    )]
+    InvalidInvoiceLifetime { value: u64 },
+}
+
 impl PaymentsConfig {
+    pub fn validate(&self) -> Result<(), PaymentsConfigError> {
+        let valid_lifetime = i64::try_from(self.invoice_lifetime_millis)
+            .ok()
+            .and_then(chrono::TimeDelta::try_milliseconds)
+            .and_then(|lifetime| Utc::now().checked_add_signed(lifetime))
+            .is_some();
+
+        if !valid_lifetime {
+            return Err(
+                PaymentsConfigError::InvalidInvoiceLifetime {
+                    value: self.invoice_lifetime_millis,
+                },
+            )
+        }
+
+        Ok(())
+    }
+
     pub(super) fn set_default_asset_id_if_missing(&mut self) {
         for chain in ChainType::iter() {
             let default = match chain {
@@ -968,6 +995,43 @@ mod tests {
         config.warn_if_zero_ex_rpc_is_public_default();
 
         logs_assert(assert_no_sentinel_leaked);
+    }
+}
+
+#[cfg(test)]
+mod payments_config_tests {
+    use super::*;
+
+    fn payments_config(invoice_lifetime_millis: u64) -> PaymentsConfig {
+        PaymentsConfig {
+            recipient: HashMap::new(),
+            invoice_lifetime_millis,
+            default_chain: ChainType::Polygon,
+            default_asset_id: HashMap::new(),
+            payment_url_base: "https://example.test".to_string(),
+            slippage_params: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn rejects_invoice_lifetime_that_cannot_produce_an_expiry() {
+        assert!(matches!(
+            payments_config(u64::MAX).validate(),
+            Err(
+                PaymentsConfigError::InvalidInvoiceLifetime {
+                    value: u64::MAX,
+                }
+            )
+        ));
+    }
+
+    #[test]
+    fn accepts_default_invoice_lifetime() {
+        assert!(
+            payments_config(DEFAULT_INVOICE_LIFETIME_MILLIS)
+                .validate()
+                .is_ok()
+        );
     }
 }
 

--- a/daemon/src/dao/changes.rs
+++ b/daemon/src/dao/changes.rs
@@ -36,6 +36,9 @@ pub enum DaoChangesError {
 
     #[error("Failed to parse JSON from database: {message}")]
     JsonParseError { message: String },
+
+    #[error("Incoming amount total overflowed for invoice {invoice_id}")]
+    AmountOverflow { invoice_id: uuid::Uuid },
 }
 
 impl From<sqlx::Error> for DaoChangesError {
@@ -50,6 +53,9 @@ impl crate::api::ApiErrorExt for DaoChangesError {
             DaoChangesError::DatabaseError
             | DaoChangesError::JsonParseError {
                 ..
+            }
+            | DaoChangesError::AmountOverflow {
+                ..
             } => "INTERNAL_SERVER_ERROR",
         }
     }
@@ -60,6 +66,9 @@ impl crate::api::ApiErrorExt for DaoChangesError {
             DaoChangesError::JsonParseError {
                 ..
             } => "JSON_PARSE_ERROR",
+            DaoChangesError::AmountOverflow {
+                ..
+            } => "INVOICE_AMOUNT_OVERFLOW",
         }
     }
 
@@ -69,6 +78,9 @@ impl crate::api::ApiErrorExt for DaoChangesError {
             DaoChangesError::JsonParseError {
                 ..
             } => "Failed to parse data from database.",
+            DaoChangesError::AmountOverflow {
+                ..
+            } => "Stored invoice amounts cannot be totaled.",
         }
     }
 

--- a/daemon/src/dao/invoice.rs
+++ b/daemon/src/dao/invoice.rs
@@ -1,3 +1,4 @@
+use rust_decimal::Decimal;
 use sqlx::QueryBuilder;
 use sqlx::types::{
     Json,
@@ -71,6 +72,11 @@ pub enum DaoInvoiceError {
     /// or deployment-history problem, not a database failure.
     #[error("Chain {chain} cannot be a payout destination")]
     UnsupportedPayoutChain { chain: ChainType },
+    /// Stored incoming amounts cannot be totaled without overflowing Decimal.
+    #[error("Incoming amount total overflowed for invoice {invoice_id}")]
+    AmountOverflow { invoice_id: Uuid },
+    #[error("Configured invoice lifetime cannot produce a valid expiry timestamp")]
+    InvalidInvoiceLifetime,
 }
 
 impl crate::api::ApiErrorExt for DaoInvoiceError {
@@ -92,7 +98,11 @@ impl crate::api::ApiErrorExt for DaoInvoiceError {
             DaoInvoiceError::UnsupportedPayoutChain {
                 ..
             }
-            | DaoInvoiceError::DatabaseError => "INTERNAL_SERVER_ERROR",
+            | DaoInvoiceError::DatabaseError
+            | DaoInvoiceError::AmountOverflow {
+                ..
+            }
+            | DaoInvoiceError::InvalidInvoiceLifetime => "INTERNAL_SERVER_ERROR",
         }
     }
 
@@ -114,6 +124,10 @@ impl crate::api::ApiErrorExt for DaoInvoiceError {
                 ..
             }
             | DaoInvoiceError::DatabaseError => "INTERNAL_SERVER_ERROR",
+            DaoInvoiceError::AmountOverflow {
+                ..
+            } => "INVOICE_AMOUNT_OVERFLOW",
+            DaoInvoiceError::InvalidInvoiceLifetime => "INVALID_INVOICE_LIFETIME",
         }
     }
 
@@ -137,6 +151,10 @@ impl crate::api::ApiErrorExt for DaoInvoiceError {
                 ..
             } => "The payout could not be prepared for this invoice's chain.",
             DaoInvoiceError::DatabaseError => "A database error occurred.",
+            DaoInvoiceError::AmountOverflow {
+                ..
+            } => "Stored invoice amounts cannot be totaled.",
+            DaoInvoiceError::InvalidInvoiceLifetime => "Configured invoice lifetime is invalid.",
         }
     }
 
@@ -157,7 +175,11 @@ impl crate::api::ApiErrorExt for DaoInvoiceError {
             DaoInvoiceError::UnsupportedPayoutChain {
                 ..
             }
-            | DaoInvoiceError::DatabaseError => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            | DaoInvoiceError::DatabaseError
+            | DaoInvoiceError::AmountOverflow {
+                ..
+            }
+            | DaoInvoiceError::InvalidInvoiceLifetime => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }
@@ -192,8 +214,12 @@ struct InvoiceWithAmountsRow {
     amounts: sqlx::types::Json<Vec<String>>,
 }
 
-impl From<InvoiceWithAmountsRow> for InvoiceWithReceivedAmount {
-    fn from(row: InvoiceWithAmountsRow) -> Self {
+impl TryFrom<InvoiceWithAmountsRow> for InvoiceWithReceivedAmount {
+    type Error = DaoInvoiceError;
+
+    fn try_from(row: InvoiceWithAmountsRow) -> Result<Self, Self::Error> {
+        let invoice: Invoice = row.invoice.into();
+        let invoice_id = invoice.id;
         let incoming_amount = row
             .amounts
             .0
@@ -203,12 +229,26 @@ impl From<InvoiceWithAmountsRow> for InvoiceWithReceivedAmount {
                     .parse::<rust_decimal::Decimal>()
                     .ok()
             })
-            .sum();
+            .try_fold(Decimal::ZERO, |total, amount| {
+                total
+                    .checked_add(amount)
+                    .ok_or_else(|| {
+                        tracing::error!(
+                            %invoice_id,
+                            accumulated_amount = %total,
+                            transaction_amount = %amount,
+                            "Stored incoming transfer total overflowed"
+                        );
+                        DaoInvoiceError::AmountOverflow {
+                            invoice_id,
+                        }
+                    })
+            })?;
 
-        Self {
-            invoice: row.invoice.into(),
+        Ok(Self {
+            invoice,
             total_received_amount: incoming_amount,
-        }
+        })
     }
 }
 
@@ -331,7 +371,8 @@ pub trait DaoInvoiceMethods: DaoExecutor + 'static {
         )
         .bind(invoice_id);
 
-        self.fetch_optional(query)
+        let row: Option<InvoiceWithAmountsRow> = self
+            .fetch_optional(query)
             .await
             .map_err(|e| {
                 tracing::debug!(
@@ -342,7 +383,10 @@ pub trait DaoInvoiceMethods: DaoExecutor + 'static {
                     "Failed to fetch invoice with received amount"
                 );
                 DaoInvoiceError::DatabaseError
-            })
+            })?;
+
+        row.map(InvoiceWithReceivedAmount::try_from)
+            .transpose()
     }
 
     /// Get all active invoices that need to be monitored and total amount of
@@ -369,7 +413,8 @@ pub trait DaoInvoiceMethods: DaoExecutor + 'static {
             ORDER BY i.created_at ASC",
         );
 
-        self.fetch_all(query)
+        let rows: Vec<InvoiceWithAmountsRow> = self
+            .fetch_all(query)
             .await
             .map_err(|e| {
                 tracing::debug!(
@@ -379,7 +424,11 @@ pub trait DaoInvoiceMethods: DaoExecutor + 'static {
                     "Failed to fetch paid amounts for invoices"
                 );
                 DaoInvoiceError::DatabaseError
-            })
+            })?;
+
+        rows.into_iter()
+            .map(InvoiceWithReceivedAmount::try_from)
+            .collect()
     }
 
     async fn update_invoice_status(
@@ -531,7 +580,8 @@ pub trait DaoInvoiceMethods: DaoExecutor + 'static {
 
         let query = builder.build_query_as::<InvoiceWithAmountsRow>();
 
-        self.fetch_all(query)
+        let rows: Vec<InvoiceWithAmountsRow> = self
+            .fetch_all(query)
             .await
             .map_err(|e| {
                 tracing::debug!(
@@ -541,7 +591,11 @@ pub trait DaoInvoiceMethods: DaoExecutor + 'static {
                     "Failed to fetch paginated invoices"
                 );
                 DaoInvoiceError::DatabaseError
-            })
+            })?;
+
+        rows.into_iter()
+            .map(InvoiceWithReceivedAmount::try_from)
+            .collect()
     }
 
     /// Count invoices matching the given filters (for pagination metadata).
@@ -688,11 +742,46 @@ mod tests {
         Transaction,
         TransactionType,
         default_create_invoice_data,
+        default_invoice,
         default_transaction,
         default_update_invoice_data,
     };
 
     use super::*;
+
+    #[test]
+    fn stored_received_amount_overflow_is_an_error() {
+        let invoice = default_invoice();
+        let invoice_id = invoice.id;
+        let row = InvoiceWithAmountsRow {
+            invoice: InvoiceRow {
+                id: invoice.id,
+                order_id: invoice.order_id,
+                asset_id: invoice.asset_id,
+                asset_name: invoice.asset_name,
+                chain: invoice.chain,
+                amount: Text(invoice.amount),
+                payment_address: invoice.payment_address,
+                status: invoice.status,
+                cart: Json(invoice.cart),
+                redirect_url: invoice.redirect_url,
+                valid_till: invoice.valid_till,
+                created_at: invoice.created_at,
+                updated_at: invoice.updated_at,
+            },
+            amounts: Json(vec![
+                Decimal::MAX.to_string(),
+                Decimal::ONE.to_string(),
+            ]),
+        };
+
+        assert!(matches!(
+            InvoiceWithReceivedAmount::try_from(row),
+            Err(DaoInvoiceError::AmountOverflow {
+                invoice_id: id,
+            }) if id == invoice_id
+        ));
+    }
 
     #[expect(clippy::too_many_lines)]
     #[tokio::test]

--- a/daemon/src/dao/invoice.rs
+++ b/daemon/src/dao/invoice.rs
@@ -1228,7 +1228,10 @@ mod tests {
             payment_address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY".to_string(),
             cart: InvoiceCart::empty(),
             redirect_url: "http://localhost:8080/thankyou".to_string(),
-            #[expect(clippy::arithmetic_side_effects)]
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "test fixture: `Utc::now()` plus a fixed 24 hours cannot overflow DateTime<Utc>"
+            )]
             valid_till: chrono::Utc::now() + chrono::Duration::hours(24),
         }
     }

--- a/daemon/src/dao/payout.rs
+++ b/daemon/src/dao/payout.rs
@@ -873,7 +873,10 @@ mod tests {
             payment_address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY".to_string(),
             cart: InvoiceCart::empty(),
             redirect_url: "http://localhost:8080/thankyou".to_string(),
-            #[expect(clippy::arithmetic_side_effects)]
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "test fixture: `Utc::now()` plus a fixed 24 hours cannot overflow DateTime<Utc>"
+            )]
             valid_till: chrono::Utc::now() + chrono::Duration::hours(24),
         }
     }
@@ -1006,6 +1009,10 @@ mod tests {
         let retry_meta = RetryMeta {
             retry_count: 1,
             last_attempt_at: Some(Utc::now()),
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "test: `Utc::now()` plus a fixed 5 minutes cannot overflow DateTime<Utc>"
+            )]
             next_retry_at: Some(Utc::now() + chrono::Duration::minutes(5)),
             failure_message: Some("Network error".to_string()),
         };

--- a/daemon/src/dao/swap.rs
+++ b/daemon/src/dao/swap.rs
@@ -1301,7 +1301,10 @@ mod tests {
             payment_address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY".to_string(),
             cart: InvoiceCart::empty(),
             redirect_url: "http://localhost:8080/thankyou".to_string(),
-            #[expect(clippy::arithmetic_side_effects)]
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "test fixture: `Utc::now()` plus a fixed 24 hours cannot overflow DateTime<Utc>"
+            )]
             valid_till: chrono::Utc::now() + chrono::Duration::hours(24),
         }
     }

--- a/daemon/src/dao/transaction.rs
+++ b/daemon/src/dao/transaction.rs
@@ -1289,7 +1289,10 @@ mod tests {
             payment_address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY".to_string(),
             cart: InvoiceCart::empty(),
             redirect_url: "http://localhost:8080/thankyou".to_string(),
-            #[expect(clippy::arithmetic_side_effects)]
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "test fixture: `Utc::now()` plus a fixed 24 hours cannot overflow DateTime<Utc>"
+            )]
             valid_till: chrono::Utc::now() + chrono::Duration::hours(24),
         }
     }

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
     #[error("failed to parse the config parameter `{0}`")]
     ConfigParse(&'static str),
 
+    #[error(transparent)]
+    InvalidConfiguration(#[from] crate::configs::PaymentsConfigError),
+
     #[error("chain {0:?} doesn't have any `endpoints` in the config")]
     EmptyEndpoints(String),
 

--- a/daemon/src/etherscan_client.rs
+++ b/daemon/src/etherscan_client.rs
@@ -32,6 +32,19 @@ pub enum EtherscanClientError {
     EtherscanError { message: String, result: String },
     #[error("Request failed")]
     RequestFailed,
+    /// Etherscan reported a transfer whose base-unit amount cannot be
+    /// represented as a `Decimal`. The item is rejected on its own, so the
+    /// other transfers in the same response are still recorded — a poisoned
+    /// item must not cost the batch, because Etherscan keeps returning it and
+    /// every retry would meet it again.
+    #[error("Transfer {tx_hash}: amount {value} with {decimals} decimals is not representable")]
+    UnrepresentableAmount {
+        value: u128,
+        decimals: u32,
+        tx_hash: String,
+        block_number: u32,
+        transaction_index: u32,
+    },
 }
 
 impl From<EtherscanResponseData<String>> for EtherscanClientError {
@@ -59,6 +72,46 @@ pub struct EtherscanClient {
 }
 
 impl EtherscanClient {
+    fn convert_incoming_transfers(
+        transactions: Vec<EtherscanTransaction>,
+        address: &str,
+        invoice_id: Uuid,
+    ) -> Vec<IncomingTransaction> {
+        transactions
+            .into_iter()
+            .filter(|transaction| transaction.to.eq_ignore_ascii_case(address))
+            .filter_map(|transaction| {
+                transaction
+                    .into_incoming_transaction(invoice_id)
+                    .map_err(|error| {
+                        match &error {
+                            EtherscanClientError::UnrepresentableAmount {
+                                value,
+                                decimals,
+                                tx_hash,
+                                block_number,
+                                transaction_index,
+                            } => tracing::error!(
+                                %invoice_id,
+                                %tx_hash,
+                                block_number,
+                                transaction_index,
+                                value,
+                                decimals,
+                                "Rejected unrepresentable Etherscan transfer; valid batch items will continue"
+                            ),
+                            _ => tracing::error!(
+                                %invoice_id,
+                                error = ?error,
+                                "Rejected Etherscan transfer during conversion"
+                            ),
+                        }
+                    })
+                    .ok()
+            })
+            .collect()
+    }
+
     pub fn new(config: EtherscanClientConfig) -> Self {
         let rate_limiter = Arc::new(RateLimiter::direct(Quota::per_second(
             config.requests_per_second,
@@ -163,17 +216,62 @@ impl EtherscanClient {
             },
         };
 
-        let result = self
+        let transactions = self
             .get_account_transfers(chain_id, asset_id, address)
-            .await?
-            .into_iter()
-            .filter_map(|trans| {
-                (trans.to.to_lowercase() == address.to_lowercase())
-                    .then(|| trans.into_incoming_transaction(invoice_id))
-                    .flatten()
-            })
-            .collect();
+            .await?;
 
-        Ok(result)
+        Ok(Self::convert_incoming_transfers(
+            transactions,
+            address,
+            invoice_id,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal::Decimal;
+
+    use super::*;
+
+    fn transaction(
+        hash: &str,
+        value: u128,
+    ) -> EtherscanTransaction {
+        EtherscanTransaction {
+            block_number: 1,
+            hash: hash.to_string(),
+            from: "0xfrom".to_string(),
+            contract_address: "0xcontract".to_string(),
+            to: "0xrecipient".to_string(),
+            value,
+            token_symbol: "USDC".to_string(),
+            token_decimal: 18,
+            transaction_index: 0,
+        }
+    }
+
+    #[test]
+    fn mixed_batch_keeps_valid_transfers_around_rejected_item() {
+        let invoice_id = Uuid::new_v4();
+        let transfers = EtherscanClient::convert_incoming_transfers(
+            vec![
+                transaction("0xgood1", 1_000_000_000_000_000_000),
+                transaction("0xbad", u128::MAX),
+                transaction("0xgood2", 2_000_000_000_000_000_000),
+            ],
+            "0xRECIPIENT",
+            invoice_id,
+        );
+
+        assert_eq!(transfers.len(), 2);
+        assert_eq!(
+            transfers[0].transfer_info.amount,
+            Decimal::ONE
+        );
+        assert_eq!(
+            transfers[1].transfer_info.amount,
+            Decimal::from(2)
+        );
     }
 }

--- a/daemon/src/etherscan_client/types.rs
+++ b/daemon/src/etherscan_client/types.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use rust_decimal::Decimal;
 use serde::{
     Deserialize,
@@ -36,8 +38,7 @@ pub enum EtherscanResponse<T> {
     Err(EtherscanResponseData<String>),
 }
 
-// TODO: hide `api_key` field in logs
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub struct GetAccountTokenTransactionsParams<'a> {
     pub module: &'a str,
     pub action: &'a str,
@@ -48,6 +49,28 @@ pub struct GetAccountTokenTransactionsParams<'a> {
     pub chain_id: u32,
     #[serde(rename = "apikey")]
     pub api_key: &'a str,
+}
+
+/// Hand-written so the key cannot reach a log through `?params`. The field has
+/// to stay a plain `&str` because `Serialize` puts it in the query string, so
+/// the derive is what would leak it.
+impl fmt::Debug for GetAccountTokenTransactionsParams<'_> {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        f.debug_struct("GetAccountTokenTransactionsParams")
+            .field("module", &self.module)
+            .field("action", &self.action)
+            .field("address", &self.address)
+            .field(
+                "contract_address",
+                &self.contract_address,
+            )
+            .field("chain_id", &self.chain_id)
+            .field("api_key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 #[serde_as]
@@ -141,7 +164,12 @@ impl EtherscanTransaction {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
+    use secrecy::SecretString;
+
     use super::*;
+    use crate::configs::EtherscanClientConfig;
 
     fn transaction(
         value: u128,
@@ -242,5 +270,44 @@ mod tests {
             err,
             EtherscanClientError::UnrepresentableAmount { .. }
         ));
+    }
+
+    /// A value that cannot occur by accident, so its absence is evidence.
+    const SENTINEL: &str = "SENTINEL-ETHERSCAN-KEY-8f3a1c";
+
+    #[test]
+    fn debug_of_request_params_hides_the_api_key() {
+        let params = GetAccountTokenTransactionsParams {
+            module: "account",
+            action: "tokentx",
+            address: "0x0000000000000000000000000000000000000000",
+            contract_address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+            chain_id: 137,
+            api_key: SENTINEL,
+        };
+
+        let rendered = format!("{params:?}");
+
+        assert!(
+            !rendered.contains(SENTINEL),
+            "api key leaked: {rendered}"
+        );
+        // The struct is still worth logging -- redaction, not omission.
+        assert!(rendered.contains("tokentx"));
+    }
+
+    #[test]
+    fn debug_of_client_config_hides_the_api_key() {
+        let config = EtherscanClientConfig {
+            requests_per_second: NonZeroU32::new(3).unwrap(),
+            api_key: SecretString::from(SENTINEL.to_string()),
+        };
+
+        let rendered = format!("{config:?}");
+
+        assert!(
+            !rendered.contains(SENTINEL),
+            "api key leaked: {rendered}"
+        );
     }
 }

--- a/daemon/src/etherscan_client/types.rs
+++ b/daemon/src/etherscan_client/types.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use rust_decimal::Decimal;
 use serde::{
     Deserialize,
@@ -17,6 +15,9 @@ use crate::types::{
     IncomingTransaction,
     TransferInfo,
 };
+use crate::utils::decimal_from_base_units;
+
+use super::EtherscanClientError;
 
 #[serde_as]
 #[expect(dead_code)]
@@ -35,7 +36,8 @@ pub enum EtherscanResponse<T> {
     Err(EtherscanResponseData<String>),
 }
 
-#[derive(Serialize)]
+// TODO: hide `api_key` field in logs
+#[derive(Debug, Serialize)]
 pub struct GetAccountTokenTransactionsParams<'a> {
     pub module: &'a str,
     pub action: &'a str,
@@ -46,28 +48,6 @@ pub struct GetAccountTokenTransactionsParams<'a> {
     pub chain_id: u32,
     #[serde(rename = "apikey")]
     pub api_key: &'a str,
-}
-
-/// Hand-written so the key cannot reach a log through `?params`. The field has
-/// to stay a plain `&str` because `Serialize` puts it in the query string, so
-/// the derive is what would leak it.
-impl fmt::Debug for GetAccountTokenTransactionsParams<'_> {
-    fn fmt(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        f.debug_struct("GetAccountTokenTransactionsParams")
-            .field("module", &self.module)
-            .field("action", &self.action)
-            .field("address", &self.address)
-            .field(
-                "contract_address",
-                &self.contract_address,
-            )
-            .field("chain_id", &self.chain_id)
-            .field("api_key", &"[REDACTED]")
-            .finish()
-    }
 }
 
 #[serde_as]
@@ -106,35 +86,34 @@ pub struct EtherscanTransaction {
 }
 
 impl EtherscanTransaction {
-    /// Returns `None` (with an error log) when the reported value or token
-    /// decimals don't fit into `Decimal`: recording a wrapped amount would
-    /// corrupt the invoice, while skipping keeps the balance mismatch
-    /// visible to the balance checker.
+    /// Convert Etherscan's `value` (base units) plus `tokenDecimal` into a
+    /// `Decimal` amount.
+    ///
+    /// This used to be `Decimal::new(self.value as i64, self.token_decimal)`,
+    /// which wrapped a `u128` into an `i64`. Ten units of an 18-decimal token
+    /// is 10^19 base units — already past `i64::MAX` — so an ordinary payment
+    /// was recorded as a *negative* amount. The conversion is now checked at
+    /// every step and cannot panic or wrap.
+    fn amount(
+        value: u128,
+        token_decimal: u32,
+    ) -> Option<Decimal> {
+        decimal_from_base_units(&value.to_string(), token_decimal)
+    }
+
     pub fn into_incoming_transaction(
         self,
         invoice_id: Uuid,
-    ) -> Option<IncomingTransaction> {
-        // Convert through `i128`, not `i64`: `Decimal` holds a 96-bit mantissa,
-        // so an `i64` intermediate would cap an 18-decimal token at ~9.22
-        // tokens and silently skip everything above it.
-        let Ok(value) = i128::try_from(self.value) else {
-            tracing::error!(
-                tx_hash = %self.hash,
-                value = self.value,
-                "Transfer value exceeds the supported range, skipping transaction"
-            );
-            return None;
-        };
-
-        let Ok(amount) = Decimal::try_from_i128_with_scale(value, self.token_decimal) else {
-            tracing::error!(
-                tx_hash = %self.hash,
-                value = self.value,
-                token_decimal = self.token_decimal,
-                "Transfer value or token decimals exceed the range representable by Decimal, skipping transaction"
-            );
-            return None;
-        };
+    ) -> Result<IncomingTransaction, EtherscanClientError> {
+        let amount = Self::amount(self.value, self.token_decimal).ok_or(
+            EtherscanClientError::UnrepresentableAmount {
+                value: self.value,
+                decimals: self.token_decimal,
+                tx_hash: self.hash.clone(),
+                block_number: self.block_number,
+                transaction_index: self.transaction_index,
+            },
+        )?;
 
         let transfer_info = TransferInfo {
             chain: ChainType::Polygon,
@@ -151,7 +130,7 @@ impl EtherscanTransaction {
             tx_hash: Some(self.hash),
         };
 
-        Some(IncomingTransaction {
+        Ok(IncomingTransaction {
             id: Uuid::new_v4(),
             invoice_id,
             transfer_info,
@@ -162,125 +141,106 @@ impl EtherscanTransaction {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
-
-    use secrecy::SecretString;
-
     use super::*;
-    use crate::configs::EtherscanClientConfig;
 
     fn transaction(
         value: u128,
         token_decimal: u32,
     ) -> EtherscanTransaction {
         EtherscanTransaction {
-            block_number: 100,
-            hash: "0xdead".to_string(),
+            block_number: 1,
+            hash: "0xdeadbeef".to_string(),
             from: "0xfrom".to_string(),
-            contract_address: "0xtoken".to_string(),
+            contract_address: "0xcontract".to_string(),
             to: "0xto".to_string(),
             value,
             token_symbol: "USDC".to_string(),
             token_decimal,
-            transaction_index: 2,
+            transaction_index: 0,
         }
     }
 
     #[test]
-    fn test_into_incoming_transaction() {
-        let invoice_id = Uuid::new_v4();
-        let result = transaction(1_500_000, 6)
-            .into_incoming_transaction(invoice_id)
+    fn six_decimal_amount_round_trips() {
+        // 1.5 USDC
+        let tx = transaction(1_500_000, 6);
+        let incoming = tx
+            .into_incoming_transaction(Uuid::nil())
             .unwrap();
 
         assert_eq!(
-            result.transfer_info.amount,
+            incoming.transfer_info.amount,
             Decimal::new(15, 1)
         );
-        assert_eq!(result.invoice_id, invoice_id);
-        assert_eq!(
-            result.transaction_id.tx_hash,
-            Some("0xdead".to_string())
-        );
     }
 
     #[test]
-    fn test_into_incoming_transaction_accepts_large_18_decimal_transfer() {
-        // 10 tokens of an 18-decimal asset is 1e19 base units — above
-        // `i64::MAX`, so an `i64` intermediate would drop it, but well within
-        // Decimal's 96-bit mantissa
-        let ten_tokens = 10_000_000_000_000_000_000_u128;
-        assert!(ten_tokens > u128::try_from(i64::MAX).unwrap());
-
-        let result = transaction(ten_tokens, 18)
-            .into_incoming_transaction(Uuid::new_v4())
-            .expect("an 18-decimal transfer above i64::MAX must still be recorded");
+    fn ten_units_of_an_18_decimal_token_is_positive_ten() {
+        // Regression: 10 * 10^18 = 10^19 base units overflows i64, and the old
+        // `self.value as i64` cast turned this into a NEGATIVE amount.
+        let tx = transaction(10_000_000_000_000_000_000, 18);
+        let incoming = tx
+            .into_incoming_transaction(Uuid::nil())
+            .unwrap();
 
         assert_eq!(
-            result.transfer_info.amount,
-            Decimal::from(10)
+            incoming.transfer_info.amount,
+            Decimal::new(10, 0)
+        );
+        assert!(incoming.transfer_info.amount > Decimal::ZERO);
+    }
+
+    #[test]
+    fn amount_beyond_i64_but_within_decimal_is_exact() {
+        // ~18.45 tokens with 18 decimals: base units are just over i64::MAX.
+        let value = u128::try_from(i64::MAX).unwrap() + 1;
+        let amount = EtherscanTransaction::amount(value, 18).unwrap();
+
+        assert_eq!(
+            amount,
+            Decimal::from_str_exact("9.223372036854775808").unwrap()
         );
     }
 
     #[test]
-    fn test_into_incoming_transaction_rejects_oversized_value() {
-        // Decimal's mantissa is 96 bits; anything above 2^96-1 base units is
-        // genuinely unrepresentable and must be skipped rather than wrapped
-        let oversized = (1_u128 << 96) + 1;
-        assert!(
-            transaction(oversized, 6)
-                .into_incoming_transaction(Uuid::new_v4())
-                .is_none()
+    fn unrepresentable_amount_is_an_error_not_a_wrap() {
+        // u128::MAX has 39 significant digits; Decimal holds at most 28.
+        let err = transaction(u128::MAX, 18)
+            .into_incoming_transaction(Uuid::nil())
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            EtherscanClientError::UnrepresentableAmount { .. }
+        ));
+    }
+
+    #[test]
+    fn scaled_value_with_large_base_unit_mantissa_is_exact() {
+        let incoming = transaction(
+            1_000_000_000_000_000_000_000_000_000_000,
+            18,
+        )
+        .into_incoming_transaction(Uuid::nil())
+        .unwrap();
+
+        assert_eq!(
+            incoming.transfer_info.amount,
+            Decimal::from(1_000_000_000_000_u64)
         );
     }
 
     #[test]
-    fn test_into_incoming_transaction_rejects_oversized_decimals() {
-        // Decimal supports at most 28 decimal places; the old Decimal::new
-        // panicked here
-        assert!(
-            transaction(1_000_000, 77)
-                .into_incoming_transaction(Uuid::new_v4())
-                .is_none()
-        );
-    }
+    fn scale_above_decimal_maximum_is_an_error_not_a_panic() {
+        // `Decimal::new(1, 29)` panics; a bogus `tokenDecimal` must not crash
+        // the poller.
+        let err = transaction(1, 29)
+            .into_incoming_transaction(Uuid::nil())
+            .unwrap_err();
 
-    /// A value that cannot occur by accident, so its absence is evidence.
-    const SENTINEL: &str = "SENTINEL-ETHERSCAN-KEY-8f3a1c";
-
-    #[test]
-    fn debug_of_request_params_hides_the_api_key() {
-        let params = GetAccountTokenTransactionsParams {
-            module: "account",
-            action: "tokentx",
-            address: "0x0000000000000000000000000000000000000000",
-            contract_address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
-            chain_id: 137,
-            api_key: SENTINEL,
-        };
-
-        let rendered = format!("{params:?}");
-
-        assert!(
-            !rendered.contains(SENTINEL),
-            "api key leaked: {rendered}"
-        );
-        // The struct is still worth logging -- redaction, not omission.
-        assert!(rendered.contains("tokentx"));
-    }
-
-    #[test]
-    fn debug_of_client_config_hides_the_api_key() {
-        let config = EtherscanClientConfig {
-            requests_per_second: NonZeroU32::new(3).unwrap(),
-            api_key: SecretString::from(SENTINEL.to_string()),
-        };
-
-        let rendered = format!("{config:?}");
-
-        assert!(
-            !rendered.contains(SENTINEL),
-            "api key leaked: {rendered}"
-        );
+        assert!(matches!(
+            err,
+            EtherscanClientError::UnrepresentableAmount { .. }
+        ));
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -268,7 +268,7 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
 
     let secrets_config = secrets_config_with_prefix(&configs_path, &env_prefix);
     let mut chains_config = chains_config_with_prefix(&configs_path, &env_prefix);
-    let mut payments_config = payments_config_with_prefix(&configs_path, &env_prefix);
+    let mut payments_config = payments_config_with_prefix(&configs_path, &env_prefix)?;
     let web_server_config = web_server_config_with_prefix(&configs_path, &env_prefix);
     let database_config = database_config_with_prefix(&configs_path, &env_prefix);
     let shop_config = shop_config_with_prefix(&configs_path, &env_prefix);

--- a/daemon/src/state.rs
+++ b/daemon/src/state.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 
 use chrono::{
-    Duration,
+    DateTime,
     Utc,
 };
 use rust_decimal::Decimal;
@@ -98,6 +98,21 @@ pub struct AppState<D: DaoInterface = DAO> {
     api_secret_key: SecretString,
 }
 
+/// Expiry timestamp for a freshly created or updated invoice.
+///
+/// `invoice_lifetime_millis` is operator-supplied configuration and is a `u64`.
+/// The previous `as i64` cast wrapped values above `i64::MAX` into a *negative*
+/// lifetime, producing an invoice that was already expired, and the subsequent
+/// `Utc::now() + Duration` panicked for lifetimes near the top of the range.
+/// Both cases now clamp to the largest representable instant instead.
+fn invoice_valid_till(invoice_lifetime_millis: u64) -> DateTime<Utc> {
+    i64::try_from(invoice_lifetime_millis)
+        .ok()
+        .and_then(chrono::TimeDelta::try_milliseconds)
+        .and_then(|lifetime| Utc::now().checked_add_signed(lifetime))
+        .unwrap_or(DateTime::<Utc>::MAX_UTC)
+}
+
 impl<D: DaoInterface> AppState<D> {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
@@ -145,7 +160,6 @@ impl<D: DaoInterface> AppState<D> {
             .await
     }
 
-    #[expect(clippy::arithmetic_side_effects, clippy::cast_possible_wrap)]
     #[tracing::instrument(skip_all)]
     pub async fn create_invoice(
         &self,
@@ -174,11 +188,10 @@ impl<D: DaoInterface> AppState<D> {
             // This should never happen, but just in case
             .unwrap_or_else(|| "UNKNOWN".to_string());
 
-        let valid_till = Utc::now()
-            + Duration::milliseconds(
-                self.payments_config
-                    .invoice_lifetime_millis as i64,
-            );
+        let valid_till = invoice_valid_till(
+            self.payments_config
+                .invoice_lifetime_millis,
+        );
 
         let payment_address = match chain {
             ChainType::PolkadotAssetHub => {
@@ -278,7 +291,6 @@ impl<D: DaoInterface> AppState<D> {
         Ok(invoice_with_amount)
     }
 
-    #[expect(clippy::arithmetic_side_effects, clippy::cast_possible_wrap)]
     pub async fn update_invoice(
         &self,
         params: UpdateInvoiceParams,
@@ -287,11 +299,10 @@ impl<D: DaoInterface> AppState<D> {
             invoice_id: params.invoice_id,
             amount: params.amount,
             cart: params.cart,
-            valid_till: Utc::now()
-                + Duration::milliseconds(
-                    self.payments_config
-                        .invoice_lifetime_millis as i64,
-                ),
+            valid_till: invoice_valid_till(
+                self.payments_config
+                    .invoice_lifetime_millis,
+            ),
         };
 
         let dao_transaction = self
@@ -1203,12 +1214,11 @@ mod tests {
                 asset_name: "USDC".to_string(),
                 chain: ChainType::PolkadotAssetHub,
                 payment_address: to_base58_string(account_id.0, 0),
-                valid_till: Utc::now()
-                    + Duration::milliseconds(
-                        app_state
-                            .payments_config
-                            .invoice_lifetime_millis as i64,
-                    ),
+                valid_till: invoice_valid_till(
+                    app_state
+                        .payments_config
+                        .invoice_lifetime_millis,
+                ),
             }
         };
 
@@ -1329,12 +1339,11 @@ mod tests {
                 asset_name: "USDC".to_string(),
                 chain: ChainType::PolkadotAssetHub,
                 payment_address: to_base58_string(account_id.0, 0),
-                valid_till: Utc::now()
-                    + Duration::milliseconds(
-                        app_state
-                            .payments_config
-                            .invoice_lifetime_millis as i64,
-                    ),
+                valid_till: invoice_valid_till(
+                    app_state
+                        .payments_config
+                        .invoice_lifetime_millis,
+                ),
             }
         };
 

--- a/daemon/src/state.rs
+++ b/daemon/src/state.rs
@@ -104,13 +104,14 @@ pub struct AppState<D: DaoInterface = DAO> {
 /// The previous `as i64` cast wrapped values above `i64::MAX` into a *negative*
 /// lifetime, producing an invoice that was already expired, and the subsequent
 /// `Utc::now() + Duration` panicked for lifetimes near the top of the range.
-/// Both cases now clamp to the largest representable instant instead.
-fn invoice_valid_till(invoice_lifetime_millis: u64) -> DateTime<Utc> {
+/// Invalid lifetimes are rejected at configuration load. This remains
+/// fallible as defense in depth for directly-constructed test/application
+/// state.
+fn invoice_valid_till(invoice_lifetime_millis: u64) -> Option<DateTime<Utc>> {
     i64::try_from(invoice_lifetime_millis)
         .ok()
         .and_then(chrono::TimeDelta::try_milliseconds)
         .and_then(|lifetime| Utc::now().checked_add_signed(lifetime))
-        .unwrap_or(DateTime::<Utc>::MAX_UTC)
 }
 
 impl<D: DaoInterface> AppState<D> {
@@ -191,7 +192,8 @@ impl<D: DaoInterface> AppState<D> {
         let valid_till = invoice_valid_till(
             self.payments_config
                 .invoice_lifetime_millis,
-        );
+        )
+        .ok_or(DaoInvoiceError::InvalidInvoiceLifetime)?;
 
         let payment_address = match chain {
             ChainType::PolkadotAssetHub => {
@@ -302,7 +304,8 @@ impl<D: DaoInterface> AppState<D> {
             valid_till: invoice_valid_till(
                 self.payments_config
                     .invoice_lifetime_millis,
-            ),
+            )
+            .ok_or(DaoInvoiceError::InvalidInvoiceLifetime)?,
         };
 
         let dao_transaction = self
@@ -770,7 +773,7 @@ impl<D: DaoInterface> AppState<D> {
             .invoices
             .sort_by_key(|i| i.invoice.updated_at);
 
-        Ok(internal_response.into_public(&self.payments_config.payment_url_base))
+        internal_response.into_public(&self.payments_config.payment_url_base)
     }
 
     pub fn get_shop_meta(&self) -> ShopMetaConfig {
@@ -1225,7 +1228,8 @@ mod tests {
                     app_state
                         .payments_config
                         .invoice_lifetime_millis,
-                ),
+                )
+                .unwrap(),
             }
         };
 
@@ -1350,7 +1354,8 @@ mod tests {
                     app_state
                         .payments_config
                         .invoice_lifetime_millis,
-                ),
+                )
+                .unwrap(),
             }
         };
 

--- a/daemon/src/state/swaps.rs
+++ b/daemon/src/state/swaps.rs
@@ -54,6 +54,11 @@ pub enum SwapRequestError {
     AssetMetadataUnavailable { asset_id: String },
     #[error("Database error")]
     DatabaseError,
+    /// Scaling the invoice's unfilled amount into integer token base units
+    /// overflowed. Kept distinct from `DatabaseError` because it is a bad
+    /// amount, not a storage fault, and is not worth retrying.
+    #[error("Amount {amount} cannot be converted to token base units")]
+    AmountConversion { amount: Decimal },
 }
 
 impl From<SwapsExecutorError> for SwapRequestError {
@@ -323,10 +328,15 @@ impl<D: DaoInterface> AppState<D> {
                 }
             })?;
 
-            (invoice.unfilled_amount() / one_unit)
-                .to_u128()
-                // TODO: change error
-                .ok_or(SwapRequestError::DatabaseError)?
+            // `/ one_unit` is a multiplication by 10^decimals and panics on
+            // `Decimal` overflow; `to_u128` rejects anything that does not fit.
+            let amount = invoice.unfilled_amount();
+            amount
+                .checked_div(one_unit)
+                .and_then(|scaled| scaled.to_u128())
+                .ok_or(SwapRequestError::AmountConversion {
+                    amount,
+                })?
         };
 
         let data = CreateSwapData {

--- a/daemon/src/state/swaps.rs
+++ b/daemon/src/state/swaps.rs
@@ -15,6 +15,7 @@ use crate::types::{
     SwapSignatureParams,
     SwapStatus,
 };
+use crate::utils::decimal_to_base_units;
 
 use super::AppState;
 
@@ -59,6 +60,8 @@ pub enum SwapRequestError {
     /// amount, not a storage fault, and is not worth retrying.
     #[error("Amount {amount} cannot be converted to token base units")]
     AmountConversion { amount: Decimal },
+    #[error("Invoice {invoice_id} has an unrepresentable remaining amount")]
+    InvalidInvoiceAmount { invoice_id: Uuid },
 }
 
 impl From<SwapsExecutorError> for SwapRequestError {
@@ -121,6 +124,9 @@ impl ApiErrorExt for SwapRequestError {
             | SwapRequestError::AmountConversion {
                 ..
             }
+            | SwapRequestError::InvalidInvoiceAmount {
+                ..
+            }
             | SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
         }
     }
@@ -152,6 +158,9 @@ impl ApiErrorExt for SwapRequestError {
                 ..
             }
             | SwapRequestError::AmountConversion {
+                ..
+            }
+            | SwapRequestError::InvalidInvoiceAmount {
                 ..
             }
             | SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
@@ -189,6 +198,9 @@ impl ApiErrorExt for SwapRequestError {
                 ..
             }
             | SwapRequestError::AmountConversion {
+                ..
+            }
+            | SwapRequestError::InvalidInvoiceAmount {
                 ..
             }
             | SwapRequestError::DatabaseError => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
@@ -230,9 +242,35 @@ impl ApiErrorExt for SwapRequestError {
             SwapRequestError::AmountConversion {
                 ..
             } => "The swap amount cannot be represented in token base units.",
+            SwapRequestError::InvalidInvoiceAmount {
+                ..
+            } => "The invoice amount cannot be represented in token base units.",
             SwapRequestError::DatabaseError => "A database error occurred.",
         }
     }
+}
+
+fn expected_invoice_amount_units(
+    invoice: &crate::types::InvoiceWithReceivedAmount,
+    decimals: u32,
+) -> Result<u128, SwapRequestError> {
+    let invoice_id = invoice.invoice.id;
+    let amount = invoice
+        .unfilled_amount()
+        .map_err(|error| {
+            tracing::error!(
+                %invoice_id,
+                error = ?error,
+                "Invoice remaining amount cannot be represented"
+            );
+            SwapRequestError::InvalidInvoiceAmount {
+                invoice_id,
+            }
+        })?;
+
+    decimal_to_base_units(amount, decimals).ok_or(SwapRequestError::AmountConversion {
+        amount,
+    })
 }
 
 impl<D: DaoInterface> AppState<D> {
@@ -328,27 +366,7 @@ impl<D: DaoInterface> AppState<D> {
                     }
                 })?;
 
-            let one_unit = Decimal::try_new(1, decimals.into()).map_err(|_| {
-                tracing::error!(
-                    chain = %default_chain,
-                    asset_id = %to_token_address,
-                    decimals,
-                    "Destination asset decimals exceed the supported range"
-                );
-                SwapRequestError::AssetMetadataUnavailable {
-                    asset_id: to_token_address.clone(),
-                }
-            })?;
-
-            // `/ one_unit` is a multiplication by 10^decimals and panics on
-            // `Decimal` overflow; `to_u128` rejects anything that does not fit.
-            let amount = invoice.unfilled_amount();
-            amount
-                .checked_div(one_unit)
-                .and_then(|scaled| scaled.to_u128())
-                .ok_or(SwapRequestError::AmountConversion {
-                    amount,
-                })?
+            expected_invoice_amount_units(&invoice, decimals.into())?
         };
 
         let data = CreateSwapData {
@@ -755,5 +773,30 @@ mod tests {
             error.message(),
             "Swaps are not available for this shop."
         );
+    }
+
+    #[test]
+    fn expected_invoice_units_reject_sub_base_unit_dust() {
+        let mut invoice = default_invoice().with_amount(Decimal::ZERO);
+        invoice.invoice.amount = Decimal::from_str_exact("1.0000001").unwrap();
+
+        assert!(matches!(
+            expected_invoice_amount_units(&invoice, 6),
+            Err(SwapRequestError::AmountConversion { .. })
+        ));
+    }
+
+    #[test]
+    fn expected_invoice_units_propagate_unrepresentable_remainder() {
+        let mut invoice = default_invoice().with_amount(Decimal::MIN);
+        invoice.invoice.amount = Decimal::MAX;
+        let invoice_id = invoice.invoice.id;
+
+        assert!(matches!(
+            expected_invoice_amount_units(&invoice, 6),
+            Err(SwapRequestError::InvalidInvoiceAmount {
+                invoice_id: id,
+            }) if id == invoice_id
+        ));
     }
 }

--- a/daemon/src/state/swaps.rs
+++ b/daemon/src/state/swaps.rs
@@ -118,6 +118,9 @@ impl ApiErrorExt for SwapRequestError {
             SwapRequestError::AssetMetadataUnavailable {
                 ..
             }
+            | SwapRequestError::AmountConversion {
+                ..
+            }
             | SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
         }
     }
@@ -146,6 +149,9 @@ impl ApiErrorExt for SwapRequestError {
             SwapRequestError::QuoteRequestFailed => "QUOTE_REQUEST_FAILED",
             SwapRequestError::SwapDestinationUnavailable => "SWAP_DESTINATION_UNAVAILABLE",
             SwapRequestError::AssetMetadataUnavailable {
+                ..
+            }
+            | SwapRequestError::AmountConversion {
                 ..
             }
             | SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
@@ -180,6 +186,9 @@ impl ApiErrorExt for SwapRequestError {
             },
             SwapRequestError::QuoteRequestFailed
             | SwapRequestError::AssetMetadataUnavailable {
+                ..
+            }
+            | SwapRequestError::AmountConversion {
                 ..
             }
             | SwapRequestError::DatabaseError => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
@@ -218,6 +227,9 @@ impl ApiErrorExt for SwapRequestError {
             SwapRequestError::AssetMetadataUnavailable {
                 ..
             } => "The swap could not be prepared: asset metadata is unavailable.",
+            SwapRequestError::AmountConversion {
+                ..
+            } => "The swap amount cannot be represented in token base units.",
             SwapRequestError::DatabaseError => "A database error occurred.",
         }
     }

--- a/daemon/src/types/changes.rs
+++ b/daemon/src/types/changes.rs
@@ -15,6 +15,8 @@ use serde::{
 };
 use uuid::Uuid;
 
+use crate::dao::DaoChangesError;
+
 use kalatori_client::types::{
     ChainType,
     Invoice as PublicInvoice,
@@ -152,16 +154,16 @@ impl ChangesResponse {
     pub fn into_public(
         self,
         payment_url_base: &str,
-    ) -> PublicChangesResponse {
-        PublicChangesResponse {
+    ) -> Result<PublicChangesResponse, DaoChangesError> {
+        Ok(PublicChangesResponse {
             invoices: self
                 .invoices
                 .into_iter()
                 .map(|ic| ic.into_public(payment_url_base))
-                .collect(),
+                .collect::<Result<Vec<_>, _>>()?,
             sync_timestamp: self.sync_timestamp,
             kalatori_version: VERSION,
-        }
+        })
     }
 }
 
@@ -169,13 +171,28 @@ impl InvoiceChanges {
     fn into_public(
         self,
         payment_url_base: &str,
-    ) -> PublicInvoiceChanges {
+    ) -> Result<PublicInvoiceChanges, DaoChangesError> {
         // Calculate total received amount from incoming transactions
-        let total_received_amount: Decimal = self
-            .transactions
-            .iter()
-            .map(|t| t.transfer_info.amount)
-            .sum();
+        let invoice_id = self.invoice.id;
+        let total_received_amount =
+            self.transactions
+                .iter()
+                .try_fold(Decimal::ZERO, |total, transaction| {
+                    total
+                        .checked_add(transaction.transfer_info.amount)
+                        .ok_or_else(|| {
+                            tracing::error!(
+                                %invoice_id,
+                                transaction_id = ?transaction.transaction_id,
+                                accumulated_amount = %total,
+                                transaction_amount = %transaction.transfer_info.amount,
+                                "Incoming transfer total overflowed while building changes response"
+                            );
+                            DaoChangesError::AmountOverflow {
+                                invoice_id,
+                            }
+                        })
+                })?;
 
         // Convert invoice to public invoice
         let public_invoice = self
@@ -183,7 +200,7 @@ impl InvoiceChanges {
             .with_amount(total_received_amount)
             .into_public_invoice(payment_url_base);
 
-        PublicInvoiceChanges {
+        Ok(PublicInvoiceChanges {
             invoice: public_invoice,
             incoming_transactions: self
                 .transactions
@@ -201,7 +218,7 @@ impl InvoiceChanges {
                 .map(RefundChanges::into_public)
                 .collect(),
             swaps: self.swaps,
-        }
+        })
     }
 }
 
@@ -578,5 +595,41 @@ impl TryFrom<FrontEndSwapJson> for FrontEndSwap {
             created_at: json.created_at,
             updated_at: json.updated_at,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        default_invoice,
+        default_transaction,
+    };
+
+    #[test]
+    fn changes_conversion_rejects_received_amount_overflow() {
+        let invoice = default_invoice();
+        let invoice_id = invoice.id;
+        let mut first = default_transaction(invoice_id);
+        first.transfer_info.amount = Decimal::MAX;
+        let mut second = default_transaction(invoice_id);
+        second.transfer_info.amount = Decimal::ONE;
+
+        let error = InvoiceChanges {
+            invoice,
+            transactions: vec![first, second],
+            payouts: vec![],
+            refunds: vec![],
+            swaps: vec![],
+        }
+        .into_public("https://example.test")
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DaoChangesError::AmountOverflow {
+                invoice_id: id,
+            } if id == invoice_id
+        ));
     }
 }

--- a/daemon/src/types/common.rs
+++ b/daemon/src/types/common.rs
@@ -88,15 +88,24 @@ impl RetryMeta {
         }
     }
 
-    #[expect(clippy::arithmetic_side_effects)]
     pub fn increment_retry(
         &mut self,
         failure_message: String,
     ) {
         let now = Utc::now();
-        self.retry_count += 1;
+        // `retry_delay_secs` caps at 2 hours once the count passes 4, so
+        // saturating the counter keeps the backoff at its cap rather than
+        // wrapping it back into the 1-minute bucket.
+        self.retry_count = self.retry_count.saturating_add(1);
         self.last_attempt_at = Some(now);
-        self.next_retry_at = Some(now + chrono::Duration::seconds(self.retry_delay_secs()));
+
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "`retry_delay_secs` returns one of six fixed values, at most 2 hours; adding that to `Utc::now()` cannot overflow DateTime<Utc>"
+        )]
+        let next_retry_at = now + chrono::Duration::seconds(self.retry_delay_secs());
+
+        self.next_retry_at = Some(next_retry_at);
         self.failure_message = Some(failure_message);
     }
 
@@ -158,9 +167,18 @@ impl PaginationParams {
             .clamp(1, MAX_PER_PAGE)
     }
 
-    #[expect(clippy::arithmetic_side_effects)]
+    /// SQL `OFFSET` for the requested page.
+    ///
+    /// `page` is an unvalidated query-string parameter, so `(page - 1) *
+    /// per_page` overflows `u32` for any `page` above ~43 million. That used to
+    /// wrap silently (serving an arbitrary wrong page) and, now that release
+    /// builds actually enable `overflow-checks`, would panic the handler.
+    /// Saturating yields an empty page, which is the right answer for a page
+    /// number that far past the end of the table.
     pub fn offset(&self) -> u32 {
-        (self.validated_page() - 1) * self.validated_per_page()
+        self.validated_page()
+            .saturating_sub(1)
+            .saturating_mul(self.validated_per_page())
     }
 }
 
@@ -194,5 +212,61 @@ impl<T: Serialize> PaginatedResponse<T> {
             per_page,
             total_pages,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params(
+        page: Option<u32>,
+        per_page: Option<u32>,
+    ) -> PaginationParams {
+        PaginationParams {
+            page,
+            per_page,
+        }
+    }
+
+    #[test]
+    fn offset_defaults_to_the_first_page() {
+        assert_eq!(params(None, None).offset(), 0);
+        assert_eq!(params(Some(1), Some(25)).offset(), 0);
+    }
+
+    #[test]
+    fn offset_scales_with_page_number() {
+        assert_eq!(params(Some(3), Some(25)).offset(), 50);
+    }
+
+    #[test]
+    fn offset_saturates_instead_of_wrapping_on_a_hostile_page_number() {
+        // `page` is an unvalidated query-string parameter. `(u32::MAX - 1) *
+        // 100` overflows: it used to wrap to a small, arbitrary offset and,
+        // with `overflow-checks` now actually enabled in release builds, would
+        // panic the handler. Saturating gives an empty page.
+        assert_eq!(
+            params(Some(u32::MAX), Some(MAX_PER_PAGE)).offset(),
+            u32::MAX
+        );
+        assert_eq!(
+            params(Some(u32::MAX), Some(1)).offset(),
+            u32::MAX.saturating_sub(1)
+        );
+    }
+
+    #[test]
+    fn increment_retry_saturates_the_counter() {
+        let mut meta = RetryMeta {
+            retry_count: u32::MAX,
+            ..RetryMeta::default()
+        };
+        meta.increment_retry("boom".to_string());
+
+        // Must stay at the cap rather than wrapping back to 0, which would
+        // reset the exponential backoff to its shortest delay.
+        assert_eq!(meta.retry_count, u32::MAX);
+        assert!(meta.next_retry_at.is_some());
     }
 }

--- a/daemon/src/types/invoice.rs
+++ b/daemon/src/types/invoice.rs
@@ -65,6 +65,12 @@ pub struct InvoiceWithReceivedAmount {
     pub total_received_amount: Decimal,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum InvoiceAmountError {
+    #[error("Invoice {invoice_id} amount remainder cannot be represented")]
+    UnrepresentableRemainder { invoice_id: Uuid },
+}
+
 impl InvoiceWithReceivedAmount {
     pub fn into_public_invoice(
         self,
@@ -96,16 +102,19 @@ impl InvoiceWithReceivedAmount {
 
     /// Returns invoice's unfilled amount or 0 if it's filled or overpaid.
     ///
-    /// Uses `saturating_sub`: `Decimal`'s `-` panics on overflow, and this is
-    /// called from request handlers. Saturating is safe here because the result
-    /// is clamped to the non-negative range anyway — an underflow can only push
-    /// it further below zero, and an overflow towards `Decimal::MAX` preserves
-    /// the "still owed" meaning rather than inventing a zero balance.
-    pub fn unfilled_amount(&self) -> Decimal {
+    /// The subtraction is fallible because extreme/corrupt signed amounts can
+    /// exceed Decimal's representable range. Only a successfully computed
+    /// negative remainder is clamped to zero.
+    pub fn unfilled_amount(&self) -> Result<Decimal, InvoiceAmountError> {
         self.invoice
             .amount
-            .saturating_sub(self.total_received_amount)
-            .max(Decimal::ZERO)
+            .checked_sub(self.total_received_amount)
+            .map(|remainder| remainder.max(Decimal::ZERO))
+            .ok_or(
+                InvoiceAmountError::UnrepresentableRemainder {
+                    invoice_id: self.invoice.id,
+                },
+            )
     }
 }
 
@@ -258,7 +267,8 @@ mod tests {
                 Decimal::new(100, 0),
                 Decimal::new(40, 0)
             )
-            .unfilled_amount(),
+            .unfilled_amount()
+            .unwrap(),
             Decimal::new(60, 0)
         );
     }
@@ -270,7 +280,8 @@ mod tests {
                 Decimal::new(100, 0),
                 Decimal::new(100, 0)
             )
-            .unfilled_amount(),
+            .unfilled_amount()
+            .unwrap(),
             Decimal::ZERO
         );
         assert_eq!(
@@ -278,24 +289,36 @@ mod tests {
                 Decimal::new(100, 0),
                 Decimal::new(250, 0)
             )
-            .unfilled_amount(),
+            .unfilled_amount()
+            .unwrap(),
             Decimal::ZERO
         );
     }
 
     #[test]
-    fn unfilled_amount_saturates_instead_of_panicking() {
+    fn unfilled_amount_rejects_unrepresentable_remainders() {
         // `Decimal::MAX - Decimal::MIN` overflows; the plain `-` this used to
         // use would panic inside a request handler.
+        let invoice = with_received(Decimal::MAX, Decimal::MIN);
         assert_eq!(
-            with_received(Decimal::MAX, Decimal::MIN).unfilled_amount(),
-            Decimal::MAX
+            invoice.unfilled_amount(),
+            Err(
+                InvoiceAmountError::UnrepresentableRemainder {
+                    invoice_id: invoice.invoice.id,
+                }
+            )
         );
 
-        // The opposite direction saturates negative and is then clamped to 0.
+        // The opposite direction is just as unrepresentable; zero is only used
+        // after a successful negative subtraction.
+        let invoice = with_received(Decimal::MIN, Decimal::MAX);
         assert_eq!(
-            with_received(Decimal::MIN, Decimal::MAX).unfilled_amount(),
-            Decimal::ZERO
+            invoice.unfilled_amount(),
+            Err(
+                InvoiceAmountError::UnrepresentableRemainder {
+                    invoice_id: invoice.invoice.id,
+                }
+            )
         );
     }
 }

--- a/daemon/src/types/invoice.rs
+++ b/daemon/src/types/invoice.rs
@@ -94,9 +94,18 @@ impl InvoiceWithReceivedAmount {
         }
     }
 
-    /// Returns invoice's unfilled amount or 0 if it's filled or overpaid
+    /// Returns invoice's unfilled amount or 0 if it's filled or overpaid.
+    ///
+    /// Uses `saturating_sub`: `Decimal`'s `-` panics on overflow, and this is
+    /// called from request handlers. Saturating is safe here because the result
+    /// is clamped to the non-negative range anyway — an underflow can only push
+    /// it further below zero, and an overflow towards `Decimal::MAX` preserves
+    /// the "still owed" meaning rather than inventing a zero balance.
     pub fn unfilled_amount(&self) -> Decimal {
-        (self.invoice.amount - self.total_received_amount).max(Decimal::ZERO)
+        self.invoice
+            .amount
+            .saturating_sub(self.total_received_amount)
+            .max(Decimal::ZERO)
     }
 }
 
@@ -201,7 +210,10 @@ pub fn default_create_invoice_data() -> CreateInvoiceData {
         payment_address: "0x45f077823C8d036a1a9f7Cd28e86Bd98191dF2b7".to_string(),
         cart: InvoiceCart::empty(),
         redirect_url: "http://localhost:8080/thankyou".to_string(),
-        #[expect(clippy::arithmetic_side_effects)]
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "test fixture: `Utc::now()` plus a fixed 24 hours cannot overflow DateTime<Utc>"
+        )]
         valid_till: now + chrono::Duration::hours(24),
     }
 }
@@ -214,7 +226,76 @@ pub fn default_update_invoice_data(invoice_id: Uuid) -> UpdateInvoiceData {
         invoice_id,
         amount: Decimal::new(15000, 2),
         cart: InvoiceCart::empty(),
-        #[expect(clippy::arithmetic_side_effects)]
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "test fixture: `Utc::now()` plus a fixed 24 hours cannot overflow DateTime<Utc>"
+        )]
         valid_till: now + chrono::Duration::hours(24),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_received(
+        amount: Decimal,
+        total_received_amount: Decimal,
+    ) -> InvoiceWithReceivedAmount {
+        let mut invoice = default_invoice();
+        invoice.amount = amount;
+
+        InvoiceWithReceivedAmount {
+            invoice,
+            total_received_amount,
+        }
+    }
+
+    #[test]
+    fn unfilled_amount_reports_the_remainder() {
+        assert_eq!(
+            with_received(
+                Decimal::new(100, 0),
+                Decimal::new(40, 0)
+            )
+            .unfilled_amount(),
+            Decimal::new(60, 0)
+        );
+    }
+
+    #[test]
+    fn unfilled_amount_is_zero_when_filled_or_overpaid() {
+        assert_eq!(
+            with_received(
+                Decimal::new(100, 0),
+                Decimal::new(100, 0)
+            )
+            .unfilled_amount(),
+            Decimal::ZERO
+        );
+        assert_eq!(
+            with_received(
+                Decimal::new(100, 0),
+                Decimal::new(250, 0)
+            )
+            .unfilled_amount(),
+            Decimal::ZERO
+        );
+    }
+
+    #[test]
+    fn unfilled_amount_saturates_instead_of_panicking() {
+        // `Decimal::MAX - Decimal::MIN` overflows; the plain `-` this used to
+        // use would panic inside a request handler.
+        assert_eq!(
+            with_received(Decimal::MAX, Decimal::MIN).unfilled_amount(),
+            Decimal::MAX
+        );
+
+        // The opposite direction saturates negative and is then clamped to 0.
+        assert_eq!(
+            with_received(Decimal::MIN, Decimal::MAX).unfilled_amount(),
+            Decimal::ZERO
+        );
     }
 }

--- a/daemon/src/types/swap.rs
+++ b/daemon/src/types/swap.rs
@@ -328,6 +328,10 @@ pub fn default_swap_quote(data: &CreateSwapData) -> SwapQuote {
         id: "123".to_string(),
         estimated_to_amount_units: data.from_amount_units,
         estimated_to_amount: Decimal::new(data.from_amount_units as i64, 6),
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "test fixture: `Utc::now()` plus a fixed 1 minute cannot overflow DateTime<Utc>"
+        )]
         valid_till: Utc::now() + TimeDelta::minutes(1),
         quote_details,
     }

--- a/daemon/src/types/webhook_event.rs
+++ b/daemon/src/types/webhook_event.rs
@@ -57,6 +57,10 @@ pub fn default_webhook_event(invoice_id: Uuid) -> GenericEvent<super::PublicInvo
         cart: kalatori_client::types::InvoiceCart {
             items: vec![],
         },
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "test fixture: `Utc::now()` plus a fixed 24 hours cannot overflow DateTime<Utc>"
+        )]
         valid_till: Utc::now() + chrono::Duration::hours(24),
         created_at: Utc::now(),
         updated_at: Utc::now(),

--- a/daemon/src/utils.rs
+++ b/daemon/src/utils.rs
@@ -1,8 +1,13 @@
+mod amount;
 pub mod logger;
 pub mod logging;
 mod refund_destination_detector;
 pub mod shutdown;
 pub mod task_tracker;
 
+pub(crate) use amount::{
+    decimal_from_base_units,
+    decimal_to_base_units,
+};
 #[cfg_attr(test, mockall_double::double)]
 pub use refund_destination_detector::RefundDestinationDetector;

--- a/daemon/src/utils/amount.rs
+++ b/daemon/src/utils/amount.rs
@@ -1,0 +1,109 @@
+use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
+
+/// Convert an unsigned integer string in token base units to an exact decimal
+/// amount at the asset's scale.
+pub(crate) fn decimal_from_base_units(
+    value: &str,
+    decimals: u32,
+) -> Option<Decimal> {
+    if value.bytes().all(|digit| digit == b'0') {
+        return Some(Decimal::ZERO)
+    }
+
+    let trailing_zeroes = value
+        .bytes()
+        .rev()
+        .take_while(|digit| *digit == b'0')
+        .count();
+    let trailing_zeroes = u32::try_from(trailing_zeroes).ok()?;
+    let significant_len = value
+        .len()
+        .checked_sub(usize::try_from(trailing_zeroes).ok()?)?;
+    let significant = value.get(..significant_len)?;
+
+    if decimals <= trailing_zeroes {
+        let integer_zeroes = usize::try_from(trailing_zeroes.checked_sub(decimals)?).ok()?;
+        let mut normalized = String::with_capacity(significant_len.checked_add(integer_zeroes)?);
+        normalized.push_str(significant);
+        normalized.extend(std::iter::repeat_n('0', integer_zeroes));
+        return Decimal::from_str_exact(&normalized).ok()
+    }
+
+    let scale = decimals.checked_sub(trailing_zeroes)?;
+    if scale > Decimal::MAX_SCALE {
+        return None
+    }
+
+    let scale = usize::try_from(scale).ok()?;
+    let normalized = if significant_len > scale {
+        let decimal_point = significant_len.checked_sub(scale)?;
+        format!(
+            "{}.{}",
+            significant.get(..decimal_point)?,
+            significant.get(decimal_point..)?
+        )
+    } else {
+        let leading_zeroes = scale.checked_sub(significant_len)?;
+        format!(
+            "0.{}{}",
+            "0".repeat(leading_zeroes),
+            significant
+        )
+    };
+
+    Decimal::from_str_exact(&normalized).ok()
+}
+
+/// Convert a decimal token amount to integer base units without rounding or
+/// truncating sub-base-unit dust.
+pub(crate) fn decimal_to_base_units(
+    value: Decimal,
+    decimals: u32,
+) -> Option<u128> {
+    let scaled = Decimal::try_new(1, decimals)
+        .ok()
+        .and_then(|unit| value.checked_div(unit))?;
+
+    if !scaled.fract().is_zero() {
+        return None
+    }
+
+    scaled.to_u128()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_scale_compatible_trailing_zeroes() {
+        assert_eq!(
+            decimal_from_base_units("1000000000000000000000000000000", 18),
+            Some(Decimal::from(1_000_000_000_000_u64))
+        );
+    }
+
+    #[test]
+    fn rejects_fractional_scale_beyond_decimal_maximum() {
+        assert_eq!(decimal_from_base_units("1", 29), None);
+    }
+
+    #[test]
+    fn base_unit_conversion_requires_an_exact_integer() {
+        assert_eq!(
+            decimal_to_base_units(
+                Decimal::from_str_exact("1.000001").unwrap(),
+                6
+            ),
+            Some(1_000_001)
+        );
+        assert_eq!(
+            decimal_to_base_units(
+                Decimal::from_str_exact("1.0000001").unwrap(),
+                6
+            ),
+            None
+        );
+    }
+}

--- a/daemon/src/webhook_sender.rs
+++ b/daemon/src/webhook_sender.rs
@@ -179,7 +179,11 @@ impl<D: DaoInterface + 'static> WebhookSender<D> {
     async fn prepare_webhook_events(
         &mut self
     ) -> Vec<Pin<Box<dyn Future<Output = SendWebhookResult> + Send + 'static>>> {
-        let limit = WEBHOOK_SENDER_MAX_CONCURRENT_REQUESTS - self.processing_events_ids.len();
+        // `saturating_sub` rather than `-`: if the in-flight set ever exceeds
+        // the cap, a `usize` underflow here would wrap to ~1.8e19 and ask the
+        // DAO for every pending webhook at once.
+        let limit =
+            WEBHOOK_SENDER_MAX_CONCURRENT_REQUESTS.saturating_sub(self.processing_events_ids.len());
 
         if limit == 0 {
             return Vec::new();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ SQLite via sqlx 0.8. `DaoInterface` + `DaoTransactionInterface` traits (mockable
 - `polygon.rs` — Polygon via alloy 1.5 (secp256k1 keys, ERC-20 tokens, Pimlico paymaster for gas abstraction)
 
 `AssetInfoStore` trait for per-chain asset metadata. Error types in `errors.rs` follow the [error handling principles](error-handling.md).
+Incoming base-unit amounts are normalized at the asset scale before conversion to `Decimal`. Outgoing amounts must convert exactly to integer base units; sub-base-unit dust and unrepresentable precision are rejected, and deterministic amount failures are not retried.
 
 ### `daemon/src/chain_client/keyring.rs` — Keyring (Actor)
 Actor pattern: mpsc channel + oneshot responses. Holds seed phrase (`Zeroize` + `ZeroizeOnDrop`). Handles both:
@@ -65,7 +66,7 @@ Client interface: `KeyringClient` (mockable via `mockall_double`).
 
 ### `daemon/src/chain/` — Chain Monitoring & Execution
 - **`transfer_tracker.rs`** (`TransfersTracker`): Subscribes to finalized blocks per chain, detects incoming transfers, and notifies `TransactionsRecorder`. Failed subscriptions and streams that end before delivering an event use a cancellation-aware exponential retry delay (1–60 seconds). Retry state resets only after a stream delivers an event; degradation is reported on entry and at most once per minute, with recovery reported separately.
-- **`transactions_recorder.rs`** (`TransactionsRecorder`): Records detected transactions to DB, updates `InvoiceRegistry`. Its transaction-scoped recording path lets Asset Hub balance reconciliation read the persisted received total and write a synthetic adjustment in one SQLite transaction; payout/refund/webhook/status side effects use that same path and the registry changes only after commit.
+- **`transactions_recorder.rs`** (`TransactionsRecorder`): Records detected transactions to DB, updates `InvoiceRegistry`. Its transaction-scoped recording path lets Asset Hub balance reconciliation read the persisted received total and write a synthetic adjustment in one SQLite transaction; payout/refund/webhook/status side effects use that same path and the registry changes only after commit. Checked amount failures abort the database transaction and are surfaced with invoice/transaction coordinates; durable live-event replay remains a separate persistence concern.
 - **`executor.rs`** (`TransfersExecutor`): Builds and submits payout transactions for both chains. Single executor instance handles Asset Hub + Polygon.
 - **`invoice_registry.rs`** (`InvoiceRegistry`): In-memory tracking of active invoices and their expected amounts. Thread-safe (internal `RwLock`). Invoice-data refreshes update only records that are still present, preserving the received amount; they never reinsert an invoice removed concurrently after reaching a terminal status.
 
@@ -76,7 +77,7 @@ Periodic background task. Checks for expired invoices, handles cleanup and statu
 Periodic background task. Sends unsent webhook events from DB to configured URLs with HMAC signatures.
 
 ### `daemon/src/etherscan_client.rs` — EtherscanClient
-Client for Etherscan/Polygonscan API. Used by ExpirationDetector for transaction verification on EVM chains.
+Client for Etherscan/Polygonscan API. Used by ExpirationDetector for transaction verification on EVM chains. Transfer conversion is isolated per response item: unrepresentable items are logged with chain coordinates while valid items in the same batch continue through reconciliation.
 
 ### `daemon/src/types/` — Domain Types
 Business logic models: `Invoice`, `Payout`, `Transaction`, `Refund`, `Swap`, `WebhookEvent`, `Changes`. Separate from DAO row types and API response types.
@@ -87,6 +88,7 @@ Monolithic `Error` enum with `PrettyCause` trait. Being migrated to domain-speci
 ### `daemon/src/utils/` — Utilities
 - `logger.rs` — tracing-subscriber setup, optional Loki integration (see [TLS](#tls))
 - `logging.rs` — Structured log category/operation constants
+- `amount.rs` — Exact checked conversion between token base units and `Decimal`
 - `task_tracker.rs` — Wraps `tokio_util::task::TaskTracker` with error collection
 - `shutdown.rs` — `ShutdownNotification`, `CancellationToken`, panic hook, signal handling
 
@@ -174,7 +176,7 @@ Ten config types loaded at startup (all support env var overrides):
 | Config | File | Key Fields |
 |--------|------|------------|
 | Chains | `chains.json` | Chain endpoints (optional — see below), assets |
-| Payments | `payments.json` | Recipient addresses, account lifetime, default chain/asset |
+| Payments | `payments.json` | Recipient addresses, invoice lifetime, default chain/asset |
 | Secrets | `secrets.json` | BIP39 seed phrase, API secret key |
 | Database | `database.json` | Database path, temporary mode, fail-closed existing-database requirement |
 | Web Server | (defaults) | Host, port (default 0.0.0.0:16726) |
@@ -198,6 +200,8 @@ endpoints currently cannot be supplied by environment variable at all
 **Custom prefix**: `KALATORI_APP_ENV_PREFIX`
 **Config directory**: `KALATORI_CONFIG_DIR_PATH`
 **Security**: Seed phrase and API secret key are zeroized from env/memory after loading.
+
+`invoice_lifetime_millis` is validated during configuration loading. Startup fails with an invalid-configuration error when the duration cannot produce a representable invoice expiry timestamp.
 
 Example configs in `configs/` directory.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -133,8 +133,8 @@ daemon aborts before finishing the lint pass without them ([#339](https://github
 
 `#[expect(clippy::too_many_lines)]` and friends sit in the tree without tripping
 `unfulfilled_lint_expectations`, even though `pedantic` is off. Among the clippy
-expectations in first-party code, **15 name a lint nothing enables**, across
-five of them: `too_many_lines` and `cast_sign_loss` (4 each),
+expectations in first-party code, **19 name a lint nothing enables**, across
+five of them: `cast_sign_loss` (8), `too_many_lines` (4),
 `struct_field_names` and `module_name_repetitions` (3 each), and `unused_self`.
 (The 13 `arithmetic_side_effects` expectations that used to sit in this bucket
 are now checked for real — the lint is enabled.)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -17,6 +17,7 @@ described in the four parts that answer it.
 
 ```toml
 allow_attributes = "deny"
+arithmetic_side_effects = "warn"
 cargo_common_metadata = "warn"
 cast_possible_truncation = "warn"
 ignored_unit_patterns = "warn"
@@ -70,30 +71,56 @@ Note also that `-Dwarnings` escalates lints that are *already enabled*. It
 cannot turn on a lint that is off — which is why the list above, not the flag,
 determines what protects you.
 
+### `arithmetic_side_effects`
+
+This is a payment daemon, so a silent wrap or truncation in an amount, fee or
+token-unit conversion is a money bug. Clippy's own documentation for this lint
+uses `rust_decimal::Decimal` — this repo's money type — as its motivating
+example, because `Decimal`'s `+`, `-`, `*` and `/` **panic** on overflow.
+
+The lint had been removed on 2026-01-16 in `ed941bc` (*"style: fix clippy and
+rustfmt warnings"* — a commit that silenced the warnings by config rather than
+fixing them) while ~12 `#[expect(clippy::arithmetic_side_effects)]` attributes
+stayed in the tree as inert markers. It is now re-enabled workspace-wide, and
+every site it flags was either converted to checked arithmetic or carries a
+justified `#[expect]`.
+
+Rules for new code:
+
+- Money, fee and token-unit paths (anything touching `Decimal`, `U256`, base-unit
+  conversion, invoice totals, refunds or gas) must use `checked_*` /
+  `saturating_*` and return a domain error on failure. Never paper over a real
+  overflow with `#[expect]`.
+- `Decimal::new(n, scale)` panics for `scale > 28`; use `Decimal::try_new`.
+- `U256::to::<u128>()` panics above `u128::MAX`; use `u128::try_from`.
+- `DateTime + Duration` panics on date overflow, and `TimeDelta::seconds` /
+  `milliseconds` panic outside their range; use `checked_add_signed` and
+  `try_seconds` / `try_milliseconds` whenever the operand is config- or
+  request-derived.
+- Everything else (test fixtures, obviously bounded counters) may use
+  `#[expect(clippy::arithmetic_side_effects, reason = "...")]` — the `reason` must
+  state *why* the value cannot overflow, not merely that it is a test.
+
 ### What is not enabled, and why the docs used to say otherwise
 
-`pedantic`, `arithmetic_side_effects` and the `shadow_*` family are **off**.
+`pedantic` and the `shadow_*` family are **off**.
 
 They were not declined after deliberation — they were configured and then
-removed, and the documentation simply went stale:
+removed, and the documentation simply went stale: `pedantic` went in `ed941bc`
+(2026-01-16, alongside `arithmetic_side_effects`, which has since been
+restored — see above), and the `shadow_*` family in `abcaf13` (2025-12-02).
 
-- `pedantic` and `arithmetic_side_effects` were removed on 2026-01-16 in
-  `ed941bc`, titled *"style: fix clippy and rustfmt warnings"* — a commit that
-  silenced the warnings by config rather than fixing them.
-- The `shadow_*` family went the same way in `abcaf13` (2025-12-02).
-
-Turning them back on today produces **471 warnings** across the workspace,
-deduplicated by site — so adopting them is a cleanup project, not a config
-change. The bulk is shadowing (149 `shadow_unrelated`, 52 `shadow_reuse`), then
-45 unseparated long literals, 32 unchecked arithmetic operations, 25
-over-long functions, 23 missing doc backticks and 19 inlinable `format!` args.
+Turning them back on produces hundreds of warnings across the workspace —
+a 2026-08 measurement found 471, deduplicated by site, of which the bulk was
+shadowing (149 `shadow_unrelated`, 52 `shadow_reuse`), then 45 unseparated long
+literals, 25 over-long functions, 23 missing doc backticks and 19 inlinable
+`format!` args. Adopting them is a cleanup project, not a config change.
 
 Re-measure with:
 
 ```bash
 cargo clippy --all-targets --all-features -- \
   -W clippy::pedantic \
-  -W clippy::arithmetic_side_effects \
   -W clippy::shadow_reuse -W clippy::shadow_same -W clippy::shadow_unrelated
 ```
 
@@ -105,11 +132,12 @@ daemon aborts before finishing the lint pass without them ([#339](https://github
 ### `#[expect]` on a lint nothing enables
 
 `#[expect(clippy::too_many_lines)]` and friends sit in the tree without tripping
-`unfulfilled_lint_expectations`, even though `pedantic` is off. Of the 122
-clippy expectations in first-party code, **28 name a lint nothing enables**,
-across six of them: `arithmetic_side_effects` (13), `too_many_lines` and
-`cast_sign_loss` (4 each), `struct_field_names` and `module_name_repetitions`
-(3 each), and `unused_self`.
+`unfulfilled_lint_expectations`, even though `pedantic` is off. Among the clippy
+expectations in first-party code, **15 name a lint nothing enables**, across
+five of them: `too_many_lines` and `cast_sign_loss` (4 each),
+`struct_field_names` and `module_name_repetitions` (3 each), and `unused_self`.
+(The 13 `arithmetic_side_effects` expectations that used to sit in this bucket
+are now checked for real — the lint is enabled.)
 
 That works because `#[expect]` is a *scoped lint level* ([RFC 2383](https://rust-lang.github.io/rfcs/2383-lint-reasons.html)):
 it raises the lint's level for its scope, so the lint runs there even though
@@ -120,6 +148,21 @@ warns.
 
 So these annotations mark real violations of lints nothing enforces. Useful as
 documentation; not evidence that anything is checking.
+
+## Build Profiles
+
+`[profile.*]` tables **must** live in the workspace root `Cargo.toml`. Cargo
+silently ignores profile tables declared in non-root workspace members: no
+warning, no error, the settings simply do not apply. `daemon/Cargo.toml` carried
+`[profile.release]` — including `overflow-checks = true`, `lto`, `codegen-units`
+and `panic = "abort"` — for a long time without any of it taking effect.
+
+Verify a profile change actually landed rather than trusting the manifest:
+
+```sh
+cargo build --release -vv 2>&1 | grep 'rustc --crate-name kalatori '
+# expect: -C overflow-checks=on -C panic=abort -C lto -C codegen-units=1
+```
 
 ## Panic Gate
 
@@ -146,18 +189,22 @@ unwrap_used      = "deny"
 
 ### What the gate does and does not cover
 
-It covers the listed constructs **in first-party code**. It is not a proof that
-the daemon cannot panic. Still uncaught, and still fatal:
+It covers the listed constructs **in first-party code**, and — now that
+`arithmetic_side_effects` is enabled (see above) — unguarded arithmetic too.
+It is not a proof that the daemon cannot panic. Still uncaught, and still
+fatal:
 
 - `assert!`, `assert_eq!`, `debug_assert!` — including production assertions.
-- **Integer and `Decimal` arithmetic, division, shifts, datetime arithmetic.**
-  `clippy::arithmetic_side_effects` is not enabled. See the backlog below.
 - Panicking library APIs — `B256::from_slice`, `Vec::remove`, `chrono`
   constructors, and anything else that panics on out-of-domain input.
 - `std::process::abort`/`exit`, and allocation failure.
 - Panics inside dependencies on data we hand them.
 
-Treat the gate as removing the *careless* panics, not as a guarantee.
+Treat the gate as removing the *careless* panics, not as a guarantee. Note
+also that `panic = "abort"` is now genuinely in effect for release builds
+(see [Build Profiles](#build-profiles)), so a release-mode panic no longer
+unwinds into a graceful shutdown — the hook still runs, but the process dies
+immediately after it.
 
 ### Test code
 
@@ -168,7 +215,9 @@ behaves like `#[test]`.
 
 **Clippy has no equivalent option for `unreachable`, `todo`, `unimplemented` or
 `string_slice`.** Those four fire inside test modules too, and need a local
-`#[expect]` there.
+`#[expect]` there. The same applies to `arithmetic_side_effects` — test-fixture
+arithmetic needs an `#[expect]` with a reason stating why the values are
+bounded.
 
 Example binaries under `client/examples/` get no test exemption and carry
 file-level `#![expect(clippy::unwrap_used)]`. That is a blunt instrument — it
@@ -221,21 +270,6 @@ In order of preference:
 
   These are *not* cleared — some are known-reachable. Prefer converting one to a
   typed error over extending the marker to new code.
-
-- **Arithmetic is not gated.** `clippy::arithmetic_side_effects` would catch
-  overflow, division by zero and `Decimal` panics; 32 sites trip it today (see
-  the measurement above), plus 13 already carrying an `#[expect]`. Division by
-  zero panics unconditionally; overflow currently *wraps silently* in release,
-  which for a daemon computing payment amounts is arguably worse than panicking.
-
-- **`[profile.release]` is in `daemon/Cargo.toml`, a workspace member, so Cargo
-  ignores it** — it prints `profiles for the non root package will be ignored`
-  on every build. `panic = "abort"`, `overflow-checks`, `lto`, `strip` and
-  `codegen-units` are therefore *not* in effect. Moving the block to the
-  workspace root should be sequenced **after** the arithmetic gate above:
-  enabling `overflow-checks` while those sites remain unguarded would turn
-  silent wrapping into live panics, i.e. create the very DoS class this gate
-  exists to close.
 
 ## Logging
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -161,7 +161,7 @@ Verify a profile change actually landed rather than trusting the manifest:
 
 ```sh
 cargo build --release -vv 2>&1 | grep 'rustc --crate-name kalatori '
-# expect: -C overflow-checks=on -C panic=abort -C lto -C codegen-units=1
+# expect: -C overflow-checks=on -C lto -C codegen-units=1
 ```
 
 ## Panic Gate
@@ -200,11 +200,18 @@ fatal:
 - `std::process::abort`/`exit`, and allocation failure.
 - Panics inside dependencies on data we hand them.
 
-Treat the gate as removing the *careless* panics, not as a guarantee. Note
-also that `panic = "abort"` is now genuinely in effect for release builds
-(see [Build Profiles](#build-profiles)), so a release-mode panic no longer
-unwinds into a graceful shutdown — the hook still runs, but the process dies
-immediately after it.
+Treat the gate as removing the *careless* panics, not as a guarantee.
+
+`panic = "abort"` is deliberately **not** part of the release profile, even
+though it sat in `daemon/Cargo.toml` for months. It was written in 2024 when
+this was a single crate and went inert when the workspace split moved the
+profile out of the root, so moving the profile back would have revived it
+rather than introduced it. Under abort the panic hook still runs, but the
+process dies before the shutdown listener can observe the cancelled token — the
+executor, chain trackers, webhook sender and keyring never drain — and Tokio's
+per-task containment goes with it, so a panic in any spawned task takes the
+daemon down instead of surfacing as a `JoinError`. Unwinding keeps the graceful
+path this daemon actually implements.
 
 ### Test code
 


### PR DESCRIPTION
Two independent causes left a money-handling daemon with neither the compile-time arithmetic lint nor the runtime overflow check its own configuration and documentation advertised.

1. `[profile.dev]` / `[profile.release]` lived in `daemon/Cargo.toml`, a non-root workspace member. Cargo silently ignores profile tables outside the workspace root, so `overflow-checks = true` (and `lto`, `codegen-units`, `panic = "abort"`) never applied. Verified against the real rustc invocation from `cargo build --release -vv`, not the manifest. Moved to the root `Cargo.toml`.

2. `clippy::arithmetic_side_effects` had been removed from the root `Cargo.toml` in ed941bc ("style: fix clippy and rustfmt warnings"), while ~12 `#[expect(clippy::arithmetic_side_effects)]` attributes stayed in the tree as inert markers. Re-enabled workspace-wide and triaged all 32 resulting violations.

Money and gas paths fixed properly (checked/fallible, domain errors):

- etherscan_client/types.rs: `Decimal::new(self.value as i64, ...)` wrapped a u128 into an i64. Ten units of an 18-decimal token is 10^19 base units, so an ordinary payment was recorded as a NEGATIVE amount. Now a checked, fallible conversion behind `EtherscanClientError::UnrepresentableAmount`.
- chain_client/polygon.rs: `u256_to_decimal` and `decimal_to_u256` substituted zero on failure, recording a real payment (or payout) as nothing. Both are now `Option`-returning, with domain errors at all four call sites.
- chain_client/polygon.rs: `U256::to::<u128>()` panics above u128::MAX on values taken verbatim from unvalidated Pimlico bundler responses. Replaced with a checked `u256_to_u128` returning `TransactionError::BuildFailed`.
- chain_client/polygon.rs: `calculate_max_cost_in_token` did unchecked U256 `+`/`*` on bundler-supplied gas quotes. Now fully checked, and lifted to a free function so it can be tested without a live provider.
- chain_client/asset_hub.rs, chain/executor.rs, state/swaps.rs: base-unit scaling via `amount / Decimal::new(1, decimals)` panics for decimals > 28 and on Decimal overflow, and `chain/executor.rs` then `.unwrap()`ed the `to_u128`. All three are now checked and fallible.
- chain/transactions_recorder.rs: invoice total, refund amount and the under/overpayment tolerance arithmetic now use `checked_*` and abandon the DB transaction via `TransactionsRecorderError::AmountOverflow`.
- types/common.rs: `PaginationParams::offset()` computed `(page - 1) * per_page` on an unvalidated query parameter — a u32 overflow that used to wrap silently and, with overflow-checks now actually on, would panic the handler.
- auth/token.rs, api/dev.rs, state.rs: `DateTime + Duration` and `TimeDelta::seconds/minutes/milliseconds` panic on out-of-range values derived from token claims, request bodies and config. All now use `checked_add_signed` / `try_*` and fail closed.
- types/invoice.rs, webhook_sender.rs, chain/executor.rs: saturating arithmetic where saturation is the correct semantics.

Remaining 12 sites are `#[expect(..., reason = "...")]` with a specific justification: fixed-offset clock arithmetic and test fixtures.

Docs corrected to match reality: conventions.md previously claimed `pedantic`, `arithmetic_side_effects` and the `shadow_*` family were enabled per-crate; none were.

Adds 29 tests covering every changed behaviour, including boundary cases at u128::MAX / one-over-max and Decimal's representable range.