### PR TITLE
fix: harden payment detection, address matching, and swap submission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ daemon/examples/              Integration test examples (crud, webhook)
 | [docs/error-handling.md](docs/error-handling.md) | 5 Error Design Principles with examples | Designing error types |
 | [docs/architecture.md](docs/architecture.md) | Component map, data flow, payment lifecycle, config, key derivation | Understanding the system |
 | [docs/testing-strategy.md](docs/testing-strategy.md) | Test types, commands, CI pipeline, mock patterns | Adding/modifying tests |
+| [docs/swaps.md](docs/swaps.md) | Swaps decision records: unusable-quote rejection, submission protocol | Changing swap clients/executor |
 | [docs/mcp-tooling.md](docs/mcp-tooling.md) | MCP server availability and usage patterns | Using MCP tools |
 | [docs/doc-update-triggers.md](docs/doc-update-triggers.md) | What docs to update after code changes | After any PR |
 | [docs/DATABASE.md](docs/DATABASE.md) | SQLite schema, DAO pattern, status transitions | DB schema changes |

--- a/configs/chains.json.example
+++ b/configs/chains.json.example
@@ -10,7 +10,8 @@
       "endpoints": [
         "wss://polygon-bor-rpc.publicnode.com"
       ],
-      "allow_insecure_endpoints": true
+      "allow_insecure_endpoints": true,
+      "confirmations": 12
     }
   }
 }

--- a/daemon/src/balance_checker.rs
+++ b/daemon/src/balance_checker.rs
@@ -20,8 +20,10 @@ use crate::dao::{
 };
 use crate::etherscan_client::EtherscanClient;
 use crate::types::{
+    GeneralTransactionId,
     IncomingTransaction,
     InvoiceWithReceivedAmount,
+    TransferInfo,
 };
 
 #[derive(Debug)]
@@ -109,28 +111,109 @@ impl<
     #[tracing::instrument(skip(self))]
     async fn get_incoming_transactions(
         &self,
-        chain: ChainType,
         asset_id: &str,
         address: &str,
         invoice_id: Uuid,
     ) -> Result<Vec<IncomingTransaction>, BalanceCheckerError> {
-        match chain {
-            ChainType::PolkadotAssetHub => {
-                // TODO: it's better to return some kind of error instead
-                Ok(vec![])
-            },
-            ChainType::Polygon => self
-                .etherscan_client
-                .get_account_incoming_transfers(chain, asset_id, address, invoice_id)
-                .await
-                .map_err(|e| {
-                    tracing::warn!(
-                        error = ?e,
-                        "Failed to get account incoming transfers using etherscan client"
-                    );
+        self.etherscan_client
+            .get_account_incoming_transfers(
+                ChainType::Polygon,
+                asset_id,
+                address,
+                invoice_id,
+            )
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    error = ?e,
+                    "Failed to get account incoming transfers using etherscan client"
+                );
 
-                    BalanceCheckerError::FetchTransfersFailed
-                }),
+                BalanceCheckerError::FetchTransfersFailed
+            })
+    }
+
+    /// Asset Hub has no external indexer to replay missed history from, but
+    /// every payment address is unique to its invoice, so the finalized
+    /// on-chain balance is the ground truth of what the invoice received.
+    /// When the balance is ahead of our records (subscription gap, restart),
+    /// record the difference as a synthetic adjustment transaction so the
+    /// invoice converges instead of expiring unpaid.
+    #[expect(clippy::arithmetic_side_effects)]
+    #[tracing::instrument(
+        skip(self, invoice),
+        fields(invoice_id = %invoice.invoice.id)
+    )]
+    async fn reconcile_asset_hub_balance(
+        &self,
+        invoice: &mut InvoiceWithReceivedAmount,
+        balance: Decimal,
+    ) -> Result<(), BalanceCheckerError> {
+        let received_amount = invoice.total_received_amount;
+        let delta = balance - received_amount;
+
+        if delta <= Decimal::ZERO {
+            // We recorded more than the address holds. Never "un-record"
+            // payments automatically — this needs a human (funds moved out of
+            // the payment address, or a transfer was double-recorded).
+            tracing::error!(
+                %balance,
+                %received_amount,
+                "Recorded received amount exceeds on-chain balance, manual intervention required"
+            );
+            return Ok(());
+        }
+
+        tracing::warn!(
+            %balance,
+            %received_amount,
+            %delta,
+            "On-chain balance is ahead of recorded transfers, recording a balance-adjustment transaction to recover missed transfers"
+        );
+
+        // Both the balance query (`at_latest` resolves to the latest finalized
+        // block in subxt) and the transfer subscription observe finalized
+        // blocks only, so the delta consists of finalized transfers the
+        // subscription missed. All-NULL transaction coordinates keep this
+        // record outside the per-chain uniqueness indexes.
+        let transaction = IncomingTransaction {
+            id: Uuid::new_v4(),
+            invoice_id: invoice.invoice.id,
+            transfer_info: TransferInfo {
+                chain: ChainType::PolkadotAssetHub,
+                asset_id: invoice.invoice.asset_id.clone(),
+                asset_name: invoice.invoice.asset_name.clone(),
+                amount: delta,
+                source_address: "unknown".to_string(),
+                destination_address: invoice.invoice.payment_address.clone(),
+            },
+            transaction_id: GeneralTransactionId {
+                block_number: None,
+                position_in_block: None,
+                tx_hash: None,
+            },
+        };
+
+        match self
+            .transactions_recorder
+            .process_invoice_transaction(invoice, transaction)
+            .await
+        {
+            Ok(()) => {
+                tracing::info!(
+                    invoice_status = %invoice.invoice.status,
+                    total_received_amount = %invoice.total_received_amount,
+                    "Balance-adjustment transaction has been recorded, invoice has been updated"
+                );
+                Ok(())
+            },
+            Err(e) => {
+                tracing::warn!(
+                    error = ?e,
+                    "Database error occurred while trying to record balance-adjustment transaction"
+                );
+                Err(BalanceCheckerError::DatabaseError)
+            },
         }
     }
 
