### PR TITLE
fix: surface swap provider rejections and log swap create failures

### DIFF
--- a/daemon/src/clients/swaps.rs
+++ b/daemon/src/clients/swaps.rs
@@ -83,6 +83,12 @@ pub enum SwapsClientError {
     WrongRawTransaction,
     #[error("Transaction hash or other identifier is not set")]
     TransactionHashIsNotSet,
+    /// The provider understood the request but refused to serve it
+    /// (unsupported route, amount below bridge minimum, insufficient
+    /// liquidity, etc.). `message` is the provider's human-readable
+    /// explanation, safe to surface to the payment UI.
+    #[error("Swap provider rejected the request: {message}")]
+    ProviderRejected { message: String },
     #[error("Unknown API error")]
     UnknownApiError,
     #[error("Operation is not allowed")]

--- a/daemon/src/clients/swaps/across.rs
+++ b/daemon/src/clients/swaps/across.rs
@@ -70,8 +70,19 @@ pub fn default_across_raw_transaction() -> AcrossRawTransaction {
 pub type AcrossQuoteDetails = AcrossRawTransaction;
 
 impl From<AcrossApiError> for SwapsClientError {
-    fn from(_value: AcrossApiError) -> Self {
-        Self::UnknownApiError
+    fn from(value: AcrossApiError) -> Self {
+        tracing::warn!(
+            error.source = ?value,
+            "Across API returned an error response"
+        );
+
+        match value.status {
+            // Provider-side failures are not the requester's fault
+            Some(status) if status >= 500 => Self::UnknownApiError,
+            _ => Self::ProviderRejected {
+                message: value.message,
+            },
+        }
     }
 }
 
@@ -695,5 +706,35 @@ mod tests {
             .unwrap();
         assert_eq!(response, expected_response);
         mock.assert();
+    }
+    #[test]
+    fn test_error_response_classification() {
+        let api_error = AcrossApiError {
+            error_type: Some("InvalidParamError".to_string()),
+            error: None,
+            code: Some("AMOUNT_TOO_LOW".to_string()),
+            status: Some(400),
+            message: "Sent amount is too low relative to fees".to_string(),
+            id: None,
+        };
+        assert_eq!(
+            SwapsClientError::from(api_error),
+            SwapsClientError::ProviderRejected {
+                message: "Sent amount is too low relative to fees".to_string(),
+            }
+        );
+
+        let server_error = AcrossApiError {
+            error_type: None,
+            error: None,
+            code: None,
+            status: Some(500),
+            message: "Internal server error".to_string(),
+            id: None,
+        };
+        assert_eq!(
+            SwapsClientError::from(server_error),
+            SwapsClientError::UnknownApiError
+        );
     }
 }

--- a/daemon/src/clients/swaps/bungee.rs
+++ b/daemon/src/clients/swaps/bungee.rs
@@ -221,7 +221,6 @@ pub fn default_bungee_raw_transaction() -> BungeeRawTransaction {
     }
 }
 
-#[expect(dead_code)]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct BungeeApiResponse<T> {
@@ -230,14 +229,26 @@ struct BungeeApiResponse<T> {
     success: bool,
     #[serde(default)]
     message: Option<String>,
-    #[expect(dead_code)]
     #[serde(default)]
     status_code: Option<u32>,
 }
 
 impl<T> From<BungeeApiResponse<T>> for SwapsClientError {
-    fn from(_value: BungeeApiResponse<T>) -> Self {
-        Self::UnknownApiError
+    fn from(value: BungeeApiResponse<T>) -> Self {
+        tracing::warn!(
+            message = ?value.message,
+            status_code = ?value.status_code,
+            "Bungee API returned an error response"
+        );
+
+        match (value.status_code, value.message) {
+            // Provider-side failures are not the requester's fault
+            (Some(status), _) if status >= 500 => Self::UnknownApiError,
+            (_, Some(message)) => Self::ProviderRejected {
+                message,
+            },
+            _ => Self::UnknownApiError,
+        }
     }
 }
 
@@ -1114,5 +1125,45 @@ mod tests {
             .unwrap();
         assert_eq!(response, expected_response);
         mock.assert();
+    }
+    #[test]
+    fn test_error_response_classification() {
+        let rejection: SwapsClientError = BungeeApiResponse::<()> {
+            result: None,
+            success: false,
+            message: Some("Amount is too low".to_string()),
+            status_code: Some(400),
+        }
+        .into();
+        assert_eq!(
+            rejection,
+            SwapsClientError::ProviderRejected {
+                message: "Amount is too low".to_string(),
+            }
+        );
+
+        let provider_failure: SwapsClientError = BungeeApiResponse::<()> {
+            result: None,
+            success: false,
+            message: Some("Internal server error".to_string()),
+            status_code: Some(500),
+        }
+        .into();
+        assert_eq!(
+            provider_failure,
+            SwapsClientError::UnknownApiError
+        );
+
+        let opaque: SwapsClientError = BungeeApiResponse::<()> {
+            result: None,
+            success: false,
+            message: None,
+            status_code: None,
+        }
+        .into();
+        assert_eq!(
+            opaque,
+            SwapsClientError::UnknownApiError
+        );
     }
 }

--- a/daemon/src/clients/swaps/zeroex.rs
+++ b/daemon/src/clients/swaps/zeroex.rs
@@ -249,8 +249,16 @@ impl TryFrom<RawSwapDetails> for ZeroExGaslessRawTransaction {
 pub type ZeroExGaslessQuoteDetails = ZeroExGaslessRawTransaction;
 
 impl From<ZeroExErrorResponse> for SwapsClientError {
-    fn from(_value: ZeroExErrorResponse) -> Self {
-        Self::UnknownApiError
+    fn from(value: ZeroExErrorResponse) -> Self {
+        tracing::warn!(
+            name = %value.name,
+            message = %value.message,
+            "0x API returned an error response"
+        );
+
+        Self::ProviderRejected {
+            message: value.message,
+        }
     }
 }
 
@@ -673,5 +681,29 @@ impl SwapsClient for ZeroExGaslessClient {
             .await?;
 
         Ok(response.status)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_response_classification() {
+        let error = ZeroExErrorResponse {
+            name: "INSUFFICIENT_LIQUIDITY".to_string(),
+            message: "Insufficient liquidity for this trade".to_string(),
+            data: ZeroExErrorResponseData {
+                zid: "0x1".to_string(),
+                details: None,
+            },
+        };
+
+        assert_eq!(
+            SwapsClientError::from(error),
+            SwapsClientError::ProviderRejected {
+                message: "Insufficient liquidity for this trade".to_string(),
+            }
+        );
     }
 }

--- a/daemon/src/clients/swaps/zeroex.rs
+++ b/daemon/src/clients/swaps/zeroex.rs
@@ -248,16 +248,28 @@ impl TryFrom<RawSwapDetails> for ZeroExGaslessRawTransaction {
 
 pub type ZeroExGaslessQuoteDetails = ZeroExGaslessRawTransaction;
 
-impl From<ZeroExErrorResponse> for SwapsClientError {
-    fn from(value: ZeroExErrorResponse) -> Self {
+impl ZeroExErrorResponse {
+    /// 0x reports the failure kind only through the HTTP status; the error body
+    /// carries no status field, so the caller has to pass it in.
+    fn into_client_error(
+        self,
+        status: reqwest::StatusCode,
+    ) -> SwapsClientError {
         tracing::warn!(
-            name = %value.name,
-            message = %value.message,
+            %status,
+            name = ?self.name,
+            message = ?self.message,
+            data = ?self.data,
             "0x API returned an error response"
         );
 
-        Self::ProviderRejected {
-            message: value.message,
+        // Provider-side failures are not the requester's fault
+        if status.is_server_error() {
+            return SwapsClientError::UnknownApiError;
+        }
+
+        SwapsClientError::ProviderRejected {
+            message: self.message,
         }
     }
 }
@@ -344,6 +356,8 @@ impl SwapsClient for ZeroExClient {
                 SwapsClientError::UnknownApiError
             })?;
 
+        let status = response.status();
+
         let text = response.text().await.map_err(|e| {
             tracing::warn!(error = ?e, "Failed to extract response text from 0x response");
             SwapsClientError::UnknownApiError
@@ -358,7 +372,7 @@ impl SwapsClient for ZeroExClient {
 
         match result {
             ZeroExResponse::Ok(resp) => Ok(resp),
-            ZeroExResponse::Err(e) => Err(e.into()),
+            ZeroExResponse::Err(e) => Err(e.into_client_error(status)),
         }
     }
 
@@ -474,6 +488,8 @@ impl ZeroExGaslessClient {
             SwapsClientError::UnknownApiError
         })?;
 
+        let status = response.status();
+
         let text = response.text().await.map_err(|e| {
             tracing::warn!(error = ?e, "Failed to extract response text from 0x response");
             SwapsClientError::UnknownApiError
@@ -488,7 +504,7 @@ impl ZeroExGaslessClient {
 
         match result {
             ZeroExResponse::Ok(resp) => Ok(resp),
-            ZeroExResponse::Err(e) => Err(e.into()),
+            ZeroExResponse::Err(e) => Err(e.into_client_error(status)),
         }
     }
 
@@ -700,10 +716,26 @@ mod tests {
         };
 
         assert_eq!(
-            SwapsClientError::from(error),
+            error.into_client_error(reqwest::StatusCode::BAD_REQUEST),
             SwapsClientError::ProviderRejected {
                 message: "Insufficient liquidity for this trade".to_string(),
             }
+        );
+
+        let server_error = ZeroExErrorResponse {
+            name: "INTERNAL_SERVER_ERROR".to_string(),
+            message: "Internal server error".to_string(),
+            data: ZeroExErrorResponseData {
+                zid: "0x2".to_string(),
+                details: None,
+            },
+        };
+
+        // A provider 5xx is not the requester's fault, so it must not surface
+        // as a 422 ProviderRejected
+        assert_eq!(
+            server_error.into_client_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR),
+            SwapsClientError::UnknownApiError
         );
     }
 }

--- a/daemon/src/clients/swaps/zeroex/types.rs
+++ b/daemon/src/clients/swaps/zeroex/types.rs
@@ -265,7 +265,6 @@ pub struct ZeroExErrorResponseData {
 pub struct ZeroExErrorResponse {
     pub name: String,
     pub message: String,
-    #[expect(dead_code)]
     pub data: ZeroExErrorResponseData,
 }
 

--- a/daemon/src/clients/swaps/zeroex/types.rs
+++ b/daemon/src/clients/swaps/zeroex/types.rs
@@ -261,7 +261,6 @@ pub struct ZeroExErrorResponseData {
     pub details: Option<serde_json::Value>,
 }
 
-#[expect(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct ZeroExErrorResponse {
     pub name: String,

--- a/daemon/src/state/swaps.rs
+++ b/daemon/src/state/swaps.rs
@@ -3,6 +3,7 @@ use uuid::Uuid;
 
 use crate::api::ApiErrorExt;
 use crate::dao::DaoInterface;
+use crate::swaps::SwapsExecutorError;
 use crate::types::{
     CreateSwapData,
     CreateSwapParams,
@@ -22,32 +23,136 @@ pub enum SwapRequestError {
     InvalidChainId { chain_id: u64 },
     #[error("Invoice not found: {invoice_id}")]
     InvoiceNotFound { invoice_id: Uuid },
+    #[error("Swap not found: {swap_id}")]
+    SwapNotFound { swap_id: Uuid },
     #[error("Swap direction from {from_chain_id} to {to_chain_id} is not supported")]
     DirectionIsUnsupported {
         from_chain_id: u64,
         to_chain_id: u64,
     },
+    /// The swap provider refused the request itself (unsupported route,
+    /// amount below bridge minimum, insufficient liquidity, etc.).
+    /// `message` is the provider's explanation, surfaced to the payment UI.
+    #[error("Swap provider rejected the request: {message}")]
+    ProviderRejected { message: String },
     #[error("Failed to get quotes for swap")]
     QuoteRequestFailed,
     #[error("Database error")]
     DatabaseError,
 }
 
+impl From<SwapsExecutorError> for SwapRequestError {
+    fn from(value: SwapsExecutorError) -> Self {
+        match value {
+            SwapsExecutorError::ProviderRejected {
+                message,
+            } => SwapRequestError::ProviderRejected {
+                message,
+            },
+            SwapsExecutorError::QuoteRequestFailed => SwapRequestError::QuoteRequestFailed,
+            SwapsExecutorError::SwapNotFound {
+                swap_id,
+            } => SwapRequestError::SwapNotFound {
+                swap_id,
+            },
+            SwapsExecutorError::InvoiceNotFound {
+                invoice_id,
+            } => SwapRequestError::InvoiceNotFound {
+                invoice_id,
+            },
+            SwapsExecutorError::DatabaseError => SwapRequestError::DatabaseError,
+        }
+    }
+}
+
 impl ApiErrorExt for SwapRequestError {
     fn category(&self) -> &str {
-        "SWAP_ERROR"
+        match self {
+            SwapRequestError::InvalidChainId {
+                ..
+            }
+            | SwapRequestError::DirectionIsUnsupported {
+                ..
+            } => "INVALID_REQUEST",
+            SwapRequestError::InvoiceNotFound {
+                ..
+            }
+            | SwapRequestError::SwapNotFound {
+                ..
+            } => "ENTITY_NOT_FOUND",
+            SwapRequestError::ProviderRejected {
+                ..
+            }
+            | SwapRequestError::QuoteRequestFailed => "SWAP_ERROR",
+            SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
+        }
     }
 
     fn code(&self) -> &str {
-        "SWAP_ERROR"
+        match self {
+            SwapRequestError::InvalidChainId {
+                ..
+            } => "INVALID_CHAIN_ID",
+            SwapRequestError::InvoiceNotFound {
+                ..
+            } => "INVOICE_NOT_FOUND",
+            SwapRequestError::SwapNotFound {
+                ..
+            } => "SWAP_NOT_FOUND",
+            SwapRequestError::DirectionIsUnsupported {
+                ..
+            } => "SWAP_DIRECTION_UNSUPPORTED",
+            SwapRequestError::ProviderRejected {
+                ..
+            } => "SWAP_PROVIDER_REJECTED",
+            SwapRequestError::QuoteRequestFailed => "QUOTE_REQUEST_FAILED",
+            SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
+        }
     }
 
     fn http_status_code(&self) -> reqwest::StatusCode {
-        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        match self {
+            SwapRequestError::InvalidChainId {
+                ..
+            }
+            | SwapRequestError::DirectionIsUnsupported {
+                ..
+            } => reqwest::StatusCode::BAD_REQUEST,
+            SwapRequestError::InvoiceNotFound {
+                ..
+            }
+            | SwapRequestError::SwapNotFound {
+                ..
+            } => reqwest::StatusCode::NOT_FOUND,
+            SwapRequestError::ProviderRejected {
+                ..
+            } => reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+            SwapRequestError::QuoteRequestFailed | SwapRequestError::DatabaseError => {
+                reqwest::StatusCode::INTERNAL_SERVER_ERROR
+            },
+        }
     }
 
     fn message(&self) -> &str {
-        "Swap error"
+        match self {
+            SwapRequestError::InvalidChainId {
+                ..
+            } => "The provided chain id is not supported.",
+            SwapRequestError::InvoiceNotFound {
+                ..
+            } => "The related invoice was not found.",
+            SwapRequestError::SwapNotFound {
+                ..
+            } => "The requested swap was not found.",
+            SwapRequestError::DirectionIsUnsupported {
+                ..
+            } => "This swap direction is not supported.",
+            SwapRequestError::ProviderRejected {
+                message,
+            } => message,
+            SwapRequestError::QuoteRequestFailed => "Failed to get a quote from the swap provider.",
+            SwapRequestError::DatabaseError => "A database error occurred.",
+        }
     }
 }
 
@@ -85,8 +190,14 @@ impl<D: DaoInterface> AppState<D> {
         let invoice = self
             .get_invoice(invoice_id)
             .await
-            // TODO: update error handling
-            .map_err(|_| SwapRequestError::DatabaseError)?
+            .map_err(|e| {
+                tracing::warn!(
+                    %invoice_id,
+                    error.source = ?e,
+                    "Failed to load invoice while creating a swap"
+                );
+                SwapRequestError::DatabaseError
+            })?
             .ok_or(SwapRequestError::InvoiceNotFound {
                 invoice_id,
             })?;
@@ -124,13 +235,23 @@ impl<D: DaoInterface> AppState<D> {
             origin: Default::default(),
         };
 
+        let from_amount_units = data.from_amount_units;
+
         let swap = self
             .swaps_executor
             .create_swap(data)
             .await
-            .map_err(|_e| {
-                // TODO: check errors
-                SwapRequestError::QuoteRequestFailed
+            .map_err(|e| {
+                tracing::warn!(
+                    %invoice_id,
+                    %swap_executor,
+                    %from_chain,
+                    %to_chain,
+                    from_amount_units,
+                    error.source = ?e,
+                    "Failed to create swap"
+                );
+                SwapRequestError::from(e)
             })?;
 
         Ok(swap)
@@ -140,21 +261,127 @@ impl<D: DaoInterface> AppState<D> {
         &self,
         params: SubmittedSwapParams,
     ) -> Result<Swap, SwapRequestError> {
+        let swap_id = params.swap_id;
+
         self.swaps_executor
             .update_swap_submitted_on_front_end(params)
             .await
-            // TODO: check and handle different errors
-            .map_err(|_| SwapRequestError::DatabaseError)
+            .map_err(|e| {
+                tracing::warn!(
+                    %swap_id,
+                    error.source = ?e,
+                    "Failed to mark swap as submitted"
+                );
+                SwapRequestError::from(e)
+            })
     }
 
     pub async fn submit_swap_with_signature(
         &self,
         params: SwapSignatureParams,
     ) -> Result<Swap, SwapRequestError> {
+        let swap_id = params.swap_id;
+
         self.swaps_executor
             .submit_with_signature(params)
             .await
-            // TODO: check and handle different errors
-            .map_err(|_| SwapRequestError::DatabaseError)
+            .map_err(|e| {
+                tracing::warn!(
+                    %swap_id,
+                    error.source = ?e,
+                    "Failed to submit swap with signature"
+                );
+                SwapRequestError::from(e)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_rejection_maps_to_422_with_provider_message() {
+        let error = SwapRequestError::from(SwapsExecutorError::ProviderRejected {
+            message: "Amount is below the bridge minimum".to_string(),
+        });
+
+        assert!(matches!(
+            &error,
+            SwapRequestError::ProviderRejected { message }
+                if message == "Amount is below the bridge minimum"
+        ));
+        assert_eq!(
+            error.http_status_code(),
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(error.code(), "SWAP_PROVIDER_REJECTED");
+        assert_eq!(
+            error.message(),
+            "Amount is below the bridge minimum"
+        );
+    }
+
+    #[test]
+    fn executor_not_found_errors_map_to_404() {
+        let swap_id = Uuid::new_v4();
+        let invoice_id = Uuid::new_v4();
+
+        let error = SwapRequestError::from(SwapsExecutorError::SwapNotFound {
+            swap_id,
+        });
+        assert!(matches!(
+            error,
+            SwapRequestError::SwapNotFound { swap_id: id } if id == swap_id
+        ));
+        assert_eq!(
+            error.http_status_code(),
+            reqwest::StatusCode::NOT_FOUND
+        );
+
+        let error = SwapRequestError::from(SwapsExecutorError::InvoiceNotFound {
+            invoice_id,
+        });
+        assert!(matches!(
+            error,
+            SwapRequestError::InvoiceNotFound { invoice_id: id } if id == invoice_id
+        ));
+        assert_eq!(
+            error.http_status_code(),
+            reqwest::StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn internal_failures_stay_500() {
+        for error in [
+            SwapRequestError::from(SwapsExecutorError::QuoteRequestFailed),
+            SwapRequestError::from(SwapsExecutorError::DatabaseError),
+        ] {
+            assert_eq!(
+                error.http_status_code(),
+                reqwest::StatusCode::INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+
+    #[test]
+    fn request_validation_errors_map_to_400() {
+        let error = SwapRequestError::InvalidChainId {
+            chain_id: 999,
+        };
+        assert_eq!(
+            error.http_status_code(),
+            reqwest::StatusCode::BAD_REQUEST
+        );
+
+        let error = SwapRequestError::DirectionIsUnsupported {
+            from_chain_id: 1,
+            to_chain_id: 137,
+        };
+        assert_eq!(
+            error.http_status_code(),
+            reqwest::StatusCode::BAD_REQUEST
+        );
     }
 }

--- a/daemon/src/swaps.rs
+++ b/daemon/src/swaps.rs
@@ -3,7 +3,6 @@ mod tracker;
 
 #[cfg_attr(test, mockall_double::double)]
 pub use executor::SwapsExecutor;
-#[cfg_attr(not(test), expect(unused_imports))]
 pub use executor::SwapsExecutorError;
 pub use tracker::SwapsTracker;
 

--- a/daemon/src/swaps/executor.rs
+++ b/daemon/src/swaps/executor.rs
@@ -22,6 +22,10 @@ pub enum SwapsExecutorError {
     // TODO: refactor
     #[error("Failed to request swap quote")]
     QuoteRequestFailed,
+    /// The swap provider refused the request itself (unsupported route,
+    /// amount below bridge minimum, insufficient liquidity, etc.).
+    #[error("Swap provider rejected the request: {message}")]
+    ProviderRejected { message: String },
     #[error("Swap {swap_id} not found")]
     SwapNotFound { swap_id: Uuid },
     #[error("Invoice {invoice_id} not found")]
@@ -31,9 +35,17 @@ pub enum SwapsExecutorError {
 }
 
 impl From<SwapsClientError> for SwapsExecutorError {
-    fn from(_value: SwapsClientError) -> Self {
-        // TODO: refactor
-        SwapsExecutorError::QuoteRequestFailed
+    fn from(value: SwapsClientError) -> Self {
+        match value {
+            SwapsClientError::ProviderRejected {
+                message,
+            } => SwapsExecutorError::ProviderRejected {
+                message,
+            },
+            // Everything else (transport failures, provider 5xx, malformed
+            // responses) is an internal failure from the requester's view
+            _ => SwapsExecutorError::QuoteRequestFailed,
+        }
     }
 }
 

--- a/daemon/src/swaps/executor.rs
+++ b/daemon/src/swaps/executor.rs
@@ -285,3 +285,59 @@ mockall::mock! {
         fn clone(&self) -> Self;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::SwapChainType;
+
+    /// The provider's own explanation is the only thing safe to surface to the
+    /// payment UI, so it has to survive the hop to the executor verbatim.
+    #[test]
+    fn provider_rejection_keeps_the_provider_message() {
+        let error = SwapsExecutorError::from(SwapsClientError::ProviderRejected {
+            message: "Amount is below the bridge minimum".to_string(),
+        });
+
+        assert!(matches!(
+            &error,
+            SwapsExecutorError::ProviderRejected { message }
+                if message == "Amount is below the bridge minimum"
+        ));
+    }
+
+    /// Transport failures, provider 5xx and malformed responses all reach this
+    /// conversion as something other than `ProviderRejected`. None of them are
+    /// the requester's fault, so none may surface as a 422 — they have to
+    /// collapse to `QuoteRequestFailed`, which the API renders as a 500.
+    #[test]
+    fn every_other_client_error_stays_an_internal_failure() {
+        let internal = [
+            SwapsClientError::UnknownApiError,
+            SwapsClientError::SignatureIsNotSet,
+            SwapsClientError::WrongRawTransaction,
+            SwapsClientError::TransactionHashIsNotSet,
+            SwapsClientError::OperationIsNotAllowed,
+            SwapsClientError::FailedToSignTransaction,
+            SwapsClientError::ChainIsNotSupported {
+                chain: SwapChainType::Polygon,
+            },
+            SwapsClientError::DirectionIsNotSupported {
+                from_chain: SwapChainType::Polygon,
+                to_chain: SwapChainType::Ethereum,
+            },
+        ];
+
+        for error in internal {
+            let converted = SwapsExecutorError::from(error.clone());
+
+            assert!(
+                matches!(
+                    converted,
+                    SwapsExecutorError::QuoteRequestFailed
+                ),
+                "{error:?} must map to QuoteRequestFailed, got {converted:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
During the 2026-08-03 production incident, POST /public/swap/create returned five 500s while the daemon logs contained zero ERROR/WARN lines: every SwapsExecutorError was collapsed into a static 500 "Swap error" with the source discarded, and provider API error responses were flattened into UnknownApiError without logging.

- Add SwapsClientError::ProviderRejected { message } and classify parsed provider error responses in the Bungee/Across/0x clients: provider 5xx stays UnknownApiError (internal), everything else becomes a rejection carrying the provider's human-readable message. Each conversion point now logs the raw error response (Principle 2).
- Thread the rejection through SwapsExecutorError into SwapRequestError, which now maps per-variant: provider rejections are 422 with the provider message (so the payment UI can show it), invalid chain id / unsupported direction are 400, invoice/swap not found are 404, and only quote transport failures and DB errors remain 500.
- Log swap params context (invoice id, executor, chains, amount) at WARN before mapping in create_swap, update_swap_submitted, and submit_swap_with_signature, so failures are diagnosable from logs.