### PR TITLE
fix(across): treat a zero gas limit as absent, not as a usable value

### DIFF
--- a/daemon/src/clients/swaps/across.rs
+++ b/daemon/src/clients/swaps/across.rs
@@ -406,6 +406,141 @@ mod tests {
     }
 
     #[test]
+    fn test_across_zero_gas_and_fee_cap_are_omitted() {
+        // Trimmed from the production shape returned when an ERC-20 approval
+        // is still missing: Across uses `"0"` as the gas sentinel even though
+        // the fee caps and value are normally absent in this response.
+        let raw = r#"{
+            "inputAmount": "1",
+            "maxInputAmount": "1",
+            "expectedOutputAmount": "1",
+            "swapTx": {
+                "simulationSuccess": false,
+                "chainId": 137,
+                "to": "0x1111111111111111111111111111111111111111",
+                "data": "0x1234",
+                "value": "0",
+                "gas": "0",
+                "maxFeePerGas": "0",
+                "maxPriorityFeePerGas": "1500000000"
+            },
+            "id": "quote-zero-sentinels",
+            "quoteExpiryTimestamp": 1893456000
+        }"#;
+
+        let AcrossApiResponse::Ok(parsed) =
+            serde_json::from_str::<AcrossApiResponse<SwapApprovalResponse>>(raw).unwrap()
+        else {
+            panic!("zero gas sentinels must parse as the success arm");
+        };
+        assert_eq!(parsed.swap_tx.gas, Some(0));
+        assert_eq!(parsed.swap_tx.max_fee_per_gas, Some(0));
+        assert_eq!(
+            parsed.swap_tx.max_priority_fee_per_gas,
+            Some(1_500_000_000)
+        );
+        assert_eq!(parsed.swap_tx.value, Some(0));
+
+        let quote = SwapQuote::try_from(parsed).unwrap();
+        let RawSwapDetails::Across(details) = quote.quote_details else {
+            panic!("expected Across quote details");
+        };
+        assert!(details.transaction.gas.is_none());
+        assert!(
+            details
+                .transaction
+                .max_fee_per_gas
+                .is_none()
+        );
+        assert!(
+            details
+                .transaction
+                .max_priority_fee_per_gas
+                .is_none()
+        );
+        assert_eq!(details.transaction.value, 0);
+
+        let serialized = serde_json::to_value(&details.transaction).unwrap();
+        assert!(serialized.get("gas").is_none());
+        assert!(
+            serialized
+                .get("max_fee_per_gas")
+                .is_none()
+        );
+        assert!(
+            serialized
+                .get("max_priority_fee_per_gas")
+                .is_none()
+        );
+        assert_eq!(
+            serialized.get("value"),
+            Some(&serde_json::json!("0"))
+        );
+    }
+
+    #[test]
+    fn test_across_preserves_non_zero_gas_and_zero_priority_fee() {
+        let raw = r#"{
+            "inputAmount": "1",
+            "maxInputAmount": "1",
+            "expectedOutputAmount": "1",
+            "swapTx": {
+                "simulationSuccess": true,
+                "chainId": 137,
+                "to": "0x1111111111111111111111111111111111111111",
+                "data": "0x1234",
+                "gas": "21000",
+                "maxFeePerGas": "30000000000",
+                "maxPriorityFeePerGas": "0"
+            },
+            "id": "quote-valid-zero-priority",
+            "quoteExpiryTimestamp": 1893456000
+        }"#;
+
+        let AcrossApiResponse::Ok(parsed) =
+            serde_json::from_str::<AcrossApiResponse<SwapApprovalResponse>>(raw).unwrap()
+        else {
+            panic!("valid gas parameters must parse as the success arm");
+        };
+        let quote = SwapQuote::try_from(parsed).unwrap();
+        let RawSwapDetails::Across(details) = quote.quote_details else {
+            panic!("expected Across quote details");
+        };
+
+        assert_eq!(details.transaction.gas, Some(21_000));
+        assert_eq!(
+            details.transaction.max_fee_per_gas,
+            Some(30_000_000_000)
+        );
+        assert_eq!(
+            details
+                .transaction
+                .max_priority_fee_per_gas,
+            Some(0)
+        );
+        // The same zero value results from an omitted provider field.
+        assert_eq!(details.transaction.value, 0);
+
+        let serialized = serde_json::to_value(&details.transaction).unwrap();
+        assert_eq!(
+            serialized.get("gas"),
+            Some(&serde_json::json!("21000"))
+        );
+        assert_eq!(
+            serialized.get("max_fee_per_gas"),
+            Some(&serde_json::json!("30000000000"))
+        );
+        assert_eq!(
+            serialized.get("max_priority_fee_per_gas"),
+            Some(&serde_json::json!("0"))
+        );
+        assert_eq!(
+            serialized.get("value"),
+            Some(&serde_json::json!("0"))
+        );
+    }
+
+    #[test]
     fn test_across_status_growth_degrades_safely() {
         // The variant is asserted alongside the mapping on purpose: asserting
         // only the `ExecutorSwapStatus` would stay green if the explicit

--- a/daemon/src/clients/swaps/across.rs
+++ b/daemon/src/clients/swaps/across.rs
@@ -407,9 +407,11 @@ mod tests {
 
     #[test]
     fn test_across_zero_gas_and_fee_cap_are_omitted() {
-        // Trimmed from the production shape returned when an ERC-20 approval
-        // is still missing: Across uses `"0"` as the gas sentinel even though
-        // the fee caps and value are normally absent in this response.
+        // Based on the production shape returned when an ERC-20 approval is
+        // still missing, where Across sends `gas: "0"`. The fee caps and
+        // `value` are normally absent from that response; they are supplied
+        // here on purpose, so one fixture exercises zero-cap normalization and
+        // the genuine-zero `value` alongside the gas sentinel.
         let raw = r#"{
             "inputAmount": "1",
             "maxInputAmount": "1",

--- a/daemon/src/clients/swaps/across/types.rs
+++ b/daemon/src/clients/swaps/across/types.rs
@@ -116,10 +116,10 @@ pub struct ApprovalTransaction {
 pub struct SwapTransactionInternal {
     // Across simulates against the depositor's CURRENT state, so this is
     // legitimately `false` before the user has granted approvals. We no longer
-    // act on it — the gas parameters decide whether a quote is usable (see
-    // `TryFrom` below) — but it must still never be *required*: Across's schema
-    // marks it optional and `/swap/gasless` omits it altogether, so a bare
-    // `bool` would fail the entire quote the first time it is absent.
+    // act on it — unusable gas sentinels are normalized during transaction
+    // conversion — but it must still never be *required*: Across's schema marks
+    // it optional and `/swap/gasless` omits it altogether, so a bare `bool`
+    // would fail the entire quote the first time it is absent.
     #[expect(dead_code)]
     #[serde(default = "default_simulation_success")]
     pub simulation_success: bool,
@@ -156,12 +156,12 @@ pub struct SwapTransaction {
     #[serde(default)]
     #[serde_as(as = "DisplayFromStr")]
     pub value: u128,
-    // Omit-and-estimate, not zero: Across leaves these out when its simulation
-    // fails, and since Kalapaja/Kassette#50 Kassette converts them with
-    // `!= null ? BigInt(…) : undefined`, which drops the key from
-    // `eth_sendTransaction` so the payer's wallet estimates instead. They must
-    // therefore be *absent* from the JSON rather than `null` or `0` — a zero
-    // gas limit or zero fee cap publishes a transaction that cannot be mined.
+    // Omit-and-estimate, not zero: with `simulationSuccess: false`, Across sends
+    // `gas: "0"` while genuinely omitting the fee caps and `value`. We normalize
+    // a zero gas limit or max fee cap to absent; dropping the cap also drops the
+    // priority fee. A zero priority fee remains valid alongside a non-zero cap.
+    // Kassette turns absent gas fields into `undefined`, so the payer's wallet
+    // estimates them instead of publishing an unmineable zero-gas transaction.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gas: Option<u128>,
@@ -177,16 +177,23 @@ impl From<SwapTransactionInternal> for SwapTransaction {
     fn from(value: SwapTransactionInternal) -> Self {
         // `value` genuinely defaults to zero — Across omits the key for
         // zero-value (ERC-20) transfers and documents `value ? BigInt(v) : 0n`
-        // as the caller's handling. The gas parameters do not default; they
-        // pass through as-is, absent included (see the field comments above).
+        // as the caller's handling. Across uses zero as the unusable sentinel
+        // for `gas` and `maxFeePerGas`; without a usable fee cap, its priority
+        // fee must be dropped too. See the field comments above.
+        let gas = value.gas.filter(|gas| *gas != 0);
+        let max_fee_per_gas = value
+            .max_fee_per_gas
+            .filter(|fee| *fee != 0);
+        let max_priority_fee_per_gas = max_fee_per_gas.and(value.max_priority_fee_per_gas);
+
         Self {
             chain_id: value.chain_id,
             contract_address: value.to,
             data: value.data,
             value: value.value.unwrap_or_default(),
-            gas: value.gas,
-            max_fee_per_gas: value.max_fee_per_gas,
-            max_priority_fee_per_gas: value.max_priority_fee_per_gas,
+            gas,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
         }
     }
 }

--- a/daemon/src/clients/swaps/zeroex.rs
+++ b/daemon/src/clients/swaps/zeroex.rs
@@ -1079,6 +1079,11 @@ mod tests {
                 details.raw_transaction.gas,
                 Some(210_000)
             );
+            let serialized = serde_json::to_value(&details.raw_transaction).unwrap();
+            assert_eq!(
+                serialized.get("gas"),
+                Some(&serde_json::json!("210000"))
+            );
         }
     }
 

--- a/docs/swaps.md
+++ b/docs/swaps.md
@@ -56,14 +56,22 @@ The shape of the payload is now checked before it is written:
   → **400 `INVALID_SWAP_SIGNATURE`**. It is the submitter's to fix by
   re-signing, so it must not be reported as an internal failure.
 
-## Absent gas parameters are forwarded as absent (2026-08-04)
+## Unusable gas parameters are forwarded as absent (2026-08-04)
 
-When a provider returns a quote without gas parameters — Across with a failed
-simulation, 0x with no gas estimate — the daemon publishes the quote with those
-keys **omitted from the JSON**. Absent means "estimate it yourself": Kassette
-converts with `!= null ? BigInt(…) : undefined` since Kalapaja/Kassette#50, and
-viem drops undefined gas fields from `eth_sendTransaction` so the payer's wallet
-estimates them.
+Across does not omit `gas` when its simulation fails. A production
+`/api/swap/approval` response with `simulationSuccess: false` instead carried
+`gas: "0"`; the fee caps and `value` were genuinely omitted. The daemon treats
+an Across gas limit of zero exactly like an absent one. It does the same for a
+zero `maxFeePerGas` and drops `maxPriorityFeePerGas` whenever the cap is absent
+or normalized away. A zero priority fee remains valid and is preserved when
+the max fee cap is non-zero. 0x remains separate: its nullable `gas` is omitted
+only when absent, and a supplied limit — including zero — passes through
+verbatim.
+
+The daemon publishes unusable or absent fields with their keys **omitted from
+the JSON**. Absent means "estimate it yourself": Kassette passes `undefined`,
+and viem drops undefined gas fields from `eth_sendTransaction` so the payer's
+wallet estimates them.
 
 Omission is load-bearing in both directions. Sending `0` would publish a
 transaction with a zero gas limit or zero fee caps, which cannot be mined.

--- a/docs/swaps.md
+++ b/docs/swaps.md
@@ -64,9 +64,16 @@ Across does not omit `gas` when its simulation fails. A production
 an Across gas limit of zero exactly like an absent one. It does the same for a
 zero `maxFeePerGas` and drops `maxPriorityFeePerGas` whenever the cap is absent
 or normalized away. A zero priority fee remains valid and is preserved when
-the max fee cap is non-zero. 0x remains separate: its nullable `gas` is omitted
-only when absent, and a supplied limit — including zero — passes through
-verbatim.
+the max fee cap is non-zero.
+
+0x remains separate because its contract differs, not because zero is
+acceptable there. 0x types `gas` as genuinely nullable rather than using zero
+as a sentinel, and its own troubleshooting guide warns that wallet-side
+`eth_estimateGas` can come in *too low* to settle — so a supplied limit is
+forwarded verbatim and only an absent one is omitted. A zero limit from 0x
+would be exactly as unmineable as Across's; there is no evidence it emits one,
+and normalizing on that speculation would risk discarding a limit 0x
+deliberately sized.
 
 The daemon publishes unusable or absent fields with their keys **omitted from
 the JSON**. Absent means "estimate it yourself": Kassette passes `undefined`,


### PR DESCRIPTION
Across does not omit `gas` when its simulation fails. A production `/api/swap/approval` response with `simulationSuccess: false` carries `gas: "0"` while genuinely omitting the fee caps and `value` — the opposite of what a09270d assumed.

`skip_serializing_if = "Option::is_none"` therefore never fired, the daemon published `"gas": "0"`, and the payer's wallet was handed a zero gas limit that can never be mined. This is the ordinary first payment on the primary cross-chain path: Across is the cross-chain executor, and an ERC-20 payer always has allowance 0 before approval, which is exactly what makes `simulationSuccess` false.

Normalization, Across-only:

- a zero `gas` is absent; a zero `maxFeePerGas` is absent
- dropping the cap drops `maxPriorityFeePerGas` with it, since a priority fee without a cap is meaningless
- a zero `maxPriorityFeePerGas` alongside a non-zero cap is a legitimate EIP-1559 value and is preserved
- `value: "0"` is genuine and is untouched

0x is deliberately left alone: its `gas` is documented as nullable rather than zero-sentinelled, and 0x warns that wallet-side estimation can come in too low, so a supplied limit must be used verbatim. A regression test guards against the normalization widening to it.

The comments that asserted the false premise are corrected rather than left to mislead the next reader.