### PR TITLE
fix: better swap handling with across and 0x 

### DIFF
--- a/daemon/src/clients/swaps.rs
+++ b/daemon/src/clients/swaps.rs
@@ -95,6 +95,12 @@ pub enum SwapsClientError {
     NoRouteAvailable,
     #[error("No liquidity available")]
     NoLiquidity,
+    // A quote that parsed but cannot be turned into a transaction the payer can
+    // actually submit — e.g. the provider omitted the gas parameters, or sent a
+    // timestamp outside the representable range. Publishing such a quote hands
+    // the payer a transaction that is guaranteed to fail on-chain.
+    #[error("Provider returned an unusable quote")]
+    UnusableQuote,
     #[error("Operation is not allowed")]
     OperationIsNotAllowed,
     #[error("Failed to sign transaction")]
@@ -117,7 +123,9 @@ pub trait SwapsClient {
     const GASLESS: bool;
 
     type GetQuoteParams: From<CreateSwapData>;
-    type GetQuoteResponse: Into<SwapQuote>;
+    // Fallible: a response can deserialize cleanly and still be unusable as a
+    // quote (missing gas parameters, unrepresentable expiry).
+    type GetQuoteResponse: TryInto<SwapQuote, Error = SwapsClientError>;
     type RawTransactionDetails: TryFrom<RawSwapDetails, Error = SwapsClientError>
         + Serialize
         + DeserializeOwned;
@@ -166,7 +174,7 @@ pub trait SwapsClient {
             .get_quote_internal(data.into())
             .await?;
 
-        Ok(result.into())
+        result.try_into()
     }
 
     fn extract_raw_details(

--- a/daemon/src/clients/swaps.rs
+++ b/daemon/src/clients/swaps.rs
@@ -91,6 +91,10 @@ pub enum SwapsClientError {
     ProviderRejected { message: String },
     #[error("Unknown API error")]
     UnknownApiError,
+    #[error("No route available")]
+    NoRouteAvailable,
+    #[error("No liquidity available")]
+    NoLiquidity,
     #[error("Operation is not allowed")]
     OperationIsNotAllowed,
     #[error("Failed to sign transaction")]

--- a/daemon/src/clients/swaps/across.rs
+++ b/daemon/src/clients/swaps/across.rs
@@ -249,6 +249,54 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_swap_approval_response_tolerates_null_approval_txns() {
+        // Trimmed from the production response that broke 0.9.3 (2026-08-03):
+        // Across sends "approvalTxns": null — not an absent key — whenever the
+        // payer already holds allowance, which made every ready-to-pay wallet
+        // fail the untagged AcrossApiResponse parse and surface a blank 500.
+        let raw = r#"{
+            "inputAmount": "2010000",
+            "maxInputAmount": "2010000",
+            "expectedOutputAmount": "2003496",
+            "approvalTxns": null,
+            "swapTx": {
+                "simulationSuccess": true,
+                "chainId": 1,
+                "to": "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5",
+                "data": "0xad5425c6",
+                "value": "0",
+                "gas": "571750",
+                "maxFeePerGas": "1094950",
+                "maxPriorityFeePerGas": "1000000"
+            },
+            "id": "cx44b-1785763721048-522b47d271d9",
+            "quoteExpiryTimestamp": 1785764021
+        }"#;
+
+        let AcrossApiResponse::Ok(parsed) =
+            serde_json::from_str::<AcrossApiResponse<SwapApprovalResponse>>(raw).unwrap()
+        else {
+            panic!("null approvalTxns must parse as the Ok variant, not AcrossApiError");
+        };
+        assert!(parsed.approval_txns.is_none());
+
+        let quote = SwapQuote::from(parsed);
+        let RawSwapDetails::Across(details) = quote.quote_details else {
+            panic!("expected Across quote details");
+        };
+        assert!(details.approval_transactions.is_empty());
+
+        // An absent key must keep working too.
+        let raw_absent = raw.replace("\"approvalTxns\": null,", "");
+        let AcrossApiResponse::Ok(parsed) =
+            serde_json::from_str::<AcrossApiResponse<SwapApprovalResponse>>(&raw_absent).unwrap()
+        else {
+            panic!("absent approvalTxns must parse as the Ok variant");
+        };
+        assert!(parsed.approval_txns.is_none());
+    }
+
+    #[test]
     fn test_try_from_raw_details() {
         let across_details = RawSwapDetails::Across(default_across_raw_transaction());
         let result = AcrossRawTransaction::try_from(across_details);

--- a/daemon/src/clients/swaps/across.rs
+++ b/daemon/src/clients/swaps/across.rs
@@ -297,6 +297,108 @@ mod tests {
     }
 
     #[test]
+    fn test_swap_approval_response_tolerates_null_or_absent_transaction_fees() {
+        for raw in [
+            r#"{
+                "inputAmount": "1",
+                "maxInputAmount": "1",
+                "expectedOutputAmount": "1",
+                "swapTx": {
+                    "simulationSuccess": true,
+                    "chainId": 137,
+                    "to": "0x1111111111111111111111111111111111111111",
+                    "data": "0x1234",
+                    "value": null,
+                    "gas": null,
+                    "maxFeePerGas": null
+                },
+                "id": "quote-benign-null",
+                "quoteExpiryTimestamp": 1893456000
+            }"#,
+            r#"{
+                "inputAmount": "1",
+                "maxInputAmount": "1",
+                "expectedOutputAmount": "1",
+                "swapTx": {
+                    "simulationSuccess": true,
+                    "chainId": 137,
+                    "to": "0x1111111111111111111111111111111111111111",
+                    "data": "0x1234",
+                    "maxPriorityFeePerGas": null
+                },
+                "id": "quote-benign-absent",
+                "quoteExpiryTimestamp": 1893456000
+            }"#,
+        ] {
+            let AcrossApiResponse::Ok(parsed) =
+                serde_json::from_str::<AcrossApiResponse<SwapApprovalResponse>>(raw).unwrap()
+            else {
+                panic!("nullable swap transaction fields must parse as the success arm");
+            };
+            assert!(parsed.swap_tx.value.is_none());
+            assert!(parsed.swap_tx.gas.is_none());
+            assert!(parsed.swap_tx.max_fee_per_gas.is_none());
+            assert!(
+                parsed
+                    .swap_tx
+                    .max_priority_fee_per_gas
+                    .is_none()
+            );
+
+            let quote = SwapQuote::from(parsed);
+            let RawSwapDetails::Across(details) = quote.quote_details else {
+                panic!("expected Across quote details");
+            };
+            assert_eq!(details.transaction.value, 0);
+            assert_eq!(details.transaction.gas, 0);
+            assert_eq!(details.transaction.max_fee_per_gas, 0);
+            assert_eq!(
+                details
+                    .transaction
+                    .max_priority_fee_per_gas,
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn test_across_status_growth_degrades_safely() {
+        for (status, expected) in [
+            ("received", ExecutorSwapStatus::Pending),
+            (
+                "deposit-pending",
+                ExecutorSwapStatus::Pending,
+            ),
+            (
+                "deposit-failed",
+                ExecutorSwapStatus::Failed,
+            ),
+            (
+                "future-provider-status",
+                ExecutorSwapStatus::Pending,
+            ),
+        ] {
+            let raw = format!(
+                r#"{{
+                    "status": "{status}",
+                    "originChainId": 137,
+                    "depositId": "deposit-benign",
+                    "depositTxnRef": "0x1234",
+                    "fillTxnRef": null,
+                    "destinationChainId": 1,
+                    "depositRefundTxnRef": null
+                }}"#,
+            );
+            let response = serde_json::from_str::<SwapStatusResponse>(&raw).unwrap();
+
+            assert_eq!(
+                ExecutorSwapStatus::from(response.status),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn test_try_from_raw_details() {
         let across_details = RawSwapDetails::Across(default_across_raw_transaction());
         let result = AcrossRawTransaction::try_from(across_details);

--- a/daemon/src/clients/swaps/across.rs
+++ b/daemon/src/clients/swaps/across.rs
@@ -280,7 +280,7 @@ mod tests {
         };
         assert!(parsed.approval_txns.is_none());
 
-        let quote = SwapQuote::from(parsed);
+        let quote = SwapQuote::try_from(parsed).unwrap();
         let RawSwapDetails::Across(details) = quote.quote_details else {
             panic!("expected Across quote details");
         };
@@ -297,7 +297,7 @@ mod tests {
     }
 
     #[test]
-    fn test_swap_approval_response_tolerates_null_or_absent_transaction_fees() {
+    fn test_swap_approval_response_parses_but_rejects_missing_gas_parameters() {
         for raw in [
             r#"{
                 "inputAmount": "1",
@@ -345,36 +345,41 @@ mod tests {
                     .is_none()
             );
 
-            let quote = SwapQuote::from(parsed);
-            let RawSwapDetails::Across(details) = quote.quote_details else {
-                panic!("expected Across quote details");
-            };
-            assert_eq!(details.transaction.value, 0);
-            assert_eq!(details.transaction.gas, 0);
-            assert_eq!(details.transaction.max_fee_per_gas, 0);
-            assert_eq!(
-                details
-                    .transaction
-                    .max_priority_fee_per_gas,
-                0
-            );
+            // Parsing must survive the nulls — but a quote with no gas
+            // parameters is not executable, and substituting 0 would publish a
+            // transaction that cannot be mined, so the conversion rejects it.
+            assert!(matches!(
+                SwapQuote::try_from(parsed),
+                Err(SwapsClientError::UnusableQuote)
+            ));
         }
     }
 
     #[test]
     fn test_across_status_growth_degrades_safely() {
-        for (status, expected) in [
-            ("received", ExecutorSwapStatus::Pending),
+        // The variant is asserted alongside the mapping on purpose: asserting
+        // only the `ExecutorSwapStatus` would stay green if the explicit
+        // `Received`/`DepositPending` variants were deleted, because
+        // `#[serde(other)] Unknown` also maps to `Pending`.
+        for (status, expected_variant, expected) in [
+            (
+                "received",
+                AcrossSwapStatus::Received,
+                ExecutorSwapStatus::Pending,
+            ),
             (
                 "deposit-pending",
+                AcrossSwapStatus::DepositPending,
                 ExecutorSwapStatus::Pending,
             ),
             (
                 "deposit-failed",
+                AcrossSwapStatus::DepositFailed,
                 ExecutorSwapStatus::Failed,
             ),
             (
                 "future-provider-status",
+                AcrossSwapStatus::Unknown,
                 ExecutorSwapStatus::Pending,
             ),
         ] {
@@ -391,11 +396,42 @@ mod tests {
             );
             let response = serde_json::from_str::<SwapStatusResponse>(&raw).unwrap();
 
+            assert_eq!(response.status, expected_variant);
             assert_eq!(
                 ExecutorSwapStatus::from(response.status),
                 expected
             );
         }
+    }
+
+    #[test]
+    fn test_status_response_tolerates_null_identifiers() {
+        // Across returns `"depositId": null` for CCTP/OFT deposits (it routes
+        // USDC over CCTP), and the early states have no proven contract for the
+        // other identifiers. A required field here would break status polling
+        // for that swap permanently.
+        let raw = r#"{
+            "status": "pending",
+            "originChainId": null,
+            "depositId": null,
+            "depositTxnRef": null,
+            "fillTxnRef": null,
+            "destinationChainId": null,
+            "depositRefundTxnRef": null
+        }"#;
+        let response = serde_json::from_str::<SwapStatusResponse>(raw).unwrap();
+        assert_eq!(
+            response.status,
+            AcrossSwapStatus::Pending
+        );
+
+        // Absent keys must work too.
+        let response =
+            serde_json::from_str::<SwapStatusResponse>(r#"{"status":"filled"}"#).unwrap();
+        assert_eq!(
+            response.status,
+            AcrossSwapStatus::Filled
+        );
     }
 
     #[test]

--- a/daemon/src/clients/swaps/across/types.rs
+++ b/daemon/src/clients/swaps/across/types.rs
@@ -14,10 +14,15 @@ use crate::types::{
     SwapExecutorType,
     SwapQuote,
 };
+use crate::utils::logging::{
+    category,
+    operation,
+};
 
 use super::super::{
     ExecutorSwapStatus,
     RawSwapDetails,
+    SwapsClientError,
 };
 use super::AcrossQuoteDetails;
 
@@ -147,21 +152,48 @@ pub struct SwapTransaction {
     pub max_priority_fee_per_gas: u128,
 }
 
-impl From<SwapTransactionInternal> for SwapTransaction {
-    fn from(value: SwapTransactionInternal) -> Self {
-        Self {
+impl TryFrom<SwapTransactionInternal> for SwapTransaction {
+    type Error = SwapsClientError;
+
+    fn try_from(value: SwapTransactionInternal) -> Result<Self, Self::Error> {
+        // `value` genuinely defaults to zero — Across omits the key for
+        // zero-value (ERC-20) transfers and documents `value ? BigInt(v) : 0n`
+        // as the caller's handling.
+        //
+        // The gas parameters do not: Across documents them as omit-and-estimate
+        // (`gas ? BigInt(gas) : undefined`), and Kassette submits them
+        // unguarded via `BigInt(swapTx.gas)`. Substituting `0` would publish a
+        // transaction with a zero gas limit and zero fee caps, which cannot be
+        // mined; omitting the field would throw in the payer's browser. Reject
+        // the quote instead of handing over either. Once Kassette accepts
+        // absent gas (Kalapaja/Kassette#49) these can be passed through as
+        // optional instead of rejected.
+        let (Some(gas), Some(max_fee_per_gas), Some(max_priority_fee_per_gas)) = (
+            value.gas,
+            value.max_fee_per_gas,
+            value.max_priority_fee_per_gas,
+        ) else {
+            tracing::warn!(
+                error.category = category::SWAPS_CLIENT,
+                error.operation = operation::GET_QUOTE,
+                gas = ?value.gas,
+                max_fee_per_gas = ?value.max_fee_per_gas,
+                max_priority_fee_per_gas = ?value.max_priority_fee_per_gas,
+                "Across quote is missing gas parameters, rejecting"
+            );
+
+            return Err(SwapsClientError::UnusableQuote)
+        };
+
+        Ok(Self {
             chain_id: value.chain_id,
             contract_address: value.to,
             data: value.data,
             value: value.value.unwrap_or_default(),
-            gas: value.gas.unwrap_or_default(),
-            max_fee_per_gas: value
-                .max_fee_per_gas
-                .unwrap_or_default(),
-            max_priority_fee_per_gas: value
-                .max_priority_fee_per_gas
-                .unwrap_or_default(),
-        }
+            gas,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+        })
     }
 }
 
@@ -176,9 +208,10 @@ pub struct SwapApprovalResponse {
     pub max_input_amount: u128,
     #[serde_as(as = "DisplayFromStr")]
     pub expected_output_amount: u128,
-    // Across sends an explicit `"approvalTxns": null` (not an absent key) when
-    // the payer already holds sufficient allowance; a bare `Vec` +
-    // `#[serde(default)]` rejects that null (production incident 2026-08-03).
+    // Across's docs describe the no-approval-needed case as an empty array and
+    // its own examples omit the key, but production responses on 2026-08-03
+    // carried an explicit `"approvalTxns": null`, which a bare `Vec` +
+    // `#[serde(default)]` rejects. Accept all three shapes.
     #[serde(default)]
     pub approval_txns: Option<Vec<ApprovalTransaction>>,
     pub swap_tx: SwapTransactionInternal,
@@ -186,24 +219,39 @@ pub struct SwapApprovalResponse {
     pub quote_expiry_timestamp: i64,
 }
 
-impl From<SwapApprovalResponse> for SwapQuote {
-    fn from(value: SwapApprovalResponse) -> Self {
+impl TryFrom<SwapApprovalResponse> for SwapQuote {
+    type Error = SwapsClientError;
+
+    fn try_from(value: SwapApprovalResponse) -> Result<Self, Self::Error> {
         let details = AcrossQuoteDetails {
-            transaction: value.swap_tx.into(),
+            transaction: value.swap_tx.try_into()?,
             approval_transactions: value.approval_txns.unwrap_or_default(),
         };
 
-        Self {
+        // Provider-controlled timestamp: any `i64` deserializes, but only a
+        // subset is representable, and `None` here used to panic the daemon.
+        let valid_till =
+            DateTime::from_timestamp_secs(value.quote_expiry_timestamp).ok_or_else(|| {
+                tracing::warn!(
+                    error.category = category::SWAPS_CLIENT,
+                    error.operation = operation::GET_QUOTE,
+                    quote_expiry_timestamp = value.quote_expiry_timestamp,
+                    "Across quote expiry is not a representable timestamp, rejecting"
+                );
+
+                SwapsClientError::UnusableQuote
+            })?;
+
+        Ok(Self {
             swap_executor: SwapExecutorType::Across,
             id: value.id,
             estimated_to_amount_units: value.expected_output_amount,
             // TODO: in response there's output token with it's params (decimals), so we can
             // calculate it
             estimated_to_amount: Decimal::ZERO,
-            // TODO: ensure unwrap is safe here?
-            valid_till: DateTime::from_timestamp_secs(value.quote_expiry_timestamp).unwrap(),
+            valid_till,
             quote_details: RawSwapDetails::Across(details),
-        }
+        })
     }
 }
 
@@ -215,19 +263,31 @@ pub struct SwapStatusRequest<'a> {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+// Only `status` is read. Every other field is optional on purpose: Across's own
+// `/deposit` example returns `"depositId": null` for non-intent deposit types
+// (CCTP `DepositForBurn`, OFT `OFTSent`) — and Across routes USDC over CCTP —
+// while the early `received` / `deposit-pending` states have no proven contract
+// for the identifiers at all. A required field here breaks status polling for
+// the swap permanently, so nothing that is never read may be required.
 pub struct SwapStatusResponse {
     pub status: AcrossSwapStatus,
     #[expect(dead_code)]
-    pub origin_chain_id: u64,
+    #[serde(default)]
+    pub origin_chain_id: Option<u64>,
     #[expect(dead_code)]
-    pub deposit_id: String,
+    #[serde(default)]
+    pub deposit_id: Option<String>,
     #[expect(dead_code)]
-    pub deposit_txn_ref: String,
+    #[serde(default)]
+    pub deposit_txn_ref: Option<String>,
     #[expect(dead_code)]
+    #[serde(default)]
     pub fill_txn_ref: Option<String>,
     #[expect(dead_code)]
-    pub destination_chain_id: u64,
+    #[serde(default)]
+    pub destination_chain_id: Option<u64>,
     #[expect(dead_code)]
+    #[serde(default)]
     pub deposit_refund_txn_ref: Option<String>,
 }
 

--- a/daemon/src/clients/swaps/across/types.rs
+++ b/daemon/src/clients/swaps/across/types.rs
@@ -36,6 +36,9 @@ pub enum AcrossSwapStatus {
     // and the recipient should have received funds. A FilledRelay event
     // was emitted on the destination chain SpokePool.
     Filled,
+    Received,
+    #[serde(rename = "deposit-pending")]
+    DepositPending,
     // Deposit has not been filled yet.
     Pending,
     // Deposit has expired and will not be filled. Expired deposits will be
@@ -45,15 +48,23 @@ pub enum AcrossSwapStatus {
     // Deposit has expired and the depositor has been successfully refunded
     // on the originChain.
     Refunded,
+    #[serde(rename = "deposit-failed")]
+    DepositFailed,
+    #[serde(other)]
+    Unknown,
 }
 
 impl From<AcrossSwapStatus> for ExecutorSwapStatus {
     fn from(value: AcrossSwapStatus) -> Self {
         match value {
             AcrossSwapStatus::Filled => Self::Executed,
+            AcrossSwapStatus::Received => Self::Pending,
+            AcrossSwapStatus::DepositPending => Self::Pending,
             AcrossSwapStatus::Pending => Self::Pending,
             AcrossSwapStatus::Expired => Self::Failed,
             AcrossSwapStatus::Refunded => Self::Failed,
+            AcrossSwapStatus::DepositFailed => Self::Failed,
+            AcrossSwapStatus::Unknown => Self::Pending,
         }
     }
 }
@@ -104,19 +115,19 @@ pub struct SwapTransactionInternal {
     pub chain_id: u64,
     pub to: String,
     pub data: String,
+    #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub value: u128,
+    pub value: Option<u128>,
     // Not presented in Solana transactions
+    #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub gas: u128,
+    pub gas: Option<u128>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub max_fee_per_gas: u128,
+    pub max_fee_per_gas: Option<u128>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub max_priority_fee_per_gas: u128,
+    pub max_priority_fee_per_gas: Option<u128>,
 }
 
 #[serde_as]
@@ -142,10 +153,14 @@ impl From<SwapTransactionInternal> for SwapTransaction {
             chain_id: value.chain_id,
             contract_address: value.to,
             data: value.data,
-            value: value.value,
-            gas: value.gas,
-            max_fee_per_gas: value.max_fee_per_gas,
-            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            value: value.value.unwrap_or_default(),
+            gas: value.gas.unwrap_or_default(),
+            max_fee_per_gas: value
+                .max_fee_per_gas
+                .unwrap_or_default(),
+            max_priority_fee_per_gas: value
+                .max_priority_fee_per_gas
+                .unwrap_or_default(),
         }
     }
 }

--- a/daemon/src/clients/swaps/across/types.rs
+++ b/daemon/src/clients/swaps/across/types.rs
@@ -161,8 +161,11 @@ pub struct SwapApprovalResponse {
     pub max_input_amount: u128,
     #[serde_as(as = "DisplayFromStr")]
     pub expected_output_amount: u128,
+    // Across sends an explicit `"approvalTxns": null` (not an absent key) when
+    // the payer already holds sufficient allowance; a bare `Vec` +
+    // `#[serde(default)]` rejects that null (production incident 2026-08-03).
     #[serde(default)]
-    pub approval_txns: Vec<ApprovalTransaction>,
+    pub approval_txns: Option<Vec<ApprovalTransaction>>,
     pub swap_tx: SwapTransactionInternal,
     pub id: String,
     pub quote_expiry_timestamp: i64,
@@ -172,7 +175,7 @@ impl From<SwapApprovalResponse> for SwapQuote {
     fn from(value: SwapApprovalResponse) -> Self {
         let details = AcrossQuoteDetails {
             transaction: value.swap_tx.into(),
-            approval_transactions: value.approval_txns,
+            approval_transactions: value.approval_txns.unwrap_or_default(),
         };
 
         Self {

--- a/daemon/src/clients/swaps/bungee.rs
+++ b/daemon/src/clients/swaps/bungee.rs
@@ -47,7 +47,8 @@ const BUNGEE_CLIENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 pub struct BungeeRawTransaction {
     pub quote_id: String,
     pub request_type: String,
-    pub approval_data: ApprovalData,
+    #[serde(default)]
+    pub approval_data: Option<ApprovalData>,
     pub sign_typed_data: SignTypedData,
 }
 
@@ -70,12 +71,12 @@ pub fn default_bungee_raw_transaction() -> BungeeRawTransaction {
     BungeeRawTransaction {
         quote_id: "68b79aeab92d6307".to_string(),
         request_type: "SWAP_REQUEST".to_string(),
-        approval_data: ApprovalData {
+        approval_data: Some(ApprovalData {
             token_address: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f".to_string(),
             spender_address: "0x000000000022D473030F116dDEE9F6B43aC78BA3".to_string(),
             user_address: "0xa4d353bbc130cbef1811f27ac70989f9d568ceab".to_string(),
             amount: "1500000".to_string(),
-        },
+        }),
         sign_typed_data: SignTypedData {
             domain: alloy::sol_types::Eip712Domain {
                 name: Some("Permit2".into()),
@@ -252,6 +253,13 @@ impl<T> From<BungeeApiResponse<T>> for SwapsClientError {
     }
 }
 
+impl QuoteResponse {
+    fn into_auto_route(self) -> Result<QuoteAutoRoute, SwapsClientError> {
+        self.auto_route
+            .ok_or(SwapsClientError::NoRouteAvailable)
+    }
+}
+
 #[derive(Clone)]
 pub struct BungeeClient {
     client: reqwest::Client,
@@ -358,7 +366,7 @@ impl BungeeClient {
 
 impl SwapsClient for BungeeClient {
     type GetQuoteParams = QuoteRequest;
-    type GetQuoteResponse = QuoteResponse;
+    type GetQuoteResponse = QuoteAutoRoute;
     type RawTransactionDetails = BungeeRawTransaction;
     type SwapStatus = BungeeSwapStatus;
 
@@ -406,13 +414,15 @@ impl SwapsClient for BungeeClient {
         &self,
         data: Self::GetQuoteParams,
     ) -> Result<Self::GetQuoteResponse, SwapsClientError> {
-        self.send_request(
-            "/api/v1/bungee/quote",
-            reqwest::Method::GET,
-            data,
-        )
-        .await
-        // TODO: check if `auto_quote` is empty, if so return an error
+        let response: QuoteResponse = self
+            .send_request(
+                "/api/v1/bungee/quote",
+                reqwest::Method::GET,
+                data,
+            )
+            .await?;
+
+        response.into_auto_route()
     }
 
     async fn submit_transaction_internal(
@@ -475,6 +485,97 @@ mod tests {
     };
 
     use super::*;
+
+    const QUOTE_WITHOUT_APPROVAL_DATA: &str = r#"{
+        "success": true,
+        "statusCode": 200,
+        "result": {
+            "autoRoute": {
+                "quoteId": "quote-benign",
+                "requestType": "SWAP_REQUEST",
+                "signTypedData": {
+                    "domain": {
+                        "name": "Permit2",
+                        "chainId": 137,
+                        "verifyingContract": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+                    },
+                    "types": {},
+                    "values": {
+                        "deadline": "1893456000",
+                        "nonce": "1",
+                        "permitted": {
+                            "amount": "1",
+                            "token": "0x1111111111111111111111111111111111111111"
+                        },
+                        "spender": "0x2222222222222222222222222222222222222222",
+                        "witness": {
+                            "affiliateFees": "0x",
+                            "basicReq": {
+                                "bungeeGateway": "0x3333333333333333333333333333333333333333",
+                                "chainId": 137,
+                                "deadline": "1893456000",
+                                "inputAmount": "1",
+                                "inputToken": "0x1111111111111111111111111111111111111111",
+                                "minOutputAmount": "1",
+                                "nonce": "1",
+                                "outputToken": "0x4444444444444444444444444444444444444444",
+                                "receiver": "0x5555555555555555555555555555555555555555",
+                                "sender": "0x6666666666666666666666666666666666666666"
+                            },
+                            "destinationPayload": "0x",
+                            "exclusiveTransmitter": "0x0000000000000000000000000000000000000000",
+                            "metadata": "0x00",
+                            "minDestGas": "0"
+                        }
+                    }
+                }
+            }
+        }
+    }"#;
+
+    #[test]
+    fn test_quote_response_maps_null_or_absent_auto_route_to_no_route_available() {
+        for raw in [
+            r#"{"success":true,"result":{"autoRoute":null}}"#,
+            r#"{"success":true,"result":{}}"#,
+        ] {
+            let response = serde_json::from_str::<BungeeApiResponse<QuoteResponse>>(raw).unwrap();
+            let result = response
+                .result
+                .unwrap()
+                .into_auto_route();
+
+            assert!(matches!(
+                result,
+                Err(SwapsClientError::NoRouteAvailable)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_quote_response_tolerates_absent_or_null_approval_data() {
+        for raw in [
+            QUOTE_WITHOUT_APPROVAL_DATA.to_string(),
+            QUOTE_WITHOUT_APPROVAL_DATA.replace(
+                "\"signTypedData\"",
+                "\"approvalData\": null, \"signTypedData\"",
+            ),
+        ] {
+            let response = serde_json::from_str::<BungeeApiResponse<QuoteResponse>>(&raw).unwrap();
+            let route = response
+                .result
+                .unwrap()
+                .into_auto_route()
+                .unwrap();
+            assert!(route.approval_data.is_none());
+
+            let quote = SwapQuote::from(route);
+            let RawSwapDetails::Bungee(details) = quote.quote_details else {
+                panic!("expected Bungee quote details");
+            };
+            assert!(details.approval_data.is_none());
+        }
+    }
 
     #[test]
     fn test_try_from_raw_details() {
@@ -749,12 +850,12 @@ mod tests {
             quote_details: RawSwapDetails::Bungee(BungeeRawTransaction {
                 quote_id: "68b79aeab92d6307".to_string(),
                 request_type: "SWAP_REQUEST".to_string(),
-                approval_data: ApprovalData {
+                approval_data: Some(ApprovalData {
                     token_address: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f".to_string(),
                     spender_address: "0x000000000022D473030F116dDEE9F6B43aC78BA3".to_string(),
                     user_address: "0xa4d353bbc130cbef1811f27ac70989f9d568ceab".to_string(),
                     amount: "1500000".to_string(),
-                },
+                }),
                 sign_typed_data: SignTypedData {
                     domain: alloy::sol_types::Eip712Domain {
                         name: Some("Permit2".into()),

--- a/daemon/src/clients/swaps/bungee.rs
+++ b/daemon/src/clients/swaps/bungee.rs
@@ -569,12 +569,43 @@ mod tests {
                 .unwrap();
             assert!(route.approval_data.is_none());
 
-            let quote = SwapQuote::from(route);
+            let quote = SwapQuote::try_from(route).unwrap();
             let RawSwapDetails::Bungee(details) = quote.quote_details else {
                 panic!("expected Bungee quote details");
             };
             assert!(details.approval_data.is_none());
         }
+    }
+
+    #[test]
+    fn test_quote_response_tolerates_null_sign_typed_data() {
+        // Bungee's OpenAPI spec marks `signTypedData` nullable and its own
+        // `onchainExample` returns null for this endpoint: an on-chain auto
+        // route (`userOp: "tx"`) rather than a Permit2 one. This integration
+        // can only execute the Permit2 shape, so this must degrade to a typed
+        // "no route" — not the deserialization failure that produced the blank
+        // 500 in the 0.9.3 incident.
+        //
+        // Note `#[serde(default)]` on `autoRoute` does not cover this: a
+        // default fires only for an absent key, never a present-but-null value.
+        let raw = QUOTE_WITHOUT_APPROVAL_DATA.replace(
+            "\"signTypedData\": {",
+            "\"signTypedData\": null, \"unusedSignTypedData\": {",
+        );
+
+        let response = serde_json::from_str::<BungeeApiResponse<QuoteResponse>>(&raw)
+            .expect("null signTypedData must still deserialize");
+        let route = response
+            .result
+            .unwrap()
+            .into_auto_route()
+            .expect("a route object is present, so this is not a no-route response");
+        assert!(route.sign_typed_data.is_none());
+
+        assert!(matches!(
+            SwapQuote::try_from(route),
+            Err(SwapsClientError::NoRouteAvailable)
+        ));
     }
 
     #[test]

--- a/daemon/src/clients/swaps/bungee/types.rs
+++ b/daemon/src/clients/swaps/bungee/types.rs
@@ -133,19 +133,19 @@ pub struct QuoteAutoRoute {
     pub quote_id: String,
     pub request_type: String,
     pub sign_typed_data: SignTypedData,
-    pub approval_data: ApprovalData,
+    #[serde(default)]
+    pub approval_data: Option<ApprovalData>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuoteResponse {
-    pub auto_route: QuoteAutoRoute,
+    #[serde(default)]
+    pub auto_route: Option<QuoteAutoRoute>,
 }
 
-impl From<QuoteResponse> for SwapQuote {
-    fn from(value: QuoteResponse) -> Self {
-        let route = value.auto_route;
-
+impl From<QuoteAutoRoute> for SwapQuote {
+    fn from(route: QuoteAutoRoute) -> Self {
         let valid_till =
             DateTime::from_timestamp_secs(route.sign_typed_data.values.deadline).unwrap();
         let estimated_to_amount_units = route

--- a/daemon/src/clients/swaps/bungee/types.rs
+++ b/daemon/src/clients/swaps/bungee/types.rs
@@ -18,6 +18,10 @@ use crate::types::{
     SwapExecutorType,
     SwapQuote,
 };
+use crate::utils::logging::{
+    category,
+    operation,
+};
 
 use super::BungeeQuoteDetails;
 
@@ -132,7 +136,16 @@ pub struct ApprovalData {
 pub struct QuoteAutoRoute {
     pub quote_id: String,
     pub request_type: String,
-    pub sign_typed_data: SignTypedData,
+    // `nullable: true` in Bungee's OpenAPI spec, and null in its own
+    // `onchainExample` for this endpoint: Bungee returns an on-chain auto route
+    // (`userOp: "tx"`, populated `txData`) instead of a Permit2 one. This
+    // integration can only execute the Permit2 shape, so a null here is "no
+    // usable route", not a parse failure — a required field made it one.
+    //
+    // NB: `#[serde(default)]` on `auto_route` below does not cover this. A
+    // default fires only for an absent key, never for a present-but-null value.
+    #[serde(default)]
+    pub sign_typed_data: Option<SignTypedData>,
     #[serde(default)]
     pub approval_data: Option<ApprovalData>,
 }
@@ -144,12 +157,36 @@ pub struct QuoteResponse {
     pub auto_route: Option<QuoteAutoRoute>,
 }
 
-impl From<QuoteAutoRoute> for SwapQuote {
-    fn from(route: QuoteAutoRoute) -> Self {
-        let valid_till =
-            DateTime::from_timestamp_secs(route.sign_typed_data.values.deadline).unwrap();
-        let estimated_to_amount_units = route
-            .sign_typed_data
+impl TryFrom<QuoteAutoRoute> for SwapQuote {
+    type Error = SwapsClientError;
+
+    fn try_from(route: QuoteAutoRoute) -> Result<Self, Self::Error> {
+        let Some(sign_typed_data) = route.sign_typed_data else {
+            tracing::debug!(
+                error.category = category::SWAPS_CLIENT,
+                error.operation = operation::GET_QUOTE,
+                request_type = %route.request_type,
+                "Bungee returned an on-chain auto route with no signTypedData"
+            );
+
+            return Err(SwapsClientError::NoRouteAvailable)
+        };
+
+        // Provider-controlled deadline: any `i64` deserializes, but only a
+        // subset is representable, and `None` here used to panic the daemon.
+        let valid_till = DateTime::from_timestamp_secs(sign_typed_data.values.deadline)
+            .ok_or_else(|| {
+                tracing::warn!(
+                    error.category = category::SWAPS_CLIENT,
+                    error.operation = operation::GET_QUOTE,
+                    deadline = sign_typed_data.values.deadline,
+                    "Bungee quote deadline is not a representable timestamp, rejecting"
+                );
+
+                SwapsClientError::UnusableQuote
+            })?;
+
+        let estimated_to_amount_units = sign_typed_data
             .values
             .witness
             .basic_req
@@ -159,20 +196,19 @@ impl From<QuoteAutoRoute> for SwapQuote {
             quote_id: route.quote_id.clone(),
             request_type: route.request_type,
             approval_data: route.approval_data,
-            sign_typed_data: route.sign_typed_data,
+            sign_typed_data,
         };
 
-        Self {
+        Ok(Self {
             swap_executor: SwapExecutorType::Bungee,
             id: route.quote_id,
             estimated_to_amount_units,
             // TODO: in response there's output token with it's params (decimals), so we can
             // calculate it
             estimated_to_amount: Decimal::ZERO,
-            // TODO: ensure unwrap is safe here?
             valid_till,
             quote_details: RawSwapDetails::Bungee(details),
-        }
+        })
     }
 }
 

--- a/daemon/src/clients/swaps/zeroex.rs
+++ b/daemon/src/clients/swaps/zeroex.rs
@@ -96,7 +96,9 @@ impl From<ZeroExTransaction> for RawTransactionData {
         Self {
             to: value.to,
             data: value.data,
-            gas: value.gas,
+            // This transaction is returned to the frontend wallet, which
+            // re-estimates gas before submission.
+            gas: value.gas.unwrap_or_default(),
             gas_price: value.gas_price,
             value: value.value,
         }
@@ -105,7 +107,8 @@ impl From<ZeroExTransaction> for RawTransactionData {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ZeroExRawTransaction {
-    pub allowance_target: String,
+    #[serde(default)]
+    pub allowance_target: Option<String>,
     // pub permit_hash: String,
     // pub permit_data: serde_json::Value,
     pub raw_transaction: RawTransactionData,
@@ -114,7 +117,7 @@ pub struct ZeroExRawTransaction {
 #[cfg(test)]
 pub fn default_zero_ex_raw_transaction() -> ZeroExRawTransaction {
     ZeroExRawTransaction {
-        allowance_target: "0x0000000000001ff3684f28c67538d4d072c22734".to_string(),
+        allowance_target: Some("0x0000000000001ff3684f28c67538d4d072c22734".to_string()),
         raw_transaction: RawTransactionData {
             to: "0x0000000000001ff3684f28c67538d4d072c22734".to_string(),
             data: "0x2213bc0b000000000000000000000000b0873c46937d34e98615e8c868bd3580bc6dcd4700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ea5ed2ad6f9c5fa000000000000000000000000b0873c46937d34e98615e8c868bd3580bc6dcd4700000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000006641fff991f0000000000000000000000005151537093e68f61a48cb98ba56922abcd2bc5e40000000000000000000000003c499c542cef5e3811e1192ce70d8cc03d5c3359000000000000000000000000000000000000000000000000000000000001821600000000000000000000000000000000000000000000000000000000000000a0f5303154d2e14bb0f960c9410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000038000000000000000000000000000000000000000000000000000000000000004400000000000000000000000000000000000000000000000000000000000000044bd01c2260000000000000000000000000000000000000000000000000000000069c2e3d00000000000000000000000000000000000000000000000000ea5ed2ad6f9c5fa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010438c9c147000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00000000000000000000000000000000000000000000000000000000000027100000000000000000000000000d500b1d8e8ef31e21c99d1db9a6444d3adf1270000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000024d0e30db00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e48d68a156000000000000000000000000b0873c46937d34e98615e8c868bd3580bc6dcd4700000000000000000000000000000000000000000000000000000000000027100000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400d500b1d8e8ef31e21c99d1db9a6444d3adf1270000001f400000000000000000000000000000001000276a43c499c542cef5e3811e1192ce70d8cc03d5c335900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008434ee90ca000000000000000000000000f5c4f3dc02c3fb9279495a8fef7b0741da9561570000000000000000000000003c499c542cef5e3811e1192ce70d8cc03d5c335900000000000000000000000000000000000000000000000000000000000187a1000000000000000000000000000000000000000000000000000000000000271000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000012438c9c1470000000000000000000000003c499c542cef5e3811e1192ce70d8cc03d5c3359000000000000000000000000000000000000000000000000000000000000000f0000000000000000000000003c499c542cef5e3811e1192ce70d8cc03d5c3359000000000000000000000000000000000000000000000000000000000000002400000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000044a9059cbb000000000000000000000000ad01c20d5886137e056775af56915de824c8fce50000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(), gas: 302525, gas_price: 198773677713, value: 1055510455939352058 }
@@ -285,6 +288,27 @@ impl ZeroExErrorResponse {
     }
 }
 
+// `status` is threaded through because 0x reports the failure kind only via the
+// HTTP status; the error body carries no status field. Note the no-liquidity arm
+// is a documented HTTP 200, so it never reaches the error classification.
+fn into_zero_ex_result<T>(
+    response: ZeroExResponse<T>,
+    status: reqwest::StatusCode,
+) -> Result<T, SwapsClientError> {
+    match response {
+        ZeroExResponse::Ok(response) => Ok(response),
+        ZeroExResponse::NoLiquidity(response) => {
+            tracing::debug!(
+                liquidity_available = response.liquidity_available,
+                zid = %response.zid,
+                "0x quote has no liquidity"
+            );
+            Err(SwapsClientError::NoLiquidity)
+        },
+        ZeroExResponse::Err(error) => Err(error.into_client_error(status)),
+    }
+}
+
 #[derive(Clone)]
 pub struct ZeroExClient {
     client: reqwest::Client,
@@ -381,10 +405,7 @@ impl SwapsClient for ZeroExClient {
             SwapsClientError::UnknownApiError
         })?;
 
-        match result {
-            ZeroExResponse::Ok(resp) => Ok(resp),
-            ZeroExResponse::Err(e) => Err(e.into_client_error(status)),
-        }
+        into_zero_ex_result(result, status)
     }
 
     async fn submit_transaction_internal(
@@ -513,10 +534,7 @@ impl ZeroExGaslessClient {
             SwapsClientError::UnknownApiError
         })?;
 
-        match result {
-            ZeroExResponse::Ok(resp) => Ok(resp),
-            ZeroExResponse::Err(e) => Err(e.into_client_error(status)),
-        }
+        into_zero_ex_result(result, status)
     }
 
     async fn sign_hash(
@@ -713,6 +731,8 @@ impl SwapsClient for ZeroExGaslessClient {
 
 #[cfg(test)]
 mod tests {
+    use crate::types::SwapQuote;
+
     use super::*;
 
     #[test]
@@ -747,6 +767,122 @@ mod tests {
         assert_eq!(
             server_error.into_client_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR),
             SwapsClientError::UnknownApiError
+        );
+    }
+
+    const FULL_QUOTE_WITH_NULLABLE_FIELDS: &str = r#"{
+        "liquidityAvailable": true,
+        "allowanceTarget": null,
+        "buyAmount": "100",
+        "buyToken": "0x1111111111111111111111111111111111111111",
+        "minBuyAmount": "99",
+        "sellAmount": "100",
+        "sellToken": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "transaction": {
+            "to": "0x2222222222222222222222222222222222222222",
+            "data": "0x1234",
+            "gas": null,
+            "gasPrice": "1",
+            "value": "100"
+        },
+        "zid": "quote-benign"
+    }"#;
+
+    const GASLESS_QUOTE_WITH_NULL_ALLOWANCE_TARGET: &str = r#"{
+        "liquidityAvailable": true,
+        "allowanceTarget": null,
+        "buyAmount": "100",
+        "buyToken": "0x1111111111111111111111111111111111111111",
+        "minBuyAmount": "99",
+        "sellAmount": "100",
+        "sellToken": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "trade": {
+            "type": "settler_metatransaction",
+            "hash": "0x1234",
+            "eip712": {}
+        },
+        "zid": "gasless-quote-benign"
+    }"#;
+
+    #[test]
+    fn test_full_quote_tolerates_null_or_absent_allowance_target_and_gas() {
+        for raw in [
+            FULL_QUOTE_WITH_NULLABLE_FIELDS.to_string(),
+            FULL_QUOTE_WITH_NULLABLE_FIELDS.replace("\"gas\": null,", ""),
+            FULL_QUOTE_WITH_NULLABLE_FIELDS.replace("\"allowanceTarget\": null,", ""),
+            FULL_QUOTE_WITH_NULLABLE_FIELDS
+                .replace("\"gas\": null,", "")
+                .replace("\"allowanceTarget\": null,", ""),
+        ] {
+            let response =
+                serde_json::from_str::<ZeroExResponse<ZeroExGetQuoteResponse>>(&raw).unwrap();
+            let ZeroExResponse::Ok(response) = response else {
+                panic!("a full liquid quote must parse as the success arm");
+            };
+            assert!(response.allowance_target.is_none());
+            assert!(response.transaction.gas.is_none());
+
+            let quote = SwapQuote::from(response);
+            let RawSwapDetails::ZeroEx(details) = quote.quote_details else {
+                panic!("expected 0x quote details");
+            };
+            assert!(details.allowance_target.is_none());
+            assert_eq!(details.raw_transaction.gas, 0);
+        }
+    }
+
+    #[test]
+    fn test_gasless_quote_tolerates_null_or_absent_allowance_target() {
+        for raw in [
+            GASLESS_QUOTE_WITH_NULL_ALLOWANCE_TARGET.to_string(),
+            GASLESS_QUOTE_WITH_NULL_ALLOWANCE_TARGET.replace("\"allowanceTarget\": null,", ""),
+        ] {
+            let response =
+                serde_json::from_str::<ZeroExResponse<ZeroExGaslessGetQuoteResponse>>(&raw)
+                    .unwrap();
+            let ZeroExResponse::Ok(response) = response else {
+                panic!("a full gasless quote must parse as the success arm");
+            };
+            assert!(response.allowance_target.is_none());
+        }
+    }
+
+    #[test]
+    fn test_no_liquidity_response_maps_to_typed_error_for_both_quote_paths() {
+        let raw = r#"{"liquidityAvailable":false,"zid":"x"}"#;
+
+        // 0x documents the no-liquidity body as an HTTP 200, so that is the
+        // status this arm is reached with.
+        let normal = serde_json::from_str::<ZeroExResponse<ZeroExGetQuoteResponse>>(raw).unwrap();
+        assert!(matches!(
+            into_zero_ex_result(normal, reqwest::StatusCode::OK),
+            Err(SwapsClientError::NoLiquidity)
+        ));
+
+        let gasless =
+            serde_json::from_str::<ZeroExResponse<ZeroExGaslessGetQuoteResponse>>(raw).unwrap();
+        assert!(matches!(
+            into_zero_ex_result(gasless, reqwest::StatusCode::OK),
+            Err(SwapsClientError::NoLiquidity)
+        ));
+    }
+
+    #[test]
+    fn test_failed_gasless_status_maps_to_failed() {
+        let raw = r#"{
+            "status": "failed",
+            "reason": "order_expired",
+            "zid": "status-benign"
+        }"#;
+        let response = serde_json::from_str::<GetTransactionStatusResponse>(raw).unwrap();
+
+        assert_eq!(
+            response.reason.as_deref(),
+            Some("order_expired")
+        );
+        assert_eq!(
+            ExecutorSwapStatus::from(response.status),
+            ExecutorSwapStatus::Failed
         );
     }
 }

--- a/daemon/src/clients/swaps/zeroex.rs
+++ b/daemon/src/clients/swaps/zeroex.rs
@@ -311,8 +311,8 @@ impl ZeroExErrorResponse {
 }
 
 // `status` is threaded through because 0x reports the failure kind only via the
-// HTTP status; the error body carries no status field. Note the no-liquidity arm
-// is a documented HTTP 200, so it never reaches the error classification.
+// HTTP status; the error body carries no status field. Note the no-liquidity
+// arm is a documented HTTP 200, so it never reaches the error classification.
 fn into_zero_ex_result<T>(
     response: ZeroExResponse<T>,
     status: reqwest::StatusCode,

--- a/daemon/src/clients/swaps/zeroex.rs
+++ b/daemon/src/clients/swaps/zeroex.rs
@@ -38,6 +38,10 @@ use crate::types::{
     SwapDetails,
     SwapExecutorType,
 };
+use crate::utils::logging::{
+    category,
+    operation,
+};
 
 use super::{
     ExecutorSwapStatus,
@@ -91,17 +95,35 @@ pub struct RawTransactionData {
     value: u128,
 }
 
-impl From<ZeroExTransaction> for RawTransactionData {
-    fn from(value: ZeroExTransaction) -> Self {
-        Self {
+impl TryFrom<ZeroExTransaction> for RawTransactionData {
+    type Error = SwapsClientError;
+
+    fn try_from(value: ZeroExTransaction) -> Result<Self, Self::Error> {
+        // 0x documents `transaction.gas` as nullable when it cannot estimate at
+        // quote time. It is not safe to substitute `0`: this transaction is
+        // handed to the payer's wallet, and Kassette submits it unguarded via
+        // `BigInt(rawTx.gas)`, so `0` becomes a zero-gas-limit transaction that
+        // cannot be mined. Omitting the key instead throws in the browser.
+        // Neither is publishable, so reject the quote. Once Kassette accepts
+        // absent gas (Kalapaja/Kassette#49) this can be passed through as
+        // optional instead of rejected.
+        let Some(gas) = value.gas else {
+            tracing::warn!(
+                error.category = category::SWAPS_CLIENT,
+                error.operation = operation::GET_QUOTE,
+                "0x quote has no gas estimate, rejecting"
+            );
+
+            return Err(SwapsClientError::UnusableQuote)
+        };
+
+        Ok(Self {
             to: value.to,
             data: value.data,
-            // This transaction is returned to the frontend wallet, which
-            // re-estimates gas before submission.
-            gas: value.gas.unwrap_or_default(),
+            gas,
             gas_price: value.gas_price,
             value: value.value,
-        }
+        })
     }
 }
 
@@ -299,7 +321,8 @@ fn into_zero_ex_result<T>(
         ZeroExResponse::Ok(response) => Ok(response),
         ZeroExResponse::NoLiquidity(response) => {
             tracing::debug!(
-                liquidity_available = response.liquidity_available,
+                error.category = category::SWAPS_CLIENT,
+                error.operation = operation::GET_QUOTE,
                 zid = %response.zid,
                 "0x quote has no liquidity"
             );
@@ -805,13 +828,14 @@ mod tests {
     }"#;
 
     #[test]
-    fn test_full_quote_tolerates_null_or_absent_allowance_target_and_gas() {
+    fn test_full_quote_tolerates_null_or_absent_allowance_target() {
+        // 0x documents `allowanceTarget` as nullable for native-asset sells —
+        // every native-POL payment — and the daemon maps native to the
+        // 0xEeee… sentinel, so this arm is reached in production.
         for raw in [
-            FULL_QUOTE_WITH_NULLABLE_FIELDS.to_string(),
-            FULL_QUOTE_WITH_NULLABLE_FIELDS.replace("\"gas\": null,", ""),
-            FULL_QUOTE_WITH_NULLABLE_FIELDS.replace("\"allowanceTarget\": null,", ""),
+            FULL_QUOTE_WITH_NULLABLE_FIELDS.replace("\"gas\": null,", "\"gas\": \"210000\","),
             FULL_QUOTE_WITH_NULLABLE_FIELDS
-                .replace("\"gas\": null,", "")
+                .replace("\"gas\": null,", "\"gas\": \"210000\",")
                 .replace("\"allowanceTarget\": null,", ""),
         ] {
             let response =
@@ -820,15 +844,59 @@ mod tests {
                 panic!("a full liquid quote must parse as the success arm");
             };
             assert!(response.allowance_target.is_none());
-            assert!(response.transaction.gas.is_none());
 
-            let quote = SwapQuote::from(response);
+            let quote = SwapQuote::try_from(response).unwrap();
             let RawSwapDetails::ZeroEx(details) = quote.quote_details else {
                 panic!("expected 0x quote details");
             };
             assert!(details.allowance_target.is_none());
-            assert_eq!(details.raw_transaction.gas, 0);
+            assert_eq!(details.raw_transaction.gas, 210_000);
         }
+    }
+
+    #[test]
+    fn test_full_quote_parses_but_rejects_missing_gas() {
+        // `transaction.gas` is nullable when 0x cannot estimate at quote time.
+        // The response must still parse, but the quote must not be published:
+        // Kassette submits `BigInt(rawTx.gas)` unguarded, so a substituted 0
+        // becomes a zero-gas-limit transaction that cannot be mined.
+        for raw in [
+            FULL_QUOTE_WITH_NULLABLE_FIELDS.to_string(),
+            FULL_QUOTE_WITH_NULLABLE_FIELDS.replace("\"gas\": null,", ""),
+        ] {
+            let response =
+                serde_json::from_str::<ZeroExResponse<ZeroExGetQuoteResponse>>(&raw).unwrap();
+            let ZeroExResponse::Ok(response) = response else {
+                panic!("a liquid quote must parse as the success arm even without gas");
+            };
+            assert!(response.transaction.gas.is_none());
+
+            assert!(matches!(
+                SwapQuote::try_from(response),
+                Err(SwapsClientError::UnusableQuote)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_liquid_quote_never_falls_through_to_the_no_liquidity_arm() {
+        // Untagged matching is first-successful-arm-wins over field *shape*, so
+        // without a value check on `liquidityAvailable` any successful quote
+        // that failed the `Ok` arm for an unrelated reason (here: a nullable
+        // field 0x does not currently document as nullable) would be reported
+        // to the customer as "no liquidity" — a plausible-looking business
+        // answer standing in for a loud parse error.
+        let raw = FULL_QUOTE_WITH_NULLABLE_FIELDS.replace(
+            "\"gasPrice\": \"1\",",
+            "\"gasPrice\": null,",
+        );
+
+        let response = serde_json::from_str::<ZeroExResponse<ZeroExGetQuoteResponse>>(&raw);
+
+        assert!(
+            response.is_err(),
+            "a liquidityAvailable:true payload must not match the NoLiquidity arm"
+        );
     }
 
     #[test]

--- a/daemon/src/clients/swaps/zeroex.rs
+++ b/daemon/src/clients/swaps/zeroex.rs
@@ -48,7 +48,18 @@ use super::{
 
 use types::*;
 
+const ZERO_EX_CLIENT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 type ChainProvider = FillProvider<JoinedRecommendedFillers, RootProvider>;
+
+// A reqwest client without a timeout hangs an invoice payment indefinitely on
+// a stalled 0x connection; Across and Bungee clients already bound theirs.
+fn zero_ex_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(ZERO_EX_CLIENT_REQUEST_TIMEOUT)
+        .build()
+        .expect("Failed to build 0x HTTP client")
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ZeroExTransactionStatus {
@@ -291,7 +302,7 @@ impl ZeroExClient {
             .expect("Failed to connect to RPC endpoint for 0x client");
 
         Self {
-            client: reqwest::Client::new(),
+            client: zero_ex_http_client(),
             chain_client,
             fees: config.fees.clone(),
             api_key: config.zero_ex.api_key.clone(),
@@ -448,7 +459,7 @@ pub struct ZeroExGaslessClient {
 impl ZeroExGaslessClient {
     pub fn new(config: &SwapsConfig) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: zero_ex_http_client(),
             fees: config.fees.clone(),
             api_key: config.zero_ex.api_key.clone(),
         }

--- a/daemon/src/clients/swaps/zeroex/types.rs
+++ b/daemon/src/clients/swaps/zeroex/types.rs
@@ -18,7 +18,10 @@ use crate::types::{
     SwapQuote,
 };
 
-use super::super::RawSwapDetails;
+use super::super::{
+    RawSwapDetails,
+    SwapsClientError,
+};
 use super::{
     ExecutorSwapStatus,
     ZeroExGaslessQuoteDetails,
@@ -110,16 +113,18 @@ pub struct ZeroExGetQuoteResponse {
     pub zid: String,
 }
 
-impl From<ZeroExGetQuoteResponse> for SwapQuote {
-    fn from(value: ZeroExGetQuoteResponse) -> Self {
+impl TryFrom<ZeroExGetQuoteResponse> for SwapQuote {
+    type Error = SwapsClientError;
+
+    fn try_from(value: ZeroExGetQuoteResponse) -> Result<Self, Self::Error> {
         let details = ZeroExQuoteDetails {
             allowance_target: value.allowance_target,
             // permit_hash: value.permit2.hash,
             // permit_data: value.permit2.eip712,
-            raw_transaction: value.transaction.into(),
+            raw_transaction: value.transaction.try_into()?,
         };
 
-        Self {
+        Ok(Self {
             // ZeroEx doesn't have swap id specifically, use request id
             id: value.zid,
             swap_executor: SwapExecutorType::ZeroEx,
@@ -130,7 +135,7 @@ impl From<ZeroExGetQuoteResponse> for SwapQuote {
             estimated_to_amount: Decimal::ZERO,
             valid_till: Utc::now() + TimeDelta::minutes(5),
             quote_details: RawSwapDetails::ZeroEx(details),
-        }
+        })
     }
 }
 
@@ -164,14 +169,18 @@ pub struct ZeroExGaslessGetQuoteResponse {
     pub zid: String,
 }
 
-impl From<ZeroExGaslessGetQuoteResponse> for SwapQuote {
-    fn from(value: ZeroExGaslessGetQuoteResponse) -> Self {
+impl TryFrom<ZeroExGaslessGetQuoteResponse> for SwapQuote {
+    type Error = SwapsClientError;
+
+    // Infallible today — the gasless quote carries no gas parameters — but the
+    // trait requires the fallible shape.
+    fn try_from(value: ZeroExGaslessGetQuoteResponse) -> Result<Self, Self::Error> {
         let details = ZeroExGaslessQuoteDetails {
             raw_trade: value.trade,
             approval: value.approval,
         };
 
-        Self {
+        Ok(Self {
             // ZeroEx doesn't have swap id specifically, use request id
             id: value.zid,
             swap_executor: SwapExecutorType::ZeroEx,
@@ -182,7 +191,7 @@ impl From<ZeroExGaslessGetQuoteResponse> for SwapQuote {
             estimated_to_amount: Decimal::ZERO,
             valid_till: Utc::now() + TimeDelta::minutes(5),
             quote_details: RawSwapDetails::ZeroExGasless(details),
-        }
+        })
     }
 }
 
@@ -275,13 +284,37 @@ pub struct ZeroExErrorResponse {
     pub data: ZeroExErrorResponseData,
 }
 
+// Deserializes only the literal `false`. Without this the untagged arm below
+// matches on field *shape* alone, so any successful `liquidityAvailable: true`
+// quote that failed the `Ok` arm for an unrelated reason (a renamed field, a
+// newly-nullable one) lands here and is reported to the customer as "no
+// liquidity" — a plausible-looking business answer in place of a loud parse
+// error. Gating on the value makes the arm self-discriminating.
+fn deserialize_liquidity_unavailable<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    if bool::deserialize(deserializer)? {
+        return Err(serde::de::Error::custom(
+            "liquidityAvailable is true; not a no-liquidity response",
+        ))
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ZeroExNoLiquidityResponse {
-    pub liquidity_available: bool,
+    // Never read: it exists so the deserializer above runs and rejects the
+    // arm when the flag is `true`.
+    #[expect(dead_code)]
+    #[serde(deserialize_with = "deserialize_liquidity_unavailable")]
+    pub liquidity_available: (),
     pub zid: String,
 }
 
+// Order matters: untagged is first-successful-arm-wins in declaration order.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ZeroExResponse<T> {

--- a/daemon/src/clients/swaps/zeroex/types.rs
+++ b/daemon/src/clients/swaps/zeroex/types.rs
@@ -74,8 +74,9 @@ impl From<CreateSwapData> for ZeroExGetQuoteRequest {
 pub struct ZeroExTransaction {
     pub to: String,
     pub data: String,
-    #[serde_as(as = "DisplayFromStr")]
-    pub gas: u64,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(default)]
+    pub gas: Option<u64>,
     #[serde_as(as = "DisplayFromStr")]
     pub gas_price: u128,
     #[serde_as(as = "DisplayFromStr")]
@@ -94,7 +95,8 @@ pub struct ZeroExPermit2 {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ZeroExGetQuoteResponse {
-    pub allowance_target: String,
+    #[serde(default)]
+    pub allowance_target: Option<String>,
     #[serde_as(as = "DisplayFromStr")]
     pub buy_amount: u128,
     pub buy_token: String,
@@ -146,7 +148,8 @@ pub struct ZeroExTrade {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ZeroExGaslessGetQuoteResponse {
-    pub allowance_target: String,
+    #[serde(default)]
+    pub allowance_target: Option<String>,
     #[serde(default)]
     pub approval: Option<ZeroExTrade>,
     #[serde_as(as = "DisplayFromStr")]
@@ -230,6 +233,7 @@ pub enum ZeroExGaslessTransactionStatus {
     Submitted,
     Succeeded,
     Confirmed,
+    Failed,
 }
 
 impl From<ZeroExGaslessTransactionStatus> for ExecutorSwapStatus {
@@ -241,6 +245,7 @@ impl From<ZeroExGaslessTransactionStatus> for ExecutorSwapStatus {
             Submitted => ExecutorSwapStatus::Pending,
             Succeeded => ExecutorSwapStatus::Pending,
             Confirmed => ExecutorSwapStatus::Executed,
+            Failed => ExecutorSwapStatus::Failed,
         }
     }
 }
@@ -250,6 +255,8 @@ impl From<ZeroExGaslessTransactionStatus> for ExecutorSwapStatus {
 #[serde(rename_all = "camelCase")]
 pub struct GetTransactionStatusResponse {
     pub status: ZeroExGaslessTransactionStatus,
+    #[serde(default)]
+    pub reason: Option<String>,
     pub zid: String,
 }
 
@@ -269,8 +276,16 @@ pub struct ZeroExErrorResponse {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZeroExNoLiquidityResponse {
+    pub liquidity_available: bool,
+    pub zid: String,
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ZeroExResponse<T> {
     Ok(T),
+    NoLiquidity(ZeroExNoLiquidityResponse),
     Err(ZeroExErrorResponse),
 }

--- a/daemon/src/swaps/executor.rs
+++ b/daemon/src/swaps/executor.rs
@@ -42,6 +42,22 @@ impl From<SwapsClientError> for SwapsExecutorError {
             } => SwapsExecutorError::ProviderRejected {
                 message,
             },
+            // The provider answered successfully and told us it will not serve
+            // this trade. That is the same class as an explicit rejection — the
+            // requester can act on it (different amount, different token) — so
+            // it must not be reported as an internal failure. These arms carry
+            // no provider text, so supply our own; it is surfaced to the
+            // payment UI verbatim.
+            SwapsClientError::NoRouteAvailable => SwapsExecutorError::ProviderRejected {
+                message: "No swap route is available for this pair right now.".to_string(),
+            },
+            SwapsClientError::NoLiquidity => SwapsExecutorError::ProviderRejected {
+                message: "There is not enough liquidity for this trade right now.".to_string(),
+            },
+            // `UnusableQuote` deliberately stays internal: the provider gave us
+            // a quote we cannot publish (missing gas parameters, unrepresentable
+            // expiry). Nothing the requester does differently would fix it.
+            //
             // Everything else (transport failures, provider 5xx, malformed
             // responses) is an internal failure from the requester's view
             _ => SwapsExecutorError::QuoteRequestFailed,
@@ -306,6 +322,32 @@ mod tests {
         ));
     }
 
+    /// A provider that answers successfully and declines to serve the trade is
+    /// making a rejection, not failing. These arms carry no provider text of
+    /// their own, so the conversion supplies a message that is safe to show the
+    /// payer — the point is that they reach the API as a 422 and not a 500.
+    #[test]
+    fn quote_unavailable_is_a_rejection_not_an_internal_failure() {
+        for error in [
+            SwapsClientError::NoRouteAvailable,
+            SwapsClientError::NoLiquidity,
+        ] {
+            let converted = SwapsExecutorError::from(error.clone());
+
+            let SwapsExecutorError::ProviderRejected {
+                message,
+            } = converted
+            else {
+                panic!("{error:?} must map to ProviderRejected, got {converted:?}")
+            };
+
+            assert!(
+                !message.is_empty(),
+                "{error:?} must carry a message for the payment UI"
+            );
+        }
+    }
+
     /// Transport failures, provider 5xx and malformed responses all reach this
     /// conversion as something other than `ProviderRejected`. None of them are
     /// the requester's fault, so none may surface as a 422 — they have to
@@ -326,6 +368,9 @@ mod tests {
                 from_chain: SwapChainType::Polygon,
                 to_chain: SwapChainType::Ethereum,
             },
+            // The provider answered, but with a quote we cannot publish. The
+            // requester cannot act on that, so it is internal.
+            SwapsClientError::UnusableQuote,
         ];
 
         for error in internal {

--- a/daemon/src/swaps/tracker.rs
+++ b/daemon/src/swaps/tracker.rs
@@ -25,6 +25,7 @@ use super::SwapsClients;
 
 const SWAPS_EXECUTOR_API_POLLING_INTERVAL_MILLIS: u64 = 3000;
 const SWAPS_EXECUTOR_DATABASE_POLLING_INTERVAL_MILLIS: u64 = 100;
+const SWAPS_EXECUTOR_PENDING_RELOAD_RETRY_MILLIS: u64 = 5000;
 
 struct TrackedSwaps {
     swaps: HashMap<Uuid, Swap>,
@@ -326,15 +327,27 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
             SWAPS_EXECUTOR_DATABASE_POLLING_INTERVAL_MILLIS,
         ));
 
-        // TODO: First of all need to fetch pending swaps which has left after service
-        // reaload. Need to either handle an error and retry loading or just
-        // panic and restart the daemon, we can't just leave those pending swaps
-        // in this state forever.
-        let pending_swaps = self
-            .dao
-            .get_pending_swaps()
-            .await
-            .unwrap();
+        // Pending swaps left over from a service reload must be reloaded: a
+        // panic here would kill only this spawned task while the daemon keeps
+        // serving, silently abandoning every submitted swap. Retry until the
+        // database answers (or shutdown is requested).
+        let pending_swaps = loop {
+            match self.dao.get_pending_swaps().await {
+                Ok(swaps) => break swaps,
+                Err(e) => {
+                    tracing::warn!(
+                        error.source = ?e,
+                        "Failed to load pending swaps on startup, retrying"
+                    );
+                    tokio::select! {
+                        () = token.cancelled() => return,
+                        () = tokio::time::sleep(Duration::from_millis(
+                            SWAPS_EXECUTOR_PENDING_RELOAD_RETRY_MILLIS,
+                        )) => {}
+                    }
+                },
+            }
+        };
 
         self.store.add_swaps(pending_swaps);
 

--- a/daemon/src/swaps/tracker.rs
+++ b/daemon/src/swaps/tracker.rs
@@ -20,12 +20,17 @@ use crate::types::{
     Swap,
     TransactionOriginVariant,
 };
+use crate::utils::logging::{
+    category,
+    operation,
+};
 
 use super::SwapsClients;
 
 const SWAPS_EXECUTOR_API_POLLING_INTERVAL_MILLIS: u64 = 3000;
 const SWAPS_EXECUTOR_DATABASE_POLLING_INTERVAL_MILLIS: u64 = 100;
 const SWAPS_EXECUTOR_PENDING_RELOAD_RETRY_MILLIS: u64 = 5000;
+const SWAPS_EXECUTOR_PENDING_RELOAD_MAX_ATTEMPTS: u32 = 12;
 
 struct TrackedSwaps {
     swaps: HashMap<Uuid, Swap>,
@@ -319,26 +324,42 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
     ) {
         tracing::info!("Starting swaps tracker");
 
-        let mut api_polling_interval = interval(Duration::from_millis(
-            SWAPS_EXECUTOR_API_POLLING_INTERVAL_MILLIS,
-        ));
+        // Pending swaps left over from a service reload must be reloaded before
+        // anything else: without them the daemon accepts new swaps while
+        // silently never monitoring the ones already submitted.
+        //
+        // A transient database error should not take the daemon down, so retry.
+        // But the retry must be bounded: the previous `unwrap()` here reached
+        // the global panic hook installed in `main`, which cancels the shutdown
+        // token and stops the daemon, so an unbounded retry would *weaken* the
+        // failure handling — a permanently undecodable row would leave the API
+        // serving forever with no tracker and no operator signal. On exhaustion,
+        // fall back to that same shutdown path.
+        let mut pending_swaps = None;
 
-        let mut database_polling_interval = interval(Duration::from_millis(
-            SWAPS_EXECUTOR_DATABASE_POLLING_INTERVAL_MILLIS,
-        ));
+        for attempt in 1..=SWAPS_EXECUTOR_PENDING_RELOAD_MAX_ATTEMPTS {
+            // Race the query itself, not just the backoff: a shutdown requested
+            // while the call is stalled on a connection must not wait it out.
+            let result = tokio::select! {
+                result = self.dao.get_pending_swaps() => result,
+                () = token.cancelled() => return,
+            };
 
-        // Pending swaps left over from a service reload must be reloaded: a
-        // panic here would kill only this spawned task while the daemon keeps
-        // serving, silently abandoning every submitted swap. Retry until the
-        // database answers (or shutdown is requested).
-        let pending_swaps = loop {
-            match self.dao.get_pending_swaps().await {
-                Ok(swaps) => break swaps,
+            match result {
+                Ok(swaps) => {
+                    pending_swaps = Some(swaps);
+                    break
+                },
                 Err(e) => {
                     tracing::warn!(
+                        error.category = category::SWAPS_TRACKER,
+                        error.operation = operation::RELOAD_PENDING_SWAPS,
                         error.source = ?e,
+                        %attempt,
+                        max_attempts = SWAPS_EXECUTOR_PENDING_RELOAD_MAX_ATTEMPTS,
                         "Failed to load pending swaps on startup, retrying"
                     );
+
                     tokio::select! {
                         () = token.cancelled() => return,
                         () = tokio::time::sleep(Duration::from_millis(
@@ -347,9 +368,35 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
                     }
                 },
             }
+        }
+
+        let Some(pending_swaps) = pending_swaps else {
+            tracing::error!(
+                error.category = category::SWAPS_TRACKER,
+                error.operation = operation::RELOAD_PENDING_SWAPS,
+                max_attempts = SWAPS_EXECUTOR_PENDING_RELOAD_MAX_ATTEMPTS,
+                "Could not load pending swaps, shutting down rather than \
+                 serving without a swaps tracker"
+            );
+
+            token.cancel();
+
+            return
         };
 
         self.store.add_swaps(pending_swaps);
+
+        // Created after the reload on purpose: tokio's default missed-tick
+        // behaviour is `Burst`, so intervals built before a slow retry would
+        // fire their accumulated backlog back-to-back and hammer both SQLite
+        // and the provider APIs on the way out of startup.
+        let mut api_polling_interval = interval(Duration::from_millis(
+            SWAPS_EXECUTOR_API_POLLING_INTERVAL_MILLIS,
+        ));
+
+        let mut database_polling_interval = interval(Duration::from_millis(
+            SWAPS_EXECUTOR_DATABASE_POLLING_INTERVAL_MILLIS,
+        ));
 
         loop {
             tokio::select! {

--- a/daemon/src/utils/logging.rs
+++ b/daemon/src/utils/logging.rs
@@ -7,6 +7,8 @@
 pub mod category {
     pub const AUTH: &str = "auth";
     pub const CHAIN_CLIENT: &str = "chain_client";
+    pub const SWAPS_CLIENT: &str = "swaps_client";
+    pub const SWAPS_TRACKER: &str = "swaps_tracker";
 }
 
 /// Log operation constants for identifying specific operations within
@@ -27,4 +29,8 @@ pub mod operation {
     pub const WATCH_TRANSACTION: &str = "watch_transaction";
     pub const BUILD_TRANSFER: &str = "build_transfer";
     pub const SUBSCRIBE_TRANSFERS: &str = "subscribe_transfers";
+
+    // Swaps operations
+    pub const GET_QUOTE: &str = "get_quote";
+    pub const RELOAD_PENDING_SWAPS: &str = "reload_pending_swaps";
 }


### PR DESCRIPTION
Hardens the three swap-provider clients against response shapes the providers actually emit, and closes two payment-preventing defects in the swap tracker and the 0x clients.

## Why

On 2026-08-03 `POST /public/swap/create` returned a blank 500 for five consecutive checkout attempts during the launch demo. Across sends `"approvalTxns": null` — an explicit null, not an absent key — whenever the payer's wallet already holds sufficient allowance. The field was modelled as `#[serde(default)] Vec<_>`, which covers only a missing key, so **exactly the wallets that were ready to pay** failed deserialization. The error was then swallowed by the untagged `AcrossApiResponse` enum, whose failure mode discards the per-arm error, leaving nothing in the logs to point at the cause.

That is one instance of a general defect class: *a non-`Option` serde field for a value a third party can send as `null` or omit*. This PR sweeps that class across all three providers, and adds the missing bounds around the code paths that turned such a failure into a silent one.

## What changed

**Across** — `approvalTxns` accepts null / empty / absent. Status enum gains `received`, `deposit-pending`, `deposit-failed`, plus a `#[serde(other)]` catch-all so a status Across adds later degrades to continued polling instead of breaking the parse. Every field of the status response except `status` itself is now optional: Across returns `"depositId": null` for CCTP/OFT deposits, and it routes USDC over CCTP, so a required field there would permanently break status polling for that swap.

**Bungee** — `autoRoute` is null on no-route quotes (dust, thin liquidity); that is now a typed `NoRouteAvailable` rather than a parse failure. `approvalData` is optional, and its absence means "no approval needed". `signTypedData` is optional: Bungee's OpenAPI spec marks it `nullable: true` and its own `onchainExample` returns null whenever it hands back an on-chain auto route (`userOp: "tx"`) instead of a Permit2 one. This integration executes only the Permit2 shape, so null is "no usable route" — while a required field made it the same blank-500 failure as the incident above, on the sibling field of the same struct.

**0x** — `allowanceTarget` is nullable (native-asset sells, i.e. every native-POL payment, plus wrap/unwrap). `transaction.gas` is nullable when 0x cannot estimate at quote time. The documented `liquidityAvailable: false` 200-response arm is modelled explicitly and gated on the discriminator's *value*, not merely its shape — without that gate, any successful quote failing the `Ok` arm for an unrelated reason would be reported to the customer as "no liquidity", a plausible business answer standing in for a parse error. Gasless status gains the documented `failed` variant with its `reason`; previously that response was unparseable, leaving swaps polling forever after funds had moved.

**Swap tracker** — `perform` unwrapped `get_pending_swaps()` at startup. That unwrap reached the global panic hook in `main.rs`, which cancels the shutdown token, so a transient SQLite error stopped the whole daemon. It now retries, but **bounded**: an unbounded retry would be the worse failure, leaving the API serving indefinitely with no swap tracker and no operator signal. On exhaustion it falls back to the same shutdown path. The DAO call is raced against the cancellation token rather than only the backoff, and the polling intervals are constructed after the reload so tokio's default `Burst` missed-tick behaviour cannot fire an accumulated backlog on the way out of startup.

**0x HTTP clients** — both used `reqwest::Client::new()` with no timeout (Across and Bungee already bound theirs), so a stalled provider connection could hang an invoice payment indefinitely. Now built with a 60s request timeout, which `reqwest` applies to the whole request including the body read.

## API-visible changes

- `POST /public/swap/create` returns **422 `SWAP_PROVIDER_REJECTED`** for no-route and no-liquidity, instead of 500. This uses the classification chain added in #345 — without the final commit here, the new typed variants would have fallen into its `_ =>` catch-all and kept surfacing as 500.
- A quote whose gas parameters the provider omitted is now **rejected** rather than published. See the trade-off below.

## The gas trade-off — deliberate, and coupled to Kassette

Across and 0x both document gas as omit-and-estimate; Across's own guide converts with `gas ? BigInt(gas) : undefined`. Substituting `0` is not safe: the transaction goes to the payer's wallet via `PublicSwap.swap_details`, and Kassette converts it with an unguarded `BigInt(swapTx.gas)`. `"0"` is truthy in JS, so the substitution defeats the wallet's own estimation guard and yields a zero-gas, unminable transaction — while omitting the key throws `TypeError` on the payment page.

Since neither publishable form works today, the conversion is fallible and rejects such a quote rather than handing the payer something guaranteed to fail. `value` still defaults to `0`, which is what Across documents and what Kassette handles correctly. Kalapaja/Kassette#49 tracks accepting absence; once that ships, these fields can be passed through as optional instead of rejected, and both code sites carry a comment pointing at it.

## Review provenance

This branch went through a two-track pre-PR review before publishing — an adversarial code review, plus an integration review that verified every assumption the diff makes about external systems against first-party sources (Across docs, Bungee's OpenAPI spec, 0x's v2 OpenAPI spec, and the serde/serde_with/reqwest sources at their lockfile versions).

That second track is what caught the `signTypedData` blocker: the same defect class this PR exists to fix, still open on the very struct the PR had edited. It also confirmed the Across status set is complete against the docs (all seven modelled, none invented, no terminal status mapped to pending), that 0x's gasless status set is complete with `succeeded`/`confirmed` mapped correctly, and that `#[serde(other)]` is legal on an externally-tagged enum despite serde's prose docs being narrower than its implementation.

Findings that were real but outside this PR's scope are filed rather than folded in: #349 (panic on the public signature endpoint), #350, #351, #352, #353, #354, #355, #356.

## Testing

19 serde-fixture and classification tests covering: null/absent/empty `approvalTxns`; null `signTypedData`; null and absent `approvalData`; null and absent `autoRoute`; null and absent `allowanceTarget` on both 0x quote paths; missing-gas rejection on Across and 0x; the `liquidityAvailable` shadowing guard; null status identifiers; the gasless `failed` status; and the executor-level classification of the new variants.

The Across status test asserts the deserialized *variant* alongside its mapping — asserting only the mapping stayed green when the explicit `Received`/`DepositPending` variants were deleted, because the `serde(other)` catch-all produces the same result.

`cargo check`, `clippy` (strict, `-Dwarnings`), `cargo +nightly fmt --check` and `cargo deny` are all clean. The DAO suite does not run on the author's machine (local SQLite predates the `||` operator used in migration `20250104000001`) and is left to CI; no non-DAO test fails.

## Not done here

No `docs/` updates — the swaps subsystem is undocumented in `docs/architecture.md` and the nullable-provider-field rule belongs in `docs/conventions.md`. Tracked in #356 rather than expanding this PR.