@@ -146,17 +229,21 @@ impl<
         invoice: &mut InvoiceWithReceivedAmount,
         balance: Decimal,
     ) -> Result<(), BalanceCheckerError> {
+        tracing::warn!("Detected inconsistency in recorded received amount and account balance");
+
+        if invoice.invoice.chain == ChainType::PolkadotAssetHub {
+            return self
+                .reconcile_asset_hub_balance(invoice, balance)
+                .await;
+        }
+
         let received_amount = invoice.total_received_amount;
         let invoice_id = invoice.invoice.id;
-        let chain = invoice.invoice.chain;
         let asset_id = &invoice.invoice.asset_id;
         let address = &invoice.invoice.payment_address;
 
-        tracing::warn!("Detected inconsistency in recorded received amount and account balance");
-
         let incoming_transactions = self
             .get_incoming_transactions(
-                chain,
                 asset_id,
                 address,
                 invoice_id

--- a/daemon/src/chain/invoice_registry.rs
+++ b/daemon/src/chain/invoice_registry.rs
@@ -98,6 +98,22 @@ impl InvoiceRegistry {
             .cloned()
     }
 
+    /// Replace the stored invoice data (amount, cart, expiry, ...) while
+    /// preserving the received amount tracked so far. Inserts the record as-is
+    /// when the invoice isn't tracked yet.
+    pub async fn refresh_invoice(
+        &self,
+        mut record: InvoiceWithReceivedAmount,
+    ) {
+        let mut invoices = self.invoices.write().await;
+
+        if let Some(existing) = invoices.get(&record.invoice.id) {
+            record.total_received_amount = existing.total_received_amount;
+        }
+
+        invoices.insert(record.invoice.id, record);
+    }
+
     pub async fn update_filled_amount(
         &self,
         invoice_id: &Uuid,
@@ -146,6 +162,72 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn test_refresh_invoice_preserves_received_amount() {
+        let registry = InvoiceRegistry::new();
+
+        let invoice_id = Uuid::new_v4();
+        let original = Invoice {
+            id: invoice_id,
+            chain: ChainType::Polygon,
+            asset_id: "1".to_string(),
+            payment_address: "1".to_string(),
+            ..default_invoice()
+        };
+
+        registry
+            .add_invoice(
+                original
+                    .clone()
+                    .with_amount(Decimal::TEN),
+            )
+            .await;
+
+        // Refresh with updated invoice data; the tracked received amount must
+        // survive even though the caller passes zero
+        let updated = Invoice {
+            amount: Decimal::ONE_HUNDRED,
+            ..original
+        };
+        registry
+            .refresh_invoice(
+                updated
+                    .clone()
+                    .with_amount(Decimal::ZERO),
+            )
+            .await;
+
+        let stored = registry
+            .get_invoice(&invoice_id)
+            .await
+            .unwrap();
+        assert_eq!(stored.invoice, updated);
+        assert_eq!(
+            stored.total_received_amount,
+            Decimal::TEN
+        );
+
+        // Refreshing an untracked invoice inserts it as-is
+        let other_id = Uuid::new_v4();
+        let other = Invoice {
+            id: other_id,
+            ..default_invoice()
+        };
+        registry
+            .refresh_invoice(other.clone().with_amount(Decimal::ONE))
+            .await;
+
+        let stored = registry
+            .get_invoice(&other_id)
+            .await
+            .unwrap();
+        assert_eq!(stored.invoice, other);
+        assert_eq!(
+            stored.total_received_amount,
+            Decimal::ONE
+        );
+    }
 
     #[tokio::test]
     async fn test_invoice_registry() {

--- a/daemon/src/chain/invoice_registry.rs
+++ b/daemon/src/chain/invoice_registry.rs
@@ -92,8 +92,26 @@ impl InvoiceRegistry {
             .values()
             .find(|inv| {
                 inv.invoice.chain == chain
-                    && inv.invoice.payment_address == address
-                    && inv.invoice.asset_id == asset_id
+                    && match chain {
+                        // EVM hex addresses are case-insensitive (casing is
+                        // only a checksum), and restored invoices may store a
+                        // differently-cased address than the chain client
+                        // reports
+                        ChainType::Polygon => {
+                            inv.invoice
+                                .payment_address
+                                .eq_ignore_ascii_case(address)
+                                && inv
+                                    .invoice
+                                    .asset_id
+                                    .eq_ignore_ascii_case(asset_id)
+                        },
+                        // Base58/SS58 and numeric asset ids are case-sensitive
+                        ChainType::PolkadotAssetHub => {
+                            inv.invoice.payment_address == address
+                                && inv.invoice.asset_id == asset_id
+                        },
+                    }
             })
             .cloned()
     }
@@ -162,6 +180,67 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn test_find_invoice_by_address_is_case_insensitive_for_polygon() {
+        let registry = InvoiceRegistry::new();
+
+        // Restored invoices may store addresses as they were cased in an old
+        // config (e.g. all-lowercase)
+        let polygon_invoice = Invoice {
+            chain: ChainType::Polygon,
+            asset_id: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359".to_string(),
+            payment_address: "0x45f077823c8d036a1a9f7cd28e86bd98191df2b7".to_string(),
+            ..default_invoice()
+        }
+        .with_amount(Decimal::ZERO);
+
+        registry
+            .add_invoice(polygon_invoice.clone())
+            .await;
+
+        // The chain client reports checksummed addresses
+        let found = registry
+            .find_invoice_by_address(
+                "0x45f077823C8d036a1a9f7Cd28e86Bd98191dF2b7",
+                ChainType::Polygon,
+                "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+            )
+            .await;
+        assert_eq!(found, Some(polygon_invoice));
+
+        // Asset Hub addresses are base58 and stay case-sensitive
+        let hub_address = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+        let hub_invoice = Invoice {
+            chain: ChainType::PolkadotAssetHub,
+            asset_id: "1337".to_string(),
+            payment_address: hub_address.to_string(),
+            ..default_invoice()
+        }
+        .with_amount(Decimal::ZERO);
+
+        registry
+            .add_invoice(hub_invoice.clone())
+            .await;
+
+        let found = registry
+            .find_invoice_by_address(
+                hub_address,
+                ChainType::PolkadotAssetHub,
+                "1337",
+            )
+            .await;
+        assert_eq!(found, Some(hub_invoice));
+
+        let not_found = registry
+            .find_invoice_by_address(
+                hub_address.to_lowercase().as_str(),
+                ChainType::PolkadotAssetHub,
+                "1337",
+            )
+            .await;
+        assert_eq!(not_found, None);
+    }
 
     #[tokio::test]
     async fn test_refresh_invoice_preserves_received_amount() {

--- a/daemon/src/chain_client.rs
+++ b/daemon/src/chain_client.rs
@@ -218,6 +218,15 @@ impl<T: ChainConfig> AssetInfoStore<T> {
             .map(|(id, info)| (id.to_string(), info.name.clone()))
             .collect()
     }
+
+    pub async fn asset_decimals_map(&self) -> HashMap<String, u8> {
+        let assets = self.assets.read().await;
+
+        assets
+            .iter()
+            .map(|(id, info)| (id.to_string(), info.decimals))
+            .collect()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/daemon/src/chain_client/asset_hub.rs
+++ b/daemon/src/chain_client/asset_hub.rs
@@ -340,12 +340,18 @@ impl AssetHubClient {
             let event = match event {
                 Ok(event) => event,
                 Err(e) => {
-                    warn!(
+                    // subxt's event iterator is NOT resumable: on a decode
+                    // error it advances the cursor to the end, so every
+                    // subsequent `next()` yields `None`. Skipping this entry
+                    // would therefore silently discard the whole remainder of
+                    // the block, so stop and say so instead.
+                    tracing::error!(
                         block_number,
+                        decoded_transfers = transfers.len(),
                         error = ?e,
-                        "Failed to decode an event, an incoming transfer may have been missed; the balance checker will recover it"
+                        "Failed to decode an event; the rest of the block cannot be read and any further incoming transfers in it are missed — the balance checker must reconcile them"
                     );
-                    continue;
+                    break;
                 },
             };
 
@@ -377,7 +383,10 @@ impl AssetHubClient {
                 continue;
             };
 
-            let Ok(amount_units) = i64::try_from(transferred.amount) else {
+            // Convert through `i128`, not `i64`: `Decimal` holds a 96-bit
+            // mantissa, so an `i64` intermediate would needlessly reject
+            // amounts that are perfectly representable.
+            let Ok(amount_units) = i128::try_from(transferred.amount) else {
                 tracing::error!(
                     block_number,
                     asset_id = transferred.asset_id,
@@ -387,12 +396,15 @@ impl AssetHubClient {
                 continue;
             };
 
-            let Ok(amount) = Decimal::try_new(amount_units, asset_info.decimals.into()) else {
+            let Ok(amount) =
+                Decimal::try_from_i128_with_scale(amount_units, asset_info.decimals.into())
+            else {
                 tracing::error!(
                     block_number,
                     asset_id = transferred.asset_id,
+                    amount = transferred.amount,
                     decimals = asset_info.decimals,
-                    "Asset decimals exceed the supported range, skipping transfer"
+                    "Transfer amount or asset decimals exceed the range representable by Decimal, skipping transfer"
                 );
                 continue;
             };
@@ -578,11 +590,34 @@ impl BlockChainClient<AssetHubChainConfig> for AssetHubClient {
                 );
             })
             .map_err(|_e| QueryError::RpcRequestFailed)?
-            .map_or(Decimal::ZERO, |acc| {
-                // TODO: check acc.balance? Cast is quite unsafe
-                #[expect(clippy::cast_possible_truncation)]
-                Decimal::new(acc.balance as i64, decimals.into())
-            });
+            .map(|acc| {
+                // This balance drives the balance checker's reconciliation
+                // delta, so a wrapping cast here would fabricate a credit for
+                // the difference. Convert through `i128` — `Decimal` holds a
+                // 96-bit mantissa — and fail loudly if it still doesn't fit.
+                i128::try_from(acc.balance)
+                    .ok()
+                    .and_then(|balance| {
+                        Decimal::try_from_i128_with_scale(balance, decimals.into()).ok()
+                    })
+                    .ok_or_else(|| {
+                        tracing::error!(
+                            error.category = crate::utils::logging::category::CHAIN_CLIENT,
+                            error.operation = crate::utils::logging::operation::FETCH_BALANCE,
+                            asset_id = %asset_id,
+                            account = %account_id,
+                            balance = acc.balance,
+                            decimals,
+                            "On-chain balance is not representable as a Decimal"
+                        );
+
+                        QueryError::DecodeFailed {
+                            data_type: format!("balance of asset {asset_id}"),
+                        }
+                    })
+            })
+            .transpose()?
+            .unwrap_or(Decimal::ZERO);
 
         Ok(amount)
     }

--- a/daemon/src/chain_client/asset_hub.rs
+++ b/daemon/src/chain_client/asset_hub.rs
@@ -1,23 +1,16 @@
 use std::collections::HashMap;
 
-use futures::{
-    StreamExt,
-    stream,
-};
 use rust_decimal::prelude::{
     Decimal,
     ToPrimitive,
 };
-use subxt::blocks::{
-    Block,
-    ExtrinsicDetails,
-    FoundExtrinsic,
-};
+use subxt::blocks::Block;
 use subxt::config::{
     DefaultExtrinsicParams,
     DefaultExtrinsicParamsBuilder,
     ExtrinsicParams,
 };
+use subxt::events::Phase;
 use subxt::utils::H256;
 use subxt::{
     Config,
@@ -92,8 +85,6 @@ impl Config for SubxtAssetHubConfig {
 type SubxtAssetHubClient = subxt::OnlineClient<SubxtAssetHubConfig>;
 
 // Runtime type aliases for Asset Hub transfer operations
-type TransferExtrinsic = runtime::assets::calls::types::Transfer;
-type TransferAllExtrinsic = runtime::assets::calls::types::TransferAll;
 type TransferredEvent = runtime::assets::events::Transferred;
 
 // For unsigned and signed transaction types use wrappers to be able to compare
@@ -225,20 +216,6 @@ impl From<(u32, u32)> for GeneralTransactionId {
     }
 }
 
-enum AnyTransferExtrinsic {
-    Transfer(FoundExtrinsic<SubxtAssetHubConfig, SubxtAssetHubClient, TransferExtrinsic>),
-    TransferAll(FoundExtrinsic<SubxtAssetHubConfig, SubxtAssetHubClient, TransferAllExtrinsic>),
-}
-
-impl AnyTransferExtrinsic {
-    pub fn details(&self) -> &ExtrinsicDetails<SubxtAssetHubConfig, SubxtAssetHubClient> {
-        match self {
-            AnyTransferExtrinsic::Transfer(e) => &e.details,
-            AnyTransferExtrinsic::TransferAll(e) => &e.details,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct AssetHubClient {
     config: crate::configs::ChainConfig,
@@ -340,11 +317,15 @@ impl AssetHubClient {
             },
         };
 
-        // Get extrinsics
-        let extrinsics = match block.extrinsics().await {
-            Ok(e) => e,
+        // Scan block events directly instead of decoding specific transfer
+        // extrinsics: this catches every `assets.Transferred` event no matter
+        // which call emitted it (transfer, transfer_keep_alive, batch, proxy,
+        // ...) and lets us log decode failures instead of silently dropping
+        // them.
+        let events = match block.events().await {
+            Ok(events) => events,
             Err(e) => {
-                tracing::error!("Failed to fetch extrinsics for block {block_number}: {e}");
+                tracing::error!("Failed to fetch events for block {block_number}: {e}");
                 return Err(
                     SubscriptionError::BlockProcessingFailed {
                         block_number,
@@ -353,60 +334,79 @@ impl AssetHubClient {
             },
         };
 
-        // Find transfer and transfer_all extrinsics
-        // TODO: Handle errors in decoding extrinsics
-        let transfer_extrinsics = extrinsics
-            .find::<TransferExtrinsic>()
-            .filter_map(Result::ok)
-            .map(AnyTransferExtrinsic::Transfer);
+        let mut transfers = Vec::new();
 
-        let transfer_all_extrinsics = extrinsics
-            .find::<TransferAllExtrinsic>()
-            .filter_map(Result::ok)
-            .map(AnyTransferExtrinsic::TransferAll);
+        for event in events.iter() {
+            let event = match event {
+                Ok(event) => event,
+                Err(e) => {
+                    warn!(
+                        block_number,
+                        error = ?e,
+                        "Failed to decode an event, an incoming transfer may have been missed; the balance checker will recover it"
+                    );
+                    continue;
+                },
+            };
 
-        let all_transfer_extrinsics = transfer_extrinsics.chain(transfer_all_extrinsics);
+            let transferred = match event.as_event::<TransferredEvent>() {
+                Ok(Some(transferred)) => transferred,
+                Ok(None) => continue,
+                Err(e) => {
+                    warn!(
+                        block_number,
+                        error = ?e,
+                        "Failed to decode assets.Transferred event, an incoming transfer may have been missed; the balance checker will recover it"
+                    );
+                    continue;
+                },
+            };
 
-        let events = stream::iter(all_transfer_extrinsics)
-            .filter_map(|ext| async move {
-                let index = ext.details().index();
+            let Some(asset_info) = assets.get(&transferred.asset_id) else {
+                continue;
+            };
 
-                ext.details()
-                    .events()
-                    .await
-                    .ok()
-                    .map(|evs| (index, evs))
-            })
-            .collect::<Vec<_>>()
-            .await;
+            let Phase::ApplyExtrinsic(extrinsic_index) = event.phase() else {
+                // `Transferred` is only emitted by dispatched calls; anything
+                // else would leave us without a transaction id.
+                warn!(
+                    block_number,
+                    phase = ?event.phase(),
+                    "assets.Transferred event outside of an extrinsic, skipping"
+                );
+                continue;
+            };
 
-        let transfers = events
-            .into_iter()
-            .flat_map(|(index, events)| {
-                events
-                    .find::<TransferredEvent>()
-                    .filter_map(Result::ok)
-                    .filter_map(|event| {
-                        let asset_info = assets.get(&event.asset_id)?;
+            let Ok(amount_units) = i64::try_from(transferred.amount) else {
+                tracing::error!(
+                    block_number,
+                    asset_id = transferred.asset_id,
+                    amount = transferred.amount,
+                    "Transfer amount exceeds the supported range, skipping"
+                );
+                continue;
+            };
 
-                        Some(ChainTransfer {
-                            asset_id: event.asset_id,
-                            asset_name: asset_info.name.clone(),
-                            // TODO: check event.amount? Cast is quite unsafe
-                            #[expect(clippy::cast_possible_truncation)]
-                            amount: Decimal::new(
-                                event.amount as i64,
-                                asset_info.decimals.into(),
-                            ),
-                            sender: event.from,
-                            recipient: event.to,
-                            transaction_id: (block_number, index),
-                            timestamp,
-                        })
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect();
+            let Ok(amount) = Decimal::try_new(amount_units, asset_info.decimals.into()) else {
+                tracing::error!(
+                    block_number,
+                    asset_id = transferred.asset_id,
+                    decimals = asset_info.decimals,
+                    "Asset decimals exceed the supported range, skipping transfer"
+                );
+                continue;
+            };
+
+            transfers.push(ChainTransfer {
+                asset_id: transferred.asset_id,
+                asset_name: asset_info.name.clone(),
+                amount,
+                sender: transferred.from,
+                recipient: transferred.to,
+                transaction_id: (block_number, extrinsic_index),
+                timestamp,
+            });
+        }
 
         Ok(transfers)
     }

--- a/daemon/src/chain_client/errors.rs
+++ b/daemon/src/chain_client/errors.rs
@@ -48,7 +48,6 @@ pub enum QueryError {
     #[error("Storage query returned no data: {query_type}")]
     NotFound { query_type: String },
 
-    #[expect(dead_code)]
     /// Data decoding failed (SCALE or other format)
     #[error("Data decoding failed: {data_type}")]
     DecodeFailed { data_type: String },

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -86,6 +86,81 @@ use pimlico_client::{
 
 const WS_MESSAGES_TIMEOUT_DURATION: Duration = Duration::from_secs(10);
 
+/// A decoded Transfer event waiting to become `confirmations` blocks deep.
+struct PendingTransfer {
+    transaction_hash: TxHash,
+    log_index: u64,
+    transfer: ChainTransfer<PolygonChainConfig>,
+}
+
+/// Buffers Transfer events until they are buried under enough blocks, dropping
+/// entries whose logs are reorged away (`removed: true`) in the meantime.
+#[derive(Default)]
+struct ConfirmationBuffer {
+    pending: std::collections::BTreeMap<u64, Vec<PendingTransfer>>,
+}
+
+impl ConfirmationBuffer {
+    fn insert(
+        &mut self,
+        block_number: u64,
+        transaction_hash: TxHash,
+        log_index: u64,
+        transfer: ChainTransfer<PolygonChainConfig>,
+    ) {
+        self.pending
+            .entry(block_number)
+            .or_default()
+            .push(PendingTransfer {
+                transaction_hash,
+                log_index,
+                transfer,
+            });
+    }
+
+    /// Drops a reorged-away log from the buffer. Returns `false` if no matching
+    /// entry was pending — either it was never seen or it has already been
+    /// released past the confirmation depth.
+    fn remove(
+        &mut self,
+        transaction_hash: TxHash,
+        log_index: u64,
+    ) -> bool {
+        let mut removed = false;
+
+        self.pending.retain(|_, transfers| {
+            let len_before = transfers.len();
+            transfers.retain(|pending| {
+                !(pending.transaction_hash == transaction_hash && pending.log_index == log_index)
+            });
+            removed |= transfers.len() != len_before;
+            !transfers.is_empty()
+        });
+
+        removed
+    }
+
+    /// Releases every transfer that is at least `confirmations` blocks below
+    /// `latest_block`, in block order.
+    fn take_confirmed(
+        &mut self,
+        latest_block: u64,
+        confirmations: u64,
+    ) -> Vec<ChainTransfer<PolygonChainConfig>> {
+        let cutoff = latest_block.saturating_sub(confirmations);
+        let still_pending = self
+            .pending
+            .split_off(&cutoff.saturating_add(1));
+        let confirmed = std::mem::replace(&mut self.pending, still_pending);
+
+        confirmed
+            .into_values()
+            .flatten()
+            .map(|pending| pending.transfer)
+            .collect()
+    }
+}
+
 // ============================================================================
 // ERC-20 Interface Definition
 // ============================================================================
@@ -817,6 +892,7 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
             .event_signature(IERC20::Transfer::SIGNATURE_HASH);
 
         let client = self.clone();
+        let confirmations = self.config.confirmations;
 
         // Subscribe to logs
         let subscription = client
@@ -833,13 +909,34 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
             })
             .map_err(|_| SubscriptionError::SubscriptionFailed)?;
 
+        // Subscribe to new heads to know how deep pending transfers are buried
+        let blocks_subscription = client
+            .subscription_provider
+            .subscribe_blocks()
+            .await
+            .inspect_err(|e| {
+                tracing::debug!(
+                    error.category = CHAIN_CLIENT,
+                    error.operation = "subscribe_transfers",
+                    error.source = ?e,
+                    "Failed to subscribe to new heads"
+                );
+            })
+            .map_err(|_| SubscriptionError::SubscriptionFailed)?;
+
         tracing::info!(
             asset_count = asset_ids.len(),
+            confirmations,
             "Subscribed to ERC-20 Transfer events"
         );
 
         let stream = async_stream::try_stream! {
             let mut sub = subscription.into_stream();
+            let mut heads = blocks_subscription.into_stream();
+            // NOTE: pending (not yet confirmed) transfers are lost when the
+            // subscription is recreated; the balance checker is the safety net
+            // for transfers missed between subscriptions.
+            let mut buffer = ConfirmationBuffer::default();
 
             loop {
                 tokio::select! {
@@ -848,6 +945,35 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
                             tracing::warn!("Polygon subscription task received None, probably ws connection has been closed");
                             break
                         };
+
+                        let (Some(block_number), Some(transaction_hash), Some(log_index)) =
+                            (log.block_number, log.transaction_hash, log.log_index)
+                        else {
+                            tracing::warn!(
+                                ?log,
+                                "Transfer log without block number, transaction hash or log index, skipping"
+                            );
+                            continue
+                        };
+
+                        if log.removed {
+                            if buffer.remove(transaction_hash, log_index) {
+                                tracing::warn!(
+                                    %transaction_hash,
+                                    log_index,
+                                    block_number,
+                                    "Transfer log has been reorged away before reaching confirmation depth, dropped"
+                                );
+                            } else {
+                                tracing::error!(
+                                    %transaction_hash,
+                                    log_index,
+                                    block_number,
+                                    "Reorged Transfer log wasn't pending — a transfer released past the configured confirmation depth may have been reverted, manual reconciliation required"
+                                );
+                            }
+                            continue
+                        }
 
                         // Decode Transfer event from log
                         match log.log_decode::<IERC20::Transfer>() {
@@ -860,9 +986,10 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
                                             to = %transfer.recipient,
                                             amount = %transfer.amount,
                                             asset = %transfer.asset_name,
-                                            "Detected ERC-20 transfer"
+                                            block_number,
+                                            "Detected ERC-20 transfer, waiting for confirmations"
                                         );
-                                        yield vec![transfer];
+                                        buffer.insert(block_number, transaction_hash, log_index, transfer);
                                     },
                                     Err(e) => {
                                         tracing::warn!(
@@ -880,6 +1007,23 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
                                 );
                                 break
                             },
+                        }
+                    },
+                    head = heads.next() => {
+                        let Some(head) = head else {
+                            tracing::warn!("Polygon heads subscription received None, probably ws connection has been closed");
+                            break
+                        };
+
+                        let confirmed = buffer.take_confirmed(head.number, confirmations);
+
+                        if !confirmed.is_empty() {
+                            tracing::trace!(
+                                latest_block = head.number,
+                                transfers = confirmed.len(),
+                                "Releasing confirmed ERC-20 transfers"
+                            );
+                            yield confirmed;
                         }
                     },
                     () = tokio::time::sleep(WS_MESSAGES_TIMEOUT_DURATION) => {
@@ -1299,5 +1443,111 @@ mod tests {
         // Convert back
         let back = decimal_to_u256(decimal, 6);
         assert_eq!(back, value);
+    }
+
+    fn test_transfer(amount: u64) -> ChainTransfer<PolygonChainConfig> {
+        use alloy::primitives::address;
+
+        ChainTransfer {
+            asset_id: address!("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"),
+            asset_name: "USDC".to_string(),
+            amount: Decimal::new(amount.try_into().unwrap(), 6),
+            sender: address!("0x45f077823C8d036a1a9f7Cd28e86Bd98191dF2b7"),
+            recipient: address!("0x0E3Ca7fD040144900AdaA5f9B8917f3933A4F5e9"),
+            transaction_id: "0xdead".to_string(),
+            timestamp: 0,
+        }
+    }
+
+    #[test]
+    fn confirmation_buffer_releases_only_deep_enough_blocks() {
+        let mut buffer = ConfirmationBuffer::default();
+        let tx_a = TxHash::with_last_byte(1);
+        let tx_b = TxHash::with_last_byte(2);
+
+        buffer.insert(100, tx_a, 0, test_transfer(1));
+        buffer.insert(105, tx_b, 3, test_transfer(2));
+
+        // Head 111 with 12 confirmations: nothing is deep enough yet
+        assert!(
+            buffer
+                .take_confirmed(111, 12)
+                .is_empty()
+        );
+
+        // Head 112: block 100 is exactly 12 blocks deep
+        let released = buffer.take_confirmed(112, 12);
+        assert_eq!(released.len(), 1);
+        assert_eq!(released[0].amount, Decimal::new(1, 6));
+
+        // Head 117: block 105 becomes deep enough
+        let released = buffer.take_confirmed(117, 12);
+        assert_eq!(released.len(), 1);
+        assert_eq!(released[0].amount, Decimal::new(2, 6));
+
+        // Nothing left
+        assert!(
+            buffer
+                .take_confirmed(1000, 12)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn confirmation_buffer_zero_confirmations_releases_on_next_head() {
+        let mut buffer = ConfirmationBuffer::default();
+
+        buffer.insert(
+            100,
+            TxHash::with_last_byte(1),
+            0,
+            test_transfer(1),
+        );
+
+        let released = buffer.take_confirmed(100, 0);
+        assert_eq!(released.len(), 1);
+    }
+
+    #[test]
+    fn confirmation_buffer_removes_reorged_logs() {
+        let mut buffer = ConfirmationBuffer::default();
+        let tx_a = TxHash::with_last_byte(1);
+        let tx_b = TxHash::with_last_byte(2);
+
+        buffer.insert(100, tx_a, 0, test_transfer(1));
+        buffer.insert(100, tx_b, 1, test_transfer(2));
+
+        // Reorged log is dropped and never released
+        assert!(buffer.remove(tx_a, 0));
+        let released = buffer.take_confirmed(200, 12);
+        assert_eq!(released.len(), 1);
+        assert_eq!(released[0].amount, Decimal::new(2, 6));
+
+        // Removing an unknown (or already released) log reports false
+        assert!(!buffer.remove(tx_a, 0));
+        assert!(!buffer.remove(tx_b, 1));
+    }
+
+    #[test]
+    fn confirmation_buffer_releases_blocks_in_order() {
+        let mut buffer = ConfirmationBuffer::default();
+
+        buffer.insert(
+            105,
+            TxHash::with_last_byte(2),
+            0,
+            test_transfer(2),
+        );
+        buffer.insert(
+            100,
+            TxHash::with_last_byte(1),
+            0,
+            test_transfer(1),
+        );
+
+        let released = buffer.take_confirmed(200, 12);
+        assert_eq!(released.len(), 2);
+        assert_eq!(released[0].amount, Decimal::new(1, 6));
+        assert_eq!(released[1].amount, Decimal::new(2, 6));
     }
 }

--- a/daemon/src/clients/swaps.rs
+++ b/daemon/src/clients/swaps.rs
@@ -89,6 +89,8 @@ pub enum SwapsClientError {
     /// explanation, safe to surface to the payment UI.
     #[error("Swap provider rejected the request: {message}")]
     ProviderRejected { message: String },
+    #[error("Swap executor refused API access: {message}")]
+    ApiAccessError { message: String },
     #[error("Unknown API error")]
     UnknownApiError,
     #[error("No route available")]

--- a/daemon/src/clients/swaps/across/types.rs
+++ b/daemon/src/clients/swaps/across/types.rs
@@ -114,8 +114,14 @@ pub struct ApprovalTransaction {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SwapTransactionInternal {
-    // TODO: check if it's true? But also probably if it's false API should return us an error?
+    // Across simulates against the depositor's CURRENT state, so this is
+    // legitimately `false` before the user has granted approvals. We no longer
+    // act on it — the gas parameters decide whether a quote is usable (see
+    // `TryFrom` below) — but it must still never be *required*: Across's schema
+    // marks it optional and `/swap/gasless` omits it altogether, so a bare
+    // `bool` would fail the entire quote the first time it is absent.
     #[expect(dead_code)]
+    #[serde(default = "default_simulation_success")]
     pub simulation_success: bool,
     pub chain_id: u64,
     pub to: String,
@@ -133,6 +139,12 @@ pub struct SwapTransactionInternal {
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
     pub max_priority_fee_per_gas: Option<u128>,
+}
+
+fn default_simulation_success() -> bool {
+    // Only reached when Across omits the field entirely. The value is never
+    // read; it exists so an absent `simulationSuccess` doesn't fail the quote.
+    true
 }
 
 #[serde_as]

--- a/daemon/src/clients/swaps/bungee.rs
+++ b/daemon/src/clients/swaps/bungee.rs
@@ -201,7 +201,9 @@ pub fn default_bungee_raw_transaction() -> BungeeRawTransaction {
                     affiliate_fees: "0x".to_string(),
                     basic_req: BasicRequest {
                         bungee_gateway: "0x6dde7cf4e6a6f53f058bf5d2b4a54afbba11ee54".to_string(),
-                        chain_id: 137,
+                        chains: BungeeRequestChains::SingleChain {
+                            chain_id: 137,
+                        },
                         deadline: 1774897293,
                         input_amount: 1500000,
                         input_token: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f".to_string(),
@@ -1012,7 +1014,9 @@ mod tests {
                             basic_req: BasicRequest {
                                 bungee_gateway: "0x6dde7cf4e6a6f53f058bf5d2b4a54afbba11ee54"
                                     .to_string(),
-                                chain_id: 137,
+                                chains: BungeeRequestChains::SingleChain {
+                                    chain_id: 137,
+                                },
                                 deadline: 1774897293,
                                 input_amount: 1500000,
                                 input_token: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f"

--- a/daemon/src/clients/swaps/bungee/types.rs
+++ b/daemon/src/clients/swaps/bungee/types.rs
@@ -7,6 +7,7 @@ use serde::{
 };
 use serde_with::{
     DisplayFromStr,
+    PickFirst,
     TryFromInto,
     serde_as,
 };
@@ -56,23 +57,44 @@ impl From<CreateSwapData> for QuoteRequest {
     }
 }
 
+/// Chain reference inside a Bungee `basicReq`: single-chain quotes carry
+/// `chainId` while cross-chain quotes carry `originChainId` +
+/// `destinationChainId` instead. Untagged + flattened so both shapes
+/// round-trip with their exact field names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BungeeRequestChains {
+    SingleChain {
+        #[serde(rename = "chainId")]
+        chain_id: u64,
+    },
+    CrossChain {
+        #[serde(rename = "originChainId")]
+        origin_chain_id: u64,
+        #[serde(rename = "destinationChainId")]
+        destination_chain_id: u64,
+    },
+}
+
+// Bungee encodes numbers as strings in single-chain responses but as plain
+// JSON numbers in cross-chain ones (e.g. `deadline`). `PickFirst` accepts
+// both and serializes back as strings — matching the single-chain flow, the
+// only one the daemon re-submits today.
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BasicRequest {
     pub bungee_gateway: String,
-    // TODO: as long as we use it only for incoming swaps
-    // on the same chain it's fine, but actually it can return either
-    // `chain_id` or `originChainId` + `destinationChainId` for cross swaps
-    pub chain_id: u64,
-    #[serde_as(as = "DisplayFromStr")]
+    #[serde(flatten)]
+    pub chains: BungeeRequestChains,
+    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     pub deadline: i64,
-    #[serde_as(as = "DisplayFromStr")]
+    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     pub input_amount: u128,
     pub input_token: String,
-    #[serde_as(as = "DisplayFromStr")]
+    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     pub min_output_amount: u128,
-    #[serde_as(as = "DisplayFromStr")]
+    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     pub nonce: u64,
     pub output_token: String,
     pub receiver: String,
@@ -88,7 +110,7 @@ pub struct Witness {
     pub destination_payload: String,
     pub exclusive_transmitter: String,
     pub metadata: String,
-    #[serde_as(as = "DisplayFromStr")]
+    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     pub min_dest_gas: u128,
 }
 
@@ -96,7 +118,7 @@ pub struct Witness {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Permitted {
-    #[serde_as(as = "DisplayFromStr")]
+    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     pub amount: u128,
     pub token: String,
 }
@@ -105,9 +127,9 @@ pub struct Permitted {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SignQuoteDataValues {
-    #[serde_as(as = "DisplayFromStr")]
+    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     pub deadline: i64,
-    #[serde_as(as = "DisplayFromStr")]
+    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     pub nonce: u64,
     pub permitted: Permitted,
     pub spender: String,
@@ -312,4 +334,71 @@ impl From<BungeeSwapStatus> for ExecutorSwapStatus {
 pub struct GetSwapStatusResponse {
     #[serde_as(as = "TryFromInto<u8>")]
     pub bungee_status_code: BungeeSwapStatus,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_request_single_chain_roundtrip() {
+        let json = serde_json::json!({
+            "bungeeGateway": "0x3a23F943181408EAC424116Af7b7790c94Cb97a5",
+            "chainId": 137,
+            "deadline": "1770679043",
+            "inputAmount": "1000000",
+            "inputToken": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+            "minOutputAmount": "990000",
+            "nonce": "42",
+            "outputToken": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+            "receiver": "0x0E3Ca7fD040144900AdaA5f9B8917f3933A4F5e9",
+            "sender": "0x45f077823C8d036a1a9f7Cd28e86Bd98191dF2b7"
+        });
+
+        let request: BasicRequest = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(
+            request.chains,
+            BungeeRequestChains::SingleChain {
+                chain_id: 137
+            }
+        );
+        assert_eq!(request.deadline, 1_770_679_043);
+        assert_eq!(request.input_amount, 1_000_000);
+
+        // Re-serialization (used when submitting the signed witness back to
+        // Bungee) must reproduce the exact single-chain shape
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            json
+        );
+    }
+
+    #[test]
+    fn test_basic_request_cross_chain_deserializes() {
+        // Cross-chain quotes replace `chainId` with origin/destination and
+        // encode `deadline` as a plain number
+        let json = serde_json::json!({
+            "bungeeGateway": "0x3a23F943181408EAC424116Af7b7790c94Cb97a5",
+            "originChainId": 8453,
+            "destinationChainId": 137,
+            "deadline": 1770679043,
+            "inputAmount": "1000000",
+            "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "minOutputAmount": "990000",
+            "nonce": "42",
+            "outputToken": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+            "receiver": "0x0E3Ca7fD040144900AdaA5f9B8917f3933A4F5e9",
+            "sender": "0x45f077823C8d036a1a9f7Cd28e86Bd98191dF2b7"
+        });
+
+        let request: BasicRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            request.chains,
+            BungeeRequestChains::CrossChain {
+                origin_chain_id: 8453,
+                destination_chain_id: 137,
+            }
+        );
+        assert_eq!(request.deadline, 1_770_679_043);
+    }
 }

--- a/daemon/src/clients/swaps/zeroex.rs
+++ b/daemon/src/clients/swaps/zeroex.rs
@@ -329,6 +329,21 @@ fn into_zero_ex_result<T>(
             Err(SwapsClientError::NoLiquidity)
         },
         ZeroExResponse::Err(error) => Err(error.into_client_error(status)),
+        ZeroExResponse::GatewayErr(error) => Err(error.into()),
+    }
+}
+
+impl From<ZeroExGatewayError> for SwapsClientError {
+    fn from(value: ZeroExGatewayError) -> Self {
+        tracing::warn!(
+            message = %value.message,
+            request_id = ?value.request_id,
+            "0x gateway refused the request (invalid API key or rate limit)"
+        );
+
+        Self::ApiAccessError {
+            message: value.message,
+        }
     }
 }
 

--- a/daemon/src/clients/swaps/zeroex/types.rs
+++ b/daemon/src/clients/swaps/zeroex/types.rs
@@ -314,11 +314,61 @@ pub struct ZeroExNoLiquidityResponse {
     pub zid: String,
 }
 
+/// Gateway-level errors (HTTP 401 invalid API key, 429 rate limited) don't
+/// follow the business-error shape above — they only carry a message and a
+/// request id.
+#[derive(Debug, Deserialize)]
+pub struct ZeroExGatewayError {
+    pub message: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
+}
+
 // Order matters: untagged is first-successful-arm-wins in declaration order.
+// `GatewayErr` is last because it is the most permissive shape ({message} plus
+// an optional id): business errors also carry `message` and would otherwise be
+// swallowed by it.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ZeroExResponse<T> {
     Ok(T),
     NoLiquidity(ZeroExNoLiquidityResponse),
     Err(ZeroExErrorResponse),
+    GatewayErr(ZeroExGatewayError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_response_variants_deserialize_in_order() {
+        // 401/429 gateway shape (live-verified) lands in the dedicated
+        // variant instead of failing to match anything
+        let gateway: ZeroExResponse<GetTransactionStatusResponse> =
+            serde_json::from_str(r#"{"message":"Rate limit exceeded","request_id":"abc-123"}"#)
+                .unwrap();
+        assert!(matches!(
+            gateway,
+            ZeroExResponse::GatewayErr(ref e)
+                if e.message == "Rate limit exceeded"
+                    && e.request_id.as_deref() == Some("abc-123")
+        ));
+
+        // Business errors also contain `message` but must keep matching their
+        // own variant (arm order)
+        let business: ZeroExResponse<GetTransactionStatusResponse> = serde_json::from_str(
+            r#"{"name":"INSUFFICIENT_BALANCE","message":"nope","data":{"zid":"z"}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            business,
+            ZeroExResponse::Err(_)
+        ));
+
+        // Success payloads still win
+        let ok: ZeroExResponse<GetTransactionStatusResponse> =
+            serde_json::from_str(r#"{"status":"confirmed","zid":"z1"}"#).unwrap();
+        assert!(matches!(ok, ZeroExResponse::Ok(_)));
+    }
 }

--- a/daemon/src/configs/consts.rs
+++ b/daemon/src/configs/consts.rs
@@ -26,6 +26,11 @@ pub const DEFAULT_POLYGON_ENDPOINTS: &[&str] = &[
 /// Native USDC on Polygon PoS (Circle's official deployment)
 pub const DEFAULT_POLYGON_USDC_ADDRESS: &str = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
 
+/// How many blocks a Polygon transfer must stay on-chain before it's treated as
+/// received. Polygon PoS blocks are ~2s; 12 confirmations ≈ 24s, which covers
+/// ordinary reorgs and milestone finality lag.
+pub const DEFAULT_POLYGON_CONFIRMATIONS: u64 = 12;
+
 pub const DEFAULT_UNDERPAYMENT_TOLERANCE: Decimal = dec!(0.1);
 
 pub const DEFAULT_OVERPAYMENT_TOLERANCE: Decimal = dec!(0.1);

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -74,6 +74,16 @@ fn default_confirmations() -> u64 {
     DEFAULT_POLYGON_CONFIRMATIONS
 }
 
+/// Normalize an EVM address to its EIP-55 checksummed form. Chain clients
+/// report addresses in this form, so configured addresses must match it
+/// byte-for-byte to be comparable as strings.
+fn checksummed_evm_address(address: &str) -> Result<String, String> {
+    address
+        .parse::<alloy::primitives::Address>()
+        .map(|addr| addr.to_checksum(None))
+        .map_err(|_| format!("Invalid EVM asset address: {address}"))
+}
+
 // TODO: add some docs for fields, their purpose might be not obvious
 #[derive(Deserialize, Clone, Debug)]
 pub struct ChainConfig {
@@ -189,11 +199,51 @@ impl ChainsConfig {
                 .unwrap();
 
             for asset_id in asset_ids {
+                // Old invoices may store the address as it was cased in the
+                // config back then; canonicalize so it doesn't duplicate the
+                // configured entry
+                let asset_id = if chain_type == ChainType::Polygon {
+                    match checksummed_evm_address(&asset_id) {
+                        Ok(canonical) => canonical,
+                        Err(error) => {
+                            tracing::warn!(
+                                %asset_id,
+                                %error,
+                                "Restored asset id is not a valid EVM address, keeping it as-is"
+                            );
+                            asset_id
+                        },
+                    }
+                } else {
+                    asset_id
+                };
+
                 if !chain_config.assets.contains(&asset_id) {
                     chain_config.assets.push(asset_id);
                 }
             }
         }
+    }
+
+    /// Canonicalize configured EVM asset addresses to their checksummed form
+    /// so a differently-cased config entry still matches addresses reported
+    /// by the chain clients.
+    pub fn canonicalize_evm_asset_ids(&mut self) -> Result<(), String> {
+        let Some(chain_config) = self.chains.get_mut(&ChainType::Polygon) else {
+            return Ok(());
+        };
+
+        for asset_id in &mut chain_config.assets {
+            *asset_id = checksummed_evm_address(asset_id)?;
+        }
+
+        // Canonicalization can collapse entries that differed only in casing
+        let mut seen = HashSet::new();
+        chain_config
+            .assets
+            .retain(|asset_id| seen.insert(asset_id.clone()));
+
+        Ok(())
     }
 
     pub(super) fn set_default_chains_if_missing(&mut self) {
@@ -341,6 +391,37 @@ impl PaymentsConfig {
         Ok(())
     }
 
+    /// Canonicalize configured EVM asset addresses (default asset and
+    /// slippage keys) to their checksummed form so lookups by chain-reported
+    /// addresses match regardless of how the config file cased them.
+    pub fn canonicalize_evm_asset_ids(&mut self) -> Result<(), String> {
+        if let Some(asset_id) = self
+            .default_asset_id
+            .get_mut(&ChainType::Polygon)
+        {
+            *asset_id = checksummed_evm_address(asset_id)?;
+        }
+
+        if let Some(params) = self
+            .slippage_params
+            .remove(&ChainType::Polygon)
+        {
+            let mut canonical = HashMap::with_capacity(params.len());
+
+            for (asset_id, slippage) in params {
+                canonical.insert(
+                    checksummed_evm_address(&asset_id)?,
+                    slippage,
+                );
+            }
+
+            self.slippage_params
+                .insert(ChainType::Polygon, canonical);
+        }
+
+        Ok(())
+    }
+
     pub fn get_asset_slippage_params(
         &self,
         chain: ChainType,
@@ -348,7 +429,21 @@ impl PaymentsConfig {
     ) -> SlippageParams {
         self.slippage_params
             .get(&chain)
-            .and_then(|map| map.get(asset_id).copied())
+            .and_then(|map| {
+                map.get(asset_id).or_else(|| {
+                    // EVM hex addresses are case-insensitive (casing is only
+                    // a checksum) and invoices restored from older databases
+                    // may carry a differently-cased asset id
+                    (chain == ChainType::Polygon)
+                        .then(|| {
+                            map.iter()
+                                .find(|(key, _)| key.eq_ignore_ascii_case(asset_id))
+                                .map(|(_, params)| params)
+                        })
+                        .flatten()
+                })
+            })
+            .copied()
             .unwrap_or_default()
     }
 
@@ -368,6 +463,105 @@ impl PaymentsConfig {
     ) -> Decimal {
         self.get_asset_slippage_params(chain, asset_id)
             .overpayment_tolerance
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const USDC_LOWER: &str = "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359";
+    const USDC_CHECKSUMMED: &str = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
+    const USDT_LOWER: &str = "0xc2132d05d31c914a87c6611c10748aeb04b58e8f";
+    const USDT_CHECKSUMMED: &str = "0xc2132D05D31c914a87C6611C10748AEb04B58e8F";
+
+    #[test]
+    fn test_canonicalize_payments_evm_asset_ids() {
+        let slippage = SlippageParams {
+            underpayment_tolerance: Decimal::new(5, 1),
+            overpayment_tolerance: Decimal::ZERO,
+        };
+
+        let mut config = PaymentsConfig {
+            recipient: HashMap::new(),
+            invoice_lifetime_millis: 1,
+            default_chain: ChainType::Polygon,
+            default_asset_id: HashMap::from([
+                (
+                    ChainType::Polygon,
+                    USDC_LOWER.to_string(),
+                ),
+                (
+                    ChainType::PolkadotAssetHub,
+                    "1337".to_string(),
+                ),
+            ]),
+            payment_url_base: String::new(),
+            slippage_params: HashMap::from([(
+                ChainType::Polygon,
+                HashMap::from([(USDT_LOWER.to_string(), slippage)]),
+            )]),
+        };
+
+        config
+            .canonicalize_evm_asset_ids()
+            .unwrap();
+
+        assert_eq!(
+            config.default_asset_id[&ChainType::Polygon],
+            USDC_CHECKSUMMED
+        );
+        // Non-EVM chains are untouched
+        assert_eq!(
+            config.default_asset_id[&ChainType::PolkadotAssetHub],
+            "1337"
+        );
+        assert!(config.slippage_params[&ChainType::Polygon].contains_key(USDT_CHECKSUMMED));
+
+        // Lookups keep working for historic lowercase asset ids
+        let found = config.get_asset_slippage_params(ChainType::Polygon, USDT_LOWER);
+        assert_eq!(
+            found.underpayment_tolerance,
+            slippage.underpayment_tolerance
+        );
+
+        // Invalid EVM addresses are rejected
+        config.default_asset_id.insert(
+            ChainType::Polygon,
+            "not-an-address".to_string(),
+        );
+        assert!(
+            config
+                .canonicalize_evm_asset_ids()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_canonicalize_chains_evm_asset_ids() {
+        let mut config = ChainsConfig {
+            chains: HashMap::from([(
+                ChainType::Polygon,
+                ChainConfig {
+                    // The same asset cased two ways plus another asset
+                    assets: vec![
+                        USDC_LOWER.to_string(),
+                        USDC_CHECKSUMMED.to_string(),
+                        USDT_LOWER.to_string(),
+                    ],
+                    ..Default::default()
+                },
+            )]),
+        };
+
+        config
+            .canonicalize_evm_asset_ids()
+            .unwrap();
+
+        assert_eq!(
+            config.chains[&ChainType::Polygon].assets,
+            vec![USDC_CHECKSUMMED.to_string(), USDT_CHECKSUMMED.to_string(),]
+        );
     }
 }
 

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -33,6 +33,7 @@ use super::consts::{
     DEFAULT_LOG_DIRECTIVES,
     DEFAULT_OVERPAYMENT_TOLERANCE,
     DEFAULT_POLKADOT_ASSET_HUB_ENDPOINTS,
+    DEFAULT_POLYGON_CONFIRMATIONS,
     DEFAULT_POLYGON_ENDPOINTS,
     DEFAULT_POLYGON_USDC_ADDRESS,
     DEFAULT_PORT,
@@ -69,8 +70,12 @@ pub enum ChainEndpoint {
     },
 }
 
+fn default_confirmations() -> u64 {
+    DEFAULT_POLYGON_CONFIRMATIONS
+}
+
 // TODO: add some docs for fields, their purpose might be not obvious
-#[derive(Deserialize, Clone, Debug, Default)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct ChainConfig {
     /// RPC endpoints for the chain node. Can be left empty to use defaults.
     #[serde(default)]
@@ -85,6 +90,23 @@ pub struct ChainConfig {
     /// Allow endpoints which starts from `http://` and `ws://` instead of `https://` and `wss://`
     #[serde(default = "default_allow_insecure_endpoints")]
     pub allow_insecure_endpoints: bool,
+    /// How many blocks an incoming transfer must stay on-chain before it's
+    /// treated as received. Only used for chains with probabilistic finality
+    /// (Polygon); Asset Hub tracks finalized blocks and ignores this. Set to 0
+    /// to act on transfers as soon as the next block arrives.
+    #[serde(default = "default_confirmations")]
+    pub confirmations: u64,
+}
+
+impl Default for ChainConfig {
+    fn default() -> Self {
+        Self {
+            endpoints: Vec::new(),
+            assets: Vec::new(),
+            allow_insecure_endpoints: DEFAULT_ALLOW_INSECURE_ENDPOINTS,
+            confirmations: DEFAULT_POLYGON_CONFIRMATIONS,
+        }
+    }
 }
 
 impl ChainConfig {

--- a/daemon/src/dao/interface.rs
+++ b/daemon/src/dao/interface.rs
@@ -328,6 +328,12 @@ pub trait DaoInterface: Send + Sync + 'static {
         transaction_hash: String,
     ) -> Result<Swap, DaoSwapError>;
 
+    async fn update_swap_transaction_hash(
+        &self,
+        swap_id: Uuid,
+        transaction_hash: String,
+    ) -> Result<Swap, DaoSwapError>;
+
     async fn update_swap_completed(
         &self,
         swap_id: Uuid,
@@ -976,6 +982,14 @@ impl DaoInterface for DAO {
         transaction_hash: String,
     ) -> Result<Swap, DaoSwapError> {
         DaoSwapMethods::update_swap_submitted_with_hash(self, swap_id, transaction_hash).await
+    }
+
+    async fn update_swap_transaction_hash(
+        &self,
+        swap_id: Uuid,
+        transaction_hash: String,
+    ) -> Result<Swap, DaoSwapError> {
+        DaoSwapMethods::update_swap_transaction_hash(self, swap_id, transaction_hash).await
     }
 
     async fn update_swap_completed(

--- a/daemon/src/dao/swap.rs
+++ b/daemon/src/dao/swap.rs
@@ -574,6 +574,47 @@ pub trait DaoSwapMethods: DaoExecutor + 'static {
             })
     }
 
+    /// Attach the executor-side transaction hash to a swap without touching
+    /// its status. Used after an external submission when the swap has
+    /// already been marked `Submitted` (and may have been picked up by the
+    /// tracker and moved to `Pending` in the meantime).
+    async fn update_swap_transaction_hash(
+        &self,
+        swap_id: Uuid,
+        transaction_hash: String,
+    ) -> Result<Swap, DaoSwapError> {
+        let query = sqlx::query_as::<_, SwapRow>(
+            "UPDATE swaps
+            SET swap_details = json_set(
+                    swap_details,
+                    '$.transaction_hash', ?
+                )
+            WHERE id = ?
+            RETURNING *",
+        )
+        .bind(transaction_hash)
+        .bind(swap_id);
+
+        self.fetch_one(query)
+            .await
+            .map_err(|e| {
+                tracing::debug!(
+                    error.category = "dao.swap",
+                    error.operation = "update_swap_transaction_hash",
+                    %swap_id,
+                    error.source = ?e,
+                    "Failed to update swap transaction hash"
+                );
+
+                match e {
+                    sqlx::Error::RowNotFound => DaoSwapError::NotFound {
+                        swap_id,
+                    },
+                    _ => DaoSwapError::DatabaseError,
+                }
+            })
+    }
+
     async fn update_swap_completed(
         &self,
         swap_id: Uuid,
@@ -989,6 +1030,53 @@ mod tests {
             result,
             DaoSwapError::InvoiceNotFound {
                 invoice_id
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_swap_transaction_hash_preserves_status() {
+        let dao = create_test_dao().await;
+
+        let invoice = default_create_invoice_data();
+        let invoice_id = invoice.id;
+        dao.create_invoice(invoice)
+            .await
+            .unwrap();
+
+        let swap = default_swap(invoice_id);
+        let swap_id = swap.id;
+        dao.create_swap(swap).await.unwrap();
+
+        // Simulate the executor flow: the swap is marked submitted before the
+        // external call...
+        dao.update_swap_submitted(swap_id)
+            .await
+            .unwrap();
+        // ...the tracker may pick it up in the meantime (Submitted → Pending)...
+        dao.get_submitted_swaps().await.unwrap();
+
+        // ...and the transaction hash lands afterwards without a status
+        // transition (Pending → Submitted would violate the trigger)
+        let updated = dao
+            .update_swap_transaction_hash(swap_id, "hash123".to_string())
+            .await
+            .unwrap();
+        assert_eq!(updated.status, SwapStatus::Pending);
+        assert_eq!(
+            updated.swap_details.transaction_hash,
+            Some("hash123".to_string())
+        );
+
+        let missing = Uuid::new_v4();
+        let err = dao
+            .update_swap_transaction_hash(missing, "hash".to_string())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err,
+            DaoSwapError::NotFound {
+                swap_id: missing
             }
         );
     }

--- a/daemon/src/etherscan_client.rs
+++ b/daemon/src/etherscan_client.rs
@@ -152,6 +152,7 @@ impl EtherscanClient {
             .filter_map(|trans| {
                 (trans.to.to_lowercase() == address.to_lowercase())
                     .then(|| trans.into_incoming_transaction(invoice_id))
+                    .flatten()
             })
             .collect();
 

--- a/daemon/src/etherscan_client/types.rs
+++ b/daemon/src/etherscan_client/types.rs
@@ -83,16 +83,37 @@ pub struct EtherscanTransaction {
 }
 
 impl EtherscanTransaction {
-    #[expect(clippy::cast_possible_truncation)]
+    /// Returns `None` (with an error log) when the reported value or token
+    /// decimals don't fit into `Decimal`: recording a wrapped amount would
+    /// corrupt the invoice, while skipping keeps the balance mismatch
+    /// visible to the balance checker.
     pub fn into_incoming_transaction(
         self,
         invoice_id: Uuid,
-    ) -> IncomingTransaction {
+    ) -> Option<IncomingTransaction> {
+        let Ok(value) = i64::try_from(self.value) else {
+            tracing::error!(
+                tx_hash = %self.hash,
+                value = self.value,
+                "Transfer value exceeds the supported range, skipping transaction"
+            );
+            return None;
+        };
+
+        let Ok(amount) = Decimal::try_new(value, self.token_decimal) else {
+            tracing::error!(
+                tx_hash = %self.hash,
+                token_decimal = self.token_decimal,
+                "Token decimals exceed the supported range, skipping transaction"
+            );
+            return None;
+        };
+
         let transfer_info = TransferInfo {
             chain: ChainType::Polygon,
             asset_id: self.contract_address,
             asset_name: self.token_symbol,
-            amount: Decimal::new(self.value as i64, self.token_decimal),
+            amount,
             source_address: self.from,
             destination_address: self.to,
         };
@@ -103,11 +124,73 @@ impl EtherscanTransaction {
             tx_hash: Some(self.hash),
         };
 
-        IncomingTransaction {
+        Some(IncomingTransaction {
             id: Uuid::new_v4(),
             invoice_id,
             transfer_info,
             transaction_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transaction(
+        value: u128,
+        token_decimal: u32,
+    ) -> EtherscanTransaction {
+        EtherscanTransaction {
+            block_number: 100,
+            hash: "0xdead".to_string(),
+            from: "0xfrom".to_string(),
+            contract_address: "0xtoken".to_string(),
+            to: "0xto".to_string(),
+            value,
+            token_symbol: "USDC".to_string(),
+            token_decimal,
+            transaction_index: 2,
         }
+    }
+
+    #[test]
+    fn test_into_incoming_transaction() {
+        let invoice_id = Uuid::new_v4();
+        let result = transaction(1_500_000, 6)
+            .into_incoming_transaction(invoice_id)
+            .unwrap();
+
+        assert_eq!(
+            result.transfer_info.amount,
+            Decimal::new(15, 1)
+        );
+        assert_eq!(result.invoice_id, invoice_id);
+        assert_eq!(
+            result.transaction_id.tx_hash,
+            Some("0xdead".to_string())
+        );
+    }
+
+    #[test]
+    fn test_into_incoming_transaction_rejects_oversized_value() {
+        // Above i64::MAX base units: the old `as i64` cast silently wrapped
+        let oversized = u128::try_from(i64::MAX).unwrap() + 1;
+        assert!(
+            transaction(oversized, 6)
+                .into_incoming_transaction(Uuid::new_v4())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_into_incoming_transaction_rejects_oversized_decimals() {
+        // Decimal supports at most 28 decimal places; the old Decimal::new
+        // panicked here
+        assert!(
+            transaction(1_000_000, 77)
+                .into_incoming_transaction(Uuid::new_v4())
+                .is_none()
+        );
     }
 }

--- a/daemon/src/etherscan_client/types.rs
+++ b/daemon/src/etherscan_client/types.rs
@@ -91,7 +91,10 @@ impl EtherscanTransaction {
         self,
         invoice_id: Uuid,
     ) -> Option<IncomingTransaction> {
-        let Ok(value) = i64::try_from(self.value) else {
+        // Convert through `i128`, not `i64`: `Decimal` holds a 96-bit mantissa,
+        // so an `i64` intermediate would cap an 18-decimal token at ~9.22
+        // tokens and silently skip everything above it.
+        let Ok(value) = i128::try_from(self.value) else {
             tracing::error!(
                 tx_hash = %self.hash,
                 value = self.value,
@@ -100,11 +103,12 @@ impl EtherscanTransaction {
             return None;
         };
 
-        let Ok(amount) = Decimal::try_new(value, self.token_decimal) else {
+        let Ok(amount) = Decimal::try_from_i128_with_scale(value, self.token_decimal) else {
             tracing::error!(
                 tx_hash = %self.hash,
+                value = self.value,
                 token_decimal = self.token_decimal,
-                "Token decimals exceed the supported range, skipping transaction"
+                "Transfer value or token decimals exceed the range representable by Decimal, skipping transaction"
             );
             return None;
         };
@@ -173,9 +177,28 @@ mod tests {
     }
 
     #[test]
+    fn test_into_incoming_transaction_accepts_large_18_decimal_transfer() {
+        // 10 tokens of an 18-decimal asset is 1e19 base units — above
+        // `i64::MAX`, so an `i64` intermediate would drop it, but well within
+        // Decimal's 96-bit mantissa
+        let ten_tokens = 10_000_000_000_000_000_000_u128;
+        assert!(ten_tokens > u128::try_from(i64::MAX).unwrap());
+
+        let result = transaction(ten_tokens, 18)
+            .into_incoming_transaction(Uuid::new_v4())
+            .expect("an 18-decimal transfer above i64::MAX must still be recorded");
+
+        assert_eq!(
+            result.transfer_info.amount,
+            Decimal::from(10)
+        );
+    }
+
+    #[test]
     fn test_into_incoming_transaction_rejects_oversized_value() {
-        // Above i64::MAX base units: the old `as i64` cast silently wrapped
-        let oversized = u128::try_from(i64::MAX).unwrap() + 1;
+        // Decimal's mantissa is 96 bits; anything above 2^96-1 base units is
+        // genuinely unrepresentable and must be skipped rather than wrapped
+        let oversized = (1_u128 << 96) + 1;
         assert!(
             transaction(oversized, 6)
                 .into_incoming_transaction(Uuid::new_v4())

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -315,6 +315,25 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
             .await,
     );
 
+    // Collect asset decimals per chain (used to convert invoice amounts to
+    // smallest units for swaps)
+    let asset_decimals_map = HashMap::from([
+        (
+            ChainType::PolkadotAssetHub,
+            asset_hub_client
+                .asset_info_store()
+                .asset_decimals_map()
+                .await,
+        ),
+        (
+            ChainType::Polygon,
+            polygon_client
+                .asset_info_store()
+                .asset_decimals_map()
+                .await,
+        ),
+    ]);
+
     let keyring = Keyring::new(secrets_config.seed);
     // Please don't keep keyring_client in this scope, it must be moved in order to
     // keep graceful shutdown working.
@@ -411,6 +430,7 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
         invoice_registry,
         swaps_executor,
         asset_names_map,
+        asset_decimals_map,
         payments_config,
         shop_config,
         secrets_config.api_secret_key,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -185,6 +185,22 @@ fn validate_and_extend_configs(
         .validate_recipients(&required_recipients)
         .map_err(|_| Error::Fatal)?;
 
+    // Canonicalize EVM asset addresses before any comparisons/merges: chain
+    // clients report checksummed addresses, and a differently-cased config
+    // entry would never match them
+    payments_config
+        .canonicalize_evm_asset_ids()
+        .map_err(|error| {
+            tracing::error!(%error, "Invalid EVM asset address in payments config");
+            Error::Fatal
+        })?;
+    chains_config
+        .canonicalize_evm_asset_ids()
+        .map_err(|error| {
+            tracing::error!(%error, "Invalid EVM asset address in chains config");
+            Error::Fatal
+        })?;
+
     // Extend chains config with default and restored asset IDs
     chains_config.add_default_asset_ids(&payments_config.default_asset_id);
     chains_config.add_restored_asset_ids(restored_asset_ids);

--- a/daemon/src/state.rs
+++ b/daemon/src/state.rs
@@ -320,6 +320,13 @@ impl<D: DaoInterface> AppState<D> {
         // We allow to update only unpaid invoices, so the received amount is zero
         let result = result.with_amount(Decimal::ZERO);
 
+        // Payment detection matches against the in-memory registry, so the
+        // updated amount/expiry must be visible there too, not only in the
+        // database.
+        self.registry
+            .refresh_invoice(result.clone())
+            .await;
+
         Ok(result)
     }
 

--- a/daemon/src/state.rs
+++ b/daemon/src/state.rs
@@ -91,6 +91,7 @@ pub struct AppState<D: DaoInterface = DAO> {
     swaps_executor: SwapsExecutor<D>,
     github_client: GithubClient,
     asset_names_map: HashMap<String, String>,
+    asset_decimals_map: HashMap<ChainType, HashMap<String, u8>>,
     payments_config: PaymentsConfig,
     shop_config: ShopConfig,
     api_secret_key: SecretString,
@@ -104,6 +105,7 @@ impl<D: DaoInterface> AppState<D> {
         registry: InvoiceRegistry,
         swaps_executor: SwapsExecutor<D>,
         asset_names_map: HashMap<String, String>,
+        asset_decimals_map: HashMap<ChainType, HashMap<String, u8>>,
         payments_config: PaymentsConfig,
         shop_config: ShopConfig,
         api_secret_key: SecretString,
@@ -117,6 +119,7 @@ impl<D: DaoInterface> AppState<D> {
             swaps_executor,
             github_client,
             asset_names_map,
+            asset_decimals_map,
             payments_config,
             shop_config,
             api_secret_key,
@@ -900,6 +903,11 @@ mod tests {
             (1984.to_string(), "USDt".to_string()),
         ]);
 
+        let asset_decimals_map = HashMap::from([(
+            ChainType::PolkadotAssetHub,
+            HashMap::from([(1337.to_string(), 6), (1984.to_string(), 6)]),
+        )]);
+
         let config = PaymentsConfig {
             default_chain: ChainType::PolkadotAssetHub,
             default_asset_id: HashMap::from([(
@@ -942,6 +950,7 @@ mod tests {
             registry,
             swaps_executor,
             asset_names_map,
+            asset_decimals_map,
             config,
             shop_config,
             SecretString::from("secret"),

--- a/daemon/src/state/swaps.rs
+++ b/daemon/src/state/swaps.rs
@@ -37,6 +37,8 @@ pub enum SwapRequestError {
     ProviderRejected { message: String },
     #[error("Failed to get quotes for swap")]
     QuoteRequestFailed,
+    #[error("Asset metadata unavailable for asset {asset_id}")]
+    AssetMetadataUnavailable { asset_id: String },
     #[error("Database error")]
     DatabaseError,
 }
@@ -84,7 +86,10 @@ impl ApiErrorExt for SwapRequestError {
                 ..
             }
             | SwapRequestError::QuoteRequestFailed => "SWAP_ERROR",
-            SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
+            SwapRequestError::AssetMetadataUnavailable {
+                ..
+            }
+            | SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
         }
     }
 
@@ -106,7 +111,10 @@ impl ApiErrorExt for SwapRequestError {
                 ..
             } => "SWAP_PROVIDER_REJECTED",
             SwapRequestError::QuoteRequestFailed => "QUOTE_REQUEST_FAILED",
-            SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
+            SwapRequestError::AssetMetadataUnavailable {
+                ..
+            }
+            | SwapRequestError::DatabaseError => "INTERNAL_SERVER_ERROR",
         }
     }
 
@@ -127,9 +135,11 @@ impl ApiErrorExt for SwapRequestError {
             SwapRequestError::ProviderRejected {
                 ..
             } => reqwest::StatusCode::UNPROCESSABLE_ENTITY,
-            SwapRequestError::QuoteRequestFailed | SwapRequestError::DatabaseError => {
-                reqwest::StatusCode::INTERNAL_SERVER_ERROR
-            },
+            SwapRequestError::QuoteRequestFailed
+            | SwapRequestError::AssetMetadataUnavailable {
+                ..
+            }
+            | SwapRequestError::DatabaseError => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
@@ -151,6 +161,11 @@ impl ApiErrorExt for SwapRequestError {
                 message,
             } => message,
             SwapRequestError::QuoteRequestFailed => "Failed to get a quote from the swap provider.",
+            // The asset id is deliberately not surfaced: it's our own
+            // configuration/chain-metadata state, not something the caller can act on.
+            SwapRequestError::AssetMetadataUnavailable {
+                ..
+            } => "The swap could not be prepared: asset metadata is unavailable.",
             SwapRequestError::DatabaseError => "A database error occurred.",
         }
     }
@@ -213,8 +228,38 @@ impl<D: DaoInterface> AppState<D> {
         let expected_to_amount_units = if let Some(units) = params.expected_to_amount_units {
             units
         } else {
-            // TODO: get real decimals for the asset
-            (invoice.unfilled_amount() / Decimal::new(1, 6))
+            // Convert the unfilled amount into the destination token's
+            // smallest units using its real on-chain decimals; assuming 6
+            // underpays or overpays for any other precision.
+            let decimals = self
+                .asset_decimals_map
+                .get(&default_chain)
+                .and_then(|assets| assets.get(&to_token_address))
+                .copied()
+                .ok_or_else(|| {
+                    tracing::error!(
+                        chain = %default_chain,
+                        asset_id = %to_token_address,
+                        "Destination asset decimals are not known, can't calculate swap target amount"
+                    );
+                    SwapRequestError::AssetMetadataUnavailable {
+                        asset_id: to_token_address.clone(),
+                    }
+                })?;
+
+            let one_unit = Decimal::try_new(1, decimals.into()).map_err(|_| {
+                tracing::error!(
+                    chain = %default_chain,
+                    asset_id = %to_token_address,
+                    decimals,
+                    "Destination asset decimals exceed the supported range"
+                );
+                SwapRequestError::AssetMetadataUnavailable {
+                    asset_id: to_token_address.clone(),
+                }
+            })?;
+
+            (invoice.unfilled_amount() / one_unit)
                 .to_u128()
                 // TODO: change error
                 .ok_or(SwapRequestError::DatabaseError)?
@@ -298,6 +343,26 @@ impl<D: DaoInterface> AppState<D> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use secrecy::SecretString;
+
+    use crate::chain::InvoiceRegistry;
+    use crate::chain_client::KeyringClient;
+    use crate::configs::{
+        PaymentsConfig,
+        ShopConfig,
+        ShopMetaConfig,
+    };
+    use crate::dao::MockDaoInterface;
+    use crate::swaps::SwapsExecutor;
+    use crate::types::{
+        ChainType,
+        DetectedShopPlatform,
+        default_invoice,
+        default_swap,
+    };
+
     use super::*;
 
     #[test]
@@ -383,5 +448,128 @@ mod tests {
             error.http_status_code(),
             reqwest::StatusCode::BAD_REQUEST
         );
+    }
+
+    const POLYGON_USDC: &str = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
+
+    fn app_state_with_decimals(
+        asset_decimals_map: HashMap<ChainType, HashMap<String, u8>>
+    ) -> AppState<MockDaoInterface> {
+        let payments_config = PaymentsConfig {
+            default_chain: ChainType::Polygon,
+            default_asset_id: HashMap::from([(
+                ChainType::Polygon,
+                POLYGON_USDC.to_string(),
+            )]),
+            invoice_lifetime_millis: 600_000,
+            recipient: HashMap::from([(
+                ChainType::Polygon,
+                "0x45f077823C8d036a1a9f7Cd28e86Bd98191dF2b7".to_string(),
+            )]),
+            payment_url_base: "https://payments.example.com".to_string(),
+            slippage_params: HashMap::new(),
+        };
+
+        let shop_config = ShopConfig {
+            invoices_webhook_url: None,
+            signature_max_age_secs: 300,
+            private_api_base_url: None,
+            meta: ShopMetaConfig {
+                shop_name: "Mega shop".to_string(),
+                shop_url: "mega.shop".to_string(),
+                logo_url: None,
+                reown_project_id: "test".to_string(),
+                ankr_api_token: None,
+            },
+            shop_platform: DetectedShopPlatform::Unknown,
+        };
+
+        AppState::new(
+            KeyringClient::default(),
+            MockDaoInterface::default(),
+            InvoiceRegistry::new(),
+            SwapsExecutor::default(),
+            HashMap::new(),
+            asset_decimals_map,
+            payments_config,
+            shop_config,
+            SecretString::from("secret"),
+        )
+    }
+
+    fn create_swap_params(invoice_id: Uuid) -> CreateSwapParams {
+        CreateSwapParams {
+            invoice_id,
+            // Base
+            from_chain_id: 8453,
+            from_asset_id: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string(),
+            from_address: "0x0E3Ca7fD040144900AdaA5f9B8917f3933A4F5e9".to_string(),
+            from_amount_units: 10_000_000,
+            expected_to_amount_units: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_swap_converts_amount_with_destination_decimals() {
+        // Give the destination asset 2 decimals to make the conversion
+        // visible: 100.00 unfilled → 10_000 smallest units (the old
+        // hardcoded 6 would produce 100_000_000)
+        let mut app_state = app_state_with_decimals(HashMap::from([(
+            ChainType::Polygon,
+            HashMap::from([(POLYGON_USDC.to_string(), 2)]),
+        )]));
+
+        let invoice = default_invoice();
+        let invoice_id = invoice.id;
+
+        app_state
+            .dao
+            .expect_get_invoice_with_received_amount_by_id()
+            .returning(move |_| {
+                Ok(Some(
+                    invoice
+                        .clone()
+                        .with_amount(Decimal::ZERO),
+                ))
+            });
+
+        app_state
+            .swaps_executor
+            .expect_create_swap()
+            .withf(|data| data.expected_to_amount_units == 10_000)
+            .returning(move |_| Ok(default_swap(invoice_id)));
+
+        app_state
+            .create_swap(create_swap_params(invoice_id))
+            .await
+            .expect("swap should be created with converted target amount");
+    }
+
+    #[tokio::test]
+    async fn test_create_swap_rejects_unknown_destination_decimals() {
+        let mut app_state = app_state_with_decimals(HashMap::new());
+
+        let invoice = default_invoice();
+        let invoice_id = invoice.id;
+
+        app_state
+            .dao
+            .expect_get_invoice_with_received_amount_by_id()
+            .returning(move |_| {
+                Ok(Some(
+                    invoice
+                        .clone()
+                        .with_amount(Decimal::ZERO),
+                ))
+            });
+
+        let result = app_state
+            .create_swap(create_swap_params(invoice_id))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SwapRequestError::AssetMetadataUnavailable { .. })
+        ));
     }
 }

--- a/daemon/src/swaps/executor.rs
+++ b/daemon/src/swaps/executor.rs
@@ -170,7 +170,8 @@ impl<D: DaoInterface + 'static> SwapsExecutor<D> {
         // external executor: if the daemon crashes or the later updates fail,
         // the swap is already `Submitted` and visible to the tracker instead
         // of silently staying `Created` while funds are in flight.
-        self.update_swap_submitted_internally(swap_signature.swap_id)
+        let submitted_swap = self
+            .update_swap_submitted_internally(swap_signature.swap_id)
             .await?;
 
         // TODO: In case of error need to check an error thoroughly.
@@ -232,11 +233,15 @@ impl<D: DaoInterface + 'static> SwapsExecutor<D> {
                 // the caller (a retry could double-submit). The swap stays
                 // Submitted/Pending without a hash and needs manual
                 // reconciliation, which this error record points at.
+                //
+                // Return the post-`Submitted` row, never the pre-submission
+                // `swap`: that one still reads `Created`, which would tell the
+                // caller nothing was sent while funds are already in flight.
                 tracing::error!(
                     error = ?e,
                     "Swap was submitted but recording its transaction hash failed, manual reconciliation required"
                 );
-                Ok(swap)
+                Ok(submitted_swap)
             },
         }
     }

--- a/daemon/src/swaps/executor.rs
+++ b/daemon/src/swaps/executor.rs
@@ -166,37 +166,79 @@ impl<D: DaoInterface + 'static> SwapsExecutor<D> {
                 _ => SwapsExecutorError::DatabaseError,
             })?;
 
+        // Persist the submission attempt BEFORE handing the swap to the
+        // external executor: if the daemon crashes or the later updates fail,
+        // the swap is already `Submitted` and visible to the tracker instead
+        // of silently staying `Created` while funds are in flight.
+        self.update_swap_submitted_internally(swap_signature.swap_id)
+            .await?;
+
         // TODO: In case of error need to check an error thoroughly.
         // If it's problem with signature, we can mark it as failed.
         // If it's some kind of network error, we can retry it.
         // In any way we have to understand if it was received by bungee
         // and is being processed to avoid double-payments or just missing
         // the transaction.
-        let transaction_hash = self
+        let transaction_hash = match self
             .clients
             .submit_transaction(
                 swap.request.swap_executor,
                 &swap.swap_details,
             )
-            .await?;
+            .await
+        {
+            Ok(transaction_hash) => transaction_hash,
+            Err(e) => {
+                tracing::warn!(
+                    error = ?e,
+                    "External executor rejected swap submission, marking swap as failed"
+                );
+
+                // The submission may still have been accepted (e.g. on a
+                // network timeout); actually arriving funds are detected by
+                // the chain transfer subscription regardless, and the Failed
+                // record keeps the attempt visible for reconciliation.
+                if let Err(db_error) = self
+                    .dao
+                    .update_swap_failed(swap_signature.swap_id, e.to_string())
+                    .await
+                {
+                    tracing::error!(
+                        error = ?db_error,
+                        "Failed to mark swap as failed after a submission error, swap stays visible to the tracker"
+                    );
+                }
+
+                return Err(e.into());
+            },
+        };
 
         tracing::Span::current().record("transaction_hash", &transaction_hash);
 
-        self.dao
-            .update_swap_submitted_with_hash(swap_signature.swap_id, transaction_hash)
+        // The tracker polls the database with a short interval and may have
+        // already moved the swap from `Submitted` to `Pending`, so only the
+        // transaction hash is written here — no status transition.
+        match self
+            .dao
+            .update_swap_transaction_hash(swap_signature.swap_id, transaction_hash)
             .await
-            .map_err(|e| match e {
-                DaoSwapError::NotFound {
-                    swap_id,
-                } => SwapsExecutorError::SwapNotFound {
-                    swap_id,
-                },
-                _ => SwapsExecutorError::DatabaseError,
-            })?;
-
-        tracing::info!("Swap has been submitted successfully");
-
-        Ok(swap)
+        {
+            Ok(swap) => {
+                tracing::info!("Swap has been submitted successfully");
+                Ok(swap)
+            },
+            Err(e) => {
+                // The submission itself succeeded — don't report a failure to
+                // the caller (a retry could double-submit). The swap stays
+                // Submitted/Pending without a hash and needs manual
+                // reconciliation, which this error record points at.
+                tracing::error!(
+                    error = ?e,
+                    "Swap was submitted but recording its transaction hash failed, manual reconciliation required"
+                );
+                Ok(swap)
+            },
+        }
     }
 
     /// Mark swap as `Submitted` in database. Use this method for swaps which
@@ -204,7 +246,6 @@ impl<D: DaoInterface + 'static> SwapsExecutor<D> {
     /// requests to executor or sent to blockhain directly. For swaps which has
     /// been sent on front-end use `update_swap_submitted_on_front_end`
     /// method.
-    #[expect(dead_code)]
     async fn update_swap_submitted_internally(
         &self,
         swap_id: Uuid,

--- a/daemon/src/swaps/tracker.rs
+++ b/daemon/src/swaps/tracker.rs
@@ -275,10 +275,82 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
         Ok(())
     }
 
+    /// Re-read a tracked swap that has no transaction hash yet and refresh the
+    /// stored copy.
+    ///
+    /// The database poll picks swaps up every 100 ms, which can be well before
+    /// `submit_with_signature` has attached the hash of a submission it is
+    /// still waiting on. Without this refresh the tracked clone stays hashless
+    /// for the lifetime of the process and every poll below fails with
+    /// `TransactionHashIsNotSet`.
+    ///
+    /// Returns `None` when the swap still can't be polled this round.
+    async fn refresh_hashless_swap(
+        &mut self,
+        swap: &Swap,
+    ) -> Option<Swap> {
+        let reloaded = match self.dao.get_swap_by_id(swap.id).await {
+            Ok(Some(reloaded)) => reloaded,
+            Ok(None) => {
+                tracing::warn!(
+                    swap_id = %swap.id,
+                    invoice_id = %swap.request.invoice_id,
+                    "Tracked swap has disappeared from the database, dropping it from the tracker"
+                );
+                self.store.remove_swap(swap.id);
+                return None;
+            },
+            Err(e) => {
+                tracing::warn!(
+                    swap_id = %swap.id,
+                    invoice_id = %swap.request.invoice_id,
+                    error = ?e,
+                    "Failed to re-read a swap with no transaction hash, will retry next round"
+                );
+                return None;
+            },
+        };
+
+        if reloaded
+            .swap_details
+            .transaction_hash
+            .is_none()
+        {
+            // Loud on purpose: the swap was marked `Submitted` before the
+            // external call, so funds may be in flight with nothing recorded
+            // to track them by.
+            tracing::warn!(
+                swap_id = %swap.id,
+                invoice_id = %swap.request.invoice_id,
+                swap_status = %reloaded.status,
+                "Tracked swap still has no transaction hash and cannot be polled — if this persists, its submission needs manual reconciliation"
+            );
+            return None;
+        }
+
+        self.store
+            .add_swaps(vec![reloaded.clone()]);
+
+        Some(reloaded)
+    }
+
     async fn check_swaps(&mut self) {
         let swaps = self.store.get_all_swaps();
 
         for swap in swaps {
+            let swap = if swap
+                .swap_details
+                .transaction_hash
+                .is_none()
+            {
+                match self.refresh_hashless_swap(&swap).await {
+                    Some(refreshed) => refreshed,
+                    None => continue,
+                }
+            } else {
+                swap
+            };
+
             let result = self.check_swap(&swap).await;
 
             if let Err(e) = result {

--- a/daemon/src/types/transaction.rs
+++ b/daemon/src/types/transaction.rs
@@ -41,6 +41,16 @@ impl GeneralTransactionId {
             tx_hash: None,
         }
     }
+
+    /// `true` when this record points at an actual on-chain event.
+    ///
+    /// Records without any coordinate are synthetic — currently the balance
+    /// checker's reconciliation adjustments, which stand in for transfers we
+    /// never observed. Their `source_address` is a placeholder, so they are
+    /// evidence that funds arrived, never evidence of who sent them.
+    pub fn is_onchain(&self) -> bool {
+        self.block_number.is_some() || self.position_in_block.is_some() || self.tx_hash.is_some()
+    }
 }
 
 /// Origin field for transactions (what triggered this transaction)

--- a/daemon/src/utils/refund_destination_detector.rs
+++ b/daemon/src/utils/refund_destination_detector.rs
@@ -127,6 +127,25 @@ impl<D: DaoInterface + 'static> RefundDestinationDetector<D> {
 
         self.filter_out_swap_transactions(&mut transactions, &swaps);
 
+        // Synthetic reconciliation records carry a placeholder sender, so they
+        // can never be a refund destination — sending there would burn the
+        // funds. Drop them before picking a destination; if that leaves
+        // nothing, `NoAvailableDestination` correctly routes the refund to
+        // manual handling.
+        transactions.retain(|trans| {
+            let is_onchain = trans.transaction_id.is_onchain();
+
+            if !is_onchain {
+                tracing::warn!(
+                    transaction_id = %trans.id,
+                    invoice_id = %refund.invoice_id,
+                    "Skipping a reconciliation record while detecting a refund destination: it has no on-chain sender"
+                );
+            }
+
+            is_onchain
+        });
+
         // TODO: now we just get the first one, later we'll have to also check them
         // using arkhm API
         if let Some(trans) = transactions.first() {
@@ -269,6 +288,7 @@ mod tests {
     };
     use crate::types::{
         ChainType,
+        GeneralTransactionId,
         SwapChainType,
         default_refund,
         default_swap,
@@ -490,6 +510,98 @@ mod tests {
                 .once()
                 .with(eq(invoice_id))
                 .returning(move |_| Ok(vec![]));
+
+            let result = detector
+                .find_refund_destination(&refund)
+                .await
+                .unwrap_err();
+
+            assert_eq!(
+                result,
+                RefundDestinationDetectorError::NoAvailableDestination
+            );
+        }
+
+        // Test case 3.1:
+        // - Successful flow
+        // - A synthetic reconciliation record precedes a real transfer
+        // Expectations:
+        // - The reconciliation record is skipped despite being first
+        // - The real transfer's sender is returned
+        {
+            let mut reconciliation = default_transaction(invoice_id);
+            reconciliation.transaction_id = GeneralTransactionId::empty();
+            reconciliation
+                .transfer_info
+                .source_address = "unknown".to_string();
+
+            let mut real_transfer = default_transaction(invoice_id);
+            real_transfer.transfer_info.chain = ChainType::Polygon;
+
+            let expected_destination_params = TransferDestinationParams {
+                destination_address: real_transfer
+                    .transfer_info
+                    .source_address
+                    .clone(),
+                destination_chain: real_transfer.transfer_info.chain.into(),
+                destination_asset_id: real_transfer
+                    .transfer_info
+                    .asset_id
+                    .clone(),
+            };
+
+            detector
+                .dao
+                .expect_get_completed_incoming_swaps_by_invoice()
+                .once()
+                .with(eq(invoice_id))
+                .returning(move |_| Ok(vec![]));
+
+            detector
+                .dao
+                .expect_get_completed_transactions_by_invoice()
+                .once()
+                .with(eq(invoice_id))
+                .returning(move |_| {
+                    Ok(vec![
+                        reconciliation.clone(),
+                        real_transfer.clone(),
+                    ])
+                });
+
+            let result = detector
+                .find_refund_destination(&refund)
+                .await
+                .unwrap();
+
+            assert_eq!(result, expected_destination_params);
+        }
+
+        // Test case 3.2:
+        // - Unsuccessful flow
+        // - The only completed transaction is a reconciliation record
+        // Expectations:
+        // - No destination is invented from its placeholder sender
+        {
+            let mut reconciliation = default_transaction(invoice_id);
+            reconciliation.transaction_id = GeneralTransactionId::empty();
+            reconciliation
+                .transfer_info
+                .source_address = "unknown".to_string();
+
+            detector
+                .dao
+                .expect_get_completed_incoming_swaps_by_invoice()
+                .once()
+                .with(eq(invoice_id))
+                .returning(move |_| Ok(vec![]));
+
+            detector
+                .dao
+                .expect_get_completed_transactions_by_invoice()
+                .once()
+                .with(eq(invoice_id))
+                .returning(move |_| Ok(vec![reconciliation.clone()]));
 
             let result = detector
                 .find_refund_destination(&refund)

--- a/docs/swaps.md
+++ b/docs/swaps.md
@@ -1,0 +1,50 @@
+# Swaps
+
+Decision records and behavioral notes for the swaps subsystem
+(`daemon/src/swaps/`, `daemon/src/clients/swaps/`). Not yet a full subsystem
+overview — see [architecture.md](architecture.md) for the component map.
+
+## Unusable provider quotes are rejected, not forwarded (2026-08-04)
+
+When a provider returns a quote without usable gas parameters — Across with a
+failed simulation, 0x with no gas estimate — the daemon rejects it with
+`SwapsClientError::UnusableQuote` rather than passing it on.
+
+The alternative (forward the quote with the gas fields omitted and let the
+signing wallet estimate them) was considered and rejected: Kassette submits
+those fields unguarded via `BigInt(swapTx.gas)`, so an omitted field throws in
+the payer's browser, and substituting `0` publishes a transaction with a zero
+gas limit that cannot be mined. Neither is publishable.
+
+Once Kassette accepts absent gas (Kalapaja/Kassette#49) these can be passed
+through as optional instead of rejected. The rationale lives next to the code in
+`daemon/src/clients/swaps/across/types.rs` and
+`daemon/src/clients/swaps/zeroex.rs`.
+
+Related: `simulationSuccess` is **not** a rejection signal and is never read.
+Across marks it optional and omits it entirely on `/swap/gasless`, so it is
+deserialized with a default purely so an absent field doesn't fail the whole
+quote. Across's own SDK ignores the flag and re-simulates locally.
+
+## Submission-attempt protocol for backend-submitted swaps (2026-08-03)
+
+`SwapsExecutor::submit_with_signature` persists `Submitted` (without a
+transaction hash) **before** calling the external executor, then attaches the
+hash afterwards via `update_swap_transaction_hash`, which never changes status:
+the swaps tracker polls the database on a 100 ms interval and may already have
+moved the swap `Submitted → Pending`, and the SQLite status trigger forbids
+going back. Consequences:
+
+- A crash between submission and hash persistence leaves a `Submitted`/`Pending`
+  swap without a hash. The tracker re-reads such swaps each round and, when the
+  hash is still missing, logs a `warn!` naming the swap — that is the signal for
+  manual reconciliation. (It must not be `debug!`: production runs at `info`,
+  where the swap would otherwise fail silently forever.) Funds that actually
+  arrive are still detected by the chain transfer subscription.
+- A rejected submission marks the swap `Failed` with the executor's error
+  message. If the rejection was spurious (e.g. a timeout after acceptance),
+  incoming funds are again caught by the transfer subscription.
+- If the hash write fails after a successful submission, the caller still gets
+  `Ok` — a retry could double-submit — but it receives the post-`Submitted` row,
+  never the pre-submission one, so the reported status matches what was
+  persisted.


### PR DESCRIPTION
Correctness fixes across payment detection, configured-address matching, and
swap quoting/submission. Every change here is a defect fix — no new features and
no schema changes.

## Payment detection

- **Polygon: gate incoming transfers behind a confirmation depth.** Transfers
  were credited on first sight of the log. They are now buffered until they are
  `confirmations` blocks deep (default 12, configurable per chain), and logs
  reorged away before release are dropped.
- **Asset Hub: recover missed transfers, stop dropping decode failures.**
  Transfer extraction now scans block events for `assets.Transferred` instead of
  decoding two specific extrinsic types, so batched and proxied payments are
  seen. Decode failures are logged rather than silently discarded, and the
  balance checker reconciles an invoice whose on-chain balance is ahead of its
  recorded transfers.
- **Propagate invoice updates to the in-memory registry.** Payment matching runs
  against the registry, so an updated amount or expiry that only reached the
  database was invisible to detection.
- **Etherscan: checked conversion of transfer value and decimals.** The previous
  `as i64` cast wrapped silently above ~9.2e18 base units and `Decimal::new`
  panicked for `tokenDecimal > 28`.

## Configured-address matching

- **Canonicalize EVM asset addresses at startup.** Configured Polygon addresses
  were compared as exact strings against the checksummed addresses the chain
  client reports, so a lowercase config entry produced invoices whose asset id
  never matched incoming transfers — payments simply went undetected. Addresses
  are now normalized to EIP-55 at startup (invalid ones fail startup loudly),
  with case-insensitive lookup as defence in depth for invoices created under
  older configs. Asset Hub stays case-sensitive.

## Swaps

- **Persist submission state before the external call.** `submit_with_signature`
  submitted first and recorded `Submitted` afterwards, so a crash in between left
  the swap `Created` — invisible to the tracker — with customer funds in flight.
  See `docs/swaps.md` for the resulting submission-attempt protocol.
- **Derive the swap target amount from the destination asset's real decimals**
  instead of a hardcoded 6.
- **Bungee: parse both single- and cross-chain `basicReq` shapes**, so enabling
  cross-chain support won't break on the first quote.
- **0x: surface gateway errors** (401 invalid key, 429 rate limited) as a
  distinct error instead of a generic deserialization warning.

## Review fixes

The last two commits come from a two-track pre-PR review — an adversarial static
review plus an integration review grounding every external-API assumption against
vendor documentation and locked crate sources. Six defects found and fixed:

- `simulationSuccess` was modelled as a required field, but Across marks it
  optional and omits it entirely on `/swap/gasless` — one omission would have
  failed every quote.
- subxt's event iterator is not resumable: on a decode error it advances to the
  end, so `continue` discarded the whole remainder of the block, not one event.
- The swap executor returned the pre-submission row on the hash-persistence
  failure path, reporting `Created` while the database said `Submitted` and funds
  were in flight.
- A swap picked up by the 100 ms tracker poll before its hash was attached stayed
  hashless in memory forever, failing every poll at `debug!` — invisible at
  production log levels.
- Reconciliation records carry a placeholder sender, and refund destination
  detection could select one, addressing a refund to it.
- The new amount guards narrowed `u128` through `i64` before building a
  `Decimal`, capping 18-decimal assets at ~9.22 tokens per transfer;
  `Decimal` holds a 96-bit mantissa.

Ten further findings were triaged and deferred rather than fixed here, and five
suspected issues were investigated and disproven.

**Rebased onto `main` after #345 and #346 landed.** One commit was dropped as
superseded: it forwarded Across quotes with the gas fields omitted so the wallet
would estimate them, which `main` has since resolved the other way — Kassette
submits those fields unguarded, so an omitted field throws in the payer's browser.
`main`'s rejection of unusable quotes is the behaviour that survives; the
rationale is recorded in `docs/swaps.md`.

## Testing

`cargo clippy` clean under `-D warnings`, `cargo +nightly fmt --all` clean.
Local test runs show DAO tests failing on an environment issue (SQLite older than
the required 3.47.0 cannot run migration `20250104000001`); the failure count and
signatures are unchanged from before this branch, and CI is the gate for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
