### PR TITLE
fix: close three state-consistency defects in swaps, registry and recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 target
+# Alternate CARGO_TARGET_DIR names (e.g. target-sq for a locally built SQLite)
+target-*
 database/
 
 # front-end

--- a/daemon/src/balance_checker.rs
+++ b/daemon/src/balance_checker.rs
@@ -17,6 +17,7 @@ use crate::chain_client::{
 use crate::dao::{
     DAO,
     DaoInterface,
+    DaoTransactionInterface,
 };
 use crate::etherscan_client::EtherscanClient;
 use crate::types::{
@@ -175,18 +176,50 @@ impl<
         invoice: &mut InvoiceWithReceivedAmount,
         balance: Decimal,
     ) -> Result<(), BalanceCheckerError> {
-        let received_amount = invoice.total_received_amount;
+        let dao_transaction = self
+            .dao
+            .begin_transaction()
+            .await
+            .map_err(|_| BalanceCheckerError::DatabaseError)?;
+
+        // This read and the adjustment write below deliberately share one
+        // transaction. If the live subscription committed a transfer after
+        // the balance fetch, this snapshot includes it; if it tries to commit
+        // after this read, SQLite serializes the competing writes (or rejects
+        // this stale writer for a later retry) instead of letting both commit.
+        let persisted_invoice = dao_transaction
+            .get_invoice_with_received_amount_by_id(invoice.invoice.id)
+            .await
+            .map_err(|_| BalanceCheckerError::DatabaseError)?
+            .ok_or(BalanceCheckerError::InvoiceNotFound {
+                invoice_id: invoice.invoice.id,
+            })?;
+
+        let received_amount = persisted_invoice.total_received_amount;
         let delta = balance - received_amount;
 
         if delta <= Decimal::ZERO {
-            // We recorded more than the address holds. Never "un-record"
-            // payments automatically — this needs a human (funds moved out of
-            // the payment address, or a transfer was double-recorded).
-            tracing::error!(
-                %balance,
-                %received_amount,
-                "Recorded received amount exceeds on-chain balance, manual intervention required"
-            );
+            if delta < Decimal::ZERO {
+                // We recorded more than the address holds. Never "un-record"
+                // payments automatically — this needs a human (funds moved out
+                // of the payment address, or a transfer was double-recorded).
+                tracing::error!(
+                    %balance,
+                    %received_amount,
+                    "Recorded received amount exceeds on-chain balance, manual intervention required"
+                );
+            } else {
+                tracing::debug!(
+                    %balance,
+                    "Transaction-scoped received amount already matches the on-chain balance"
+                );
+            }
+
+            dao_transaction
+                .commit()
+                .await
+                .map_err(|_| BalanceCheckerError::DatabaseError)?;
+            *invoice = persisted_invoice;
             return Ok(());
         }
 
@@ -204,14 +237,23 @@ impl<
         // record outside the per-chain uniqueness indexes.
         let transaction = IncomingTransaction {
             id: Uuid::new_v4(),
-            invoice_id: invoice.invoice.id,
+            invoice_id: persisted_invoice.invoice.id,
             transfer_info: TransferInfo {
                 chain: ChainType::PolkadotAssetHub,
-                asset_id: invoice.invoice.asset_id.clone(),
-                asset_name: invoice.invoice.asset_name.clone(),
+                asset_id: persisted_invoice
+                    .invoice
+                    .asset_id
+                    .clone(),
+                asset_name: persisted_invoice
+                    .invoice
+                    .asset_name
+                    .clone(),
                 amount: delta,
                 source_address: "unknown".to_string(),
-                destination_address: invoice.invoice.payment_address.clone(),
+                destination_address: persisted_invoice
+                    .invoice
+                    .payment_address
+                    .clone(),
             },
             transaction_id: GeneralTransactionId {
                 block_number: None,
@@ -220,27 +262,45 @@ impl<
             },
         };
 
-        match self
+        let (updated_invoice, min_paid_amount) = match self
             .transactions_recorder
-            .process_invoice_transaction(invoice, transaction)
+            .process_invoice_transaction_in(
+                &dao_transaction,
+                &persisted_invoice,
+                transaction,
+            )
             .await
         {
-            Ok(()) => {
-                tracing::info!(
-                    invoice_status = %invoice.invoice.status,
-                    total_received_amount = %invoice.total_received_amount,
-                    "Balance-adjustment transaction has been recorded, invoice has been updated"
-                );
-                Ok(())
-            },
+            Ok(update) => update,
             Err(e) => {
                 tracing::warn!(
                     error = ?e,
                     "Database error occurred while trying to record balance-adjustment transaction"
                 );
-                Err(BalanceCheckerError::DatabaseError)
+                return Err(BalanceCheckerError::DatabaseError)
             },
-        }
+        };
+
+        dao_transaction
+            .commit()
+            .await
+            .map_err(|_| BalanceCheckerError::DatabaseError)?;
+
+        self.transactions_recorder
+            .apply_recorded_invoice_update(
+                invoice,
+                updated_invoice,
+                min_paid_amount,
+            )
+            .await;
+
+        tracing::info!(
+            invoice_status = %invoice.invoice.status,
+            total_received_amount = %invoice.total_received_amount,
+            "Balance-adjustment transaction has been recorded, invoice has been updated"
+        );
+
+        Ok(())
     }
 
     #[tracing::instrument(
@@ -395,7 +455,14 @@ mod tests {
     use crate::chain::TransactionsRecorder;
     use crate::chain_client::MockBlockChainClient;
     use crate::configs::EtherscanClientConfig;
-    use crate::dao::MockDaoInterface;
+    use crate::dao::{
+        MockDaoInterface,
+        MockDaoTransactionInterface,
+    };
+    use crate::types::{
+        InvoiceStatus,
+        default_invoice,
+    };
 
     use super::*;
 
@@ -452,5 +519,156 @@ mod tests {
                 Err(BalanceCheckerError::FetchBalanceFailed)
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn asset_hub_reconciliation_observes_transfer_committed_after_balance_fetch() {
+        let mut stale_invoice = default_invoice().with_amount(Decimal::ZERO);
+        stale_invoice.invoice.chain = ChainType::PolkadotAssetHub;
+        let invoice_id = stale_invoice.invoice.id;
+        let balance = Decimal::TEN;
+
+        // Inject the race deterministically: the balance checker still holds a
+        // zero-total clone, while the transaction-scoped read represents the
+        // live subscription having committed the full balance in between.
+        let mut persisted_invoice = stale_invoice.clone();
+        persisted_invoice.total_received_amount = balance;
+        let mut dao_transaction = MockDaoTransactionInterface::default();
+        dao_transaction
+            .expect_get_invoice_with_received_amount_by_id()
+            .once()
+            .with(mockall::predicate::eq(invoice_id))
+            .return_once(move |_| Ok(Some(persisted_invoice)));
+        dao_transaction
+            .expect_commit()
+            .once()
+            .return_once(|| Ok(()));
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_begin_transaction()
+            .once()
+            .return_once(move || Ok(dao_transaction));
+
+        let mut recorder = TransactionsRecorder::<MockDaoInterface>::default();
+        recorder
+            .expect_process_invoice_transaction()
+            .never();
+        recorder
+            .expect_process_invoice_transaction_in()
+            .never();
+        recorder
+            .expect_apply_recorded_invoice_update()
+            .never();
+
+        let checker = BalanceChecker::new(
+            dao,
+            InvoiceRegistry::new(),
+            MockBlockChainClient::<AssetHubChainConfig>::default(),
+            MockBlockChainClient::<PolygonChainConfig>::default(),
+            EtherscanClient::new(EtherscanClientConfig {
+                requests_per_second: NonZeroU32::MIN,
+                api_key: String::new(),
+            }),
+            recorder,
+        );
+
+        assert!(
+            checker
+                .reconcile_asset_hub_balance(&mut stale_invoice, balance)
+                .await
+                .is_ok()
+        );
+        assert_eq!(
+            stale_invoice.total_received_amount,
+            balance
+        );
+    }
+
+    #[tokio::test]
+    async fn asset_hub_reconciliation_records_genuine_shortfall_once() {
+        let mut stale_invoice = default_invoice().with_amount(Decimal::ZERO);
+        stale_invoice.invoice.chain = ChainType::PolkadotAssetHub;
+        let invoice_id = stale_invoice.invoice.id;
+        let recorded_amount = Decimal::new(3, 0);
+        let balance = Decimal::TEN;
+        let expected_delta = balance - recorded_amount;
+
+        let mut persisted_invoice = stale_invoice.clone();
+        persisted_invoice.total_received_amount = recorded_amount;
+        let returned_persisted_invoice = persisted_invoice.clone();
+
+        let mut dao_transaction = MockDaoTransactionInterface::default();
+        dao_transaction
+            .expect_get_invoice_with_received_amount_by_id()
+            .once()
+            .with(mockall::predicate::eq(invoice_id))
+            .return_once(move |_| Ok(Some(returned_persisted_invoice)));
+        dao_transaction
+            .expect_commit()
+            .once()
+            .return_once(|| Ok(()));
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_begin_transaction()
+            .once()
+            .return_once(move || Ok(dao_transaction));
+
+        let mut recorder = TransactionsRecorder::<MockDaoInterface>::default();
+        recorder
+            .expect_process_invoice_transaction()
+            .never();
+        recorder
+            .expect_process_invoice_transaction_in()
+            .once()
+            .withf(move |_, invoice, transaction| {
+                invoice.total_received_amount == recorded_amount
+                    && transaction.invoice_id == invoice_id
+                    && transaction.transfer_info.amount == expected_delta
+                    && transaction
+                        .transaction_id
+                        .block_number
+                        .is_none()
+                    && transaction
+                        .transaction_id
+                        .position_in_block
+                        .is_none()
+                    && transaction
+                        .transaction_id
+                        .tx_hash
+                        .is_none()
+            })
+            .return_once(|_, invoice, transaction| {
+                let mut updated_invoice = invoice.clone();
+                updated_invoice.total_received_amount += transaction.transfer_info.amount;
+                updated_invoice.invoice.status = InvoiceStatus::PartiallyPaid;
+                Ok((updated_invoice, Decimal::ZERO))
+            });
+        recorder
+            .expect_apply_recorded_invoice_update()
+            .once()
+            .return_once(|invoice, updated_invoice, _| *invoice = updated_invoice);
+
+        let checker = BalanceChecker::new(
+            dao,
+            InvoiceRegistry::new(),
+            MockBlockChainClient::<AssetHubChainConfig>::default(),
+            MockBlockChainClient::<PolygonChainConfig>::default(),
+            EtherscanClient::new(EtherscanClientConfig {
+                requests_per_second: NonZeroU32::MIN,
+                api_key: String::new(),
+            }),
+            recorder,
+        );
+
+        assert!(
+            checker
+                .reconcile_asset_hub_balance(&mut stale_invoice, balance)
+                .await
+                .is_ok()
+        );
+        assert_eq!(
+            stale_invoice.total_received_amount,
+            balance
+        );
     }
 }

--- a/daemon/src/chain/invoice_registry.rs
+++ b/daemon/src/chain/invoice_registry.rs
@@ -116,20 +116,22 @@ impl InvoiceRegistry {
             .cloned()
     }
 
-    /// Replace the stored invoice data (amount, cart, expiry, ...) while
-    /// preserving the received amount tracked so far. Inserts the record as-is
-    /// when the invoice isn't tracked yet.
+    /// Replace the data of a still-tracked invoice (amount, cart, expiry, ...)
+    /// while preserving the received amount tracked so far.
+    ///
+    /// An absent record is deliberately not inserted: payment processing
+    /// removes final invoices, and a post-commit update refresh must not
+    /// resurrect one from its stale pre-payment snapshot.
     pub async fn refresh_invoice(
         &self,
         mut record: InvoiceWithReceivedAmount,
     ) {
         let mut invoices = self.invoices.write().await;
 
-        if let Some(existing) = invoices.get(&record.invoice.id) {
+        if let Some(existing) = invoices.get_mut(&record.invoice.id) {
             record.total_received_amount = existing.total_received_amount;
+            *existing = record;
         }
-
-        invoices.insert(record.invoice.id, record);
     }
 
     pub async fn update_filled_amount(
@@ -287,7 +289,9 @@ mod tests {
             Decimal::TEN
         );
 
-        // Refreshing an untracked invoice inserts it as-is
+        // Deterministic update/payment interleaving: payment processing removes
+        // a final invoice before the post-commit update refresh reaches the
+        // registry. The stale update must not resurrect that absent invoice.
         let other_id = Uuid::new_v4();
         let other = Invoice {
             id: other_id,
@@ -297,14 +301,9 @@ mod tests {
             .refresh_invoice(other.clone().with_amount(Decimal::ONE))
             .await;
 
-        let stored = registry
-            .get_invoice(&other_id)
-            .await
-            .unwrap();
-        assert_eq!(stored.invoice, other);
         assert_eq!(
-            stored.total_received_amount,
-            Decimal::ONE
+            registry.get_invoice(&other_id).await,
+            None
         );
     }
 

--- a/daemon/src/chain/invoice_registry.rs
+++ b/daemon/src/chain/invoice_registry.rs
@@ -117,11 +117,20 @@ impl InvoiceRegistry {
     }
 
     /// Replace the data of a still-tracked invoice (amount, cart, expiry, ...)
-    /// while preserving the received amount tracked so far.
+    /// while preserving the payment progress tracked so far.
     ///
     /// An absent record is deliberately not inserted: payment processing
     /// removes final invoices, and a post-commit update refresh must not
     /// resurrect one from its stale pre-payment snapshot.
+    ///
+    /// Payment progress means both the received amount *and* the status:
+    /// `update_filled_amount` maintains them as a matched pair, and the record
+    /// handed to a refresh is a pre-payment snapshot of both. `update_invoice`
+    /// never intends to change the status — its UPDATE touches only `amount`,
+    /// `cart` and `valid_till` — so carrying the status through would let a
+    /// concurrently recorded `PartiallyPaid` be reverted to an unpaid status
+    /// while its received amount stayed, which is exactly the inconsistent view
+    /// this function exists to avoid.
     pub async fn refresh_invoice(
         &self,
         mut record: InvoiceWithReceivedAmount,
@@ -130,6 +139,7 @@ impl InvoiceRegistry {
 
         if let Some(existing) = invoices.get_mut(&record.invoice.id) {
             record.total_received_amount = existing.total_received_amount;
+            record.invoice.status = existing.invoice.status;
             *existing = record;
         }
     }
@@ -304,6 +314,74 @@ mod tests {
         assert_eq!(
             registry.get_invoice(&other_id).await,
             None
+        );
+    }
+
+    /// Deterministic update/payment interleaving on a *still-tracked* invoice:
+    /// a transfer lands between the update's commit and its registry refresh.
+    /// The refresh carries a pre-payment snapshot, so it must keep neither half
+    /// of the payment-progress pair — reverting the status while retaining the
+    /// received amount would leave the registry internally inconsistent.
+    #[tokio::test]
+    async fn test_refresh_invoice_does_not_revert_concurrent_payment_status() {
+        let registry = InvoiceRegistry::new();
+        let invoice_id = Uuid::new_v4();
+        let original = Invoice {
+            id: invoice_id,
+            status: InvoiceStatus::Waiting,
+            amount: Decimal::ONE_HUNDRED,
+            ..default_invoice()
+        };
+
+        registry
+            .add_invoice(
+                original
+                    .clone()
+                    .with_amount(Decimal::ZERO),
+            )
+            .await;
+
+        // A transfer is recorded: amount and status move together.
+        registry
+            .update_filled_amount(
+                &invoice_id,
+                Decimal::TEN,
+                InvoiceStatus::PartiallyPaid,
+            )
+            .await;
+
+        // The in-flight invoice update commits and refreshes with the snapshot
+        // it built *before* that transfer: still `Waiting`, still zero.
+        let updated = Invoice {
+            amount: Decimal::from(250),
+            ..original
+        };
+        registry
+            .refresh_invoice(
+                updated
+                    .clone()
+                    .with_amount(Decimal::ZERO),
+            )
+            .await;
+
+        let stored = registry
+            .get_invoice(&invoice_id)
+            .await
+            .unwrap();
+
+        // The edited invoice data is applied ...
+        assert_eq!(
+            stored.invoice.amount,
+            Decimal::from(250)
+        );
+        // ... but payment progress survives intact, both halves.
+        assert_eq!(
+            stored.invoice.status,
+            InvoiceStatus::PartiallyPaid
+        );
+        assert_eq!(
+            stored.total_received_amount,
+            Decimal::TEN
         );
     }
 

--- a/daemon/src/chain/transactions_recorder.rs
+++ b/daemon/src/chain/transactions_recorder.rs
@@ -135,18 +135,13 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
         Ok(())
     }
 
-    async fn store_transaction(
+    async fn store_transaction_in(
         &self,
+        dao_transaction: &D::Transaction,
         transaction: IncomingTransaction,
         invoice_status: InvoiceStatus,
         total_received_amount: Decimal,
     ) -> Result<(), TransactionsRecorderError> {
-        let dao_transaction = self
-            .dao
-            .begin_transaction()
-            .await
-            .map_err(|_e| TransactionsRecorderError::DaoTransactionError)?;
-
         let invoice_id = transaction.invoice_id;
 
         dao_transaction
@@ -178,21 +173,21 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             // put here total received amount which might be slightly higher or lower then
             // invoice amount
             self.add_payout_to_dao_transaction(
-                &dao_transaction,
+                dao_transaction,
                 invoice,
                 total_received_amount,
             )
             .await?;
 
             self.add_webhook_to_dao_transaction(
-                &dao_transaction,
+                dao_transaction,
                 public_invoice,
                 InvoiceEventType::Paid,
             )
             .await?;
         } else if invoice_status == InvoiceStatus::PartiallyPaid {
             self.add_webhook_to_dao_transaction(
-                &dao_transaction,
+                dao_transaction,
                 public_invoice,
                 InvoiceEventType::PartiallyPaid,
             )
@@ -204,7 +199,7 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             let refund_amount = total_received_amount - payout_amount;
 
             self.add_payout_to_dao_transaction(
-                &dao_transaction,
+                dao_transaction,
                 invoice.clone(),
                 payout_amount,
             )
@@ -218,19 +213,143 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
                 .map_err(|_e| TransactionsRecorderError::DaoTransactionError)?;
 
             self.add_webhook_to_dao_transaction(
-                &dao_transaction,
+                dao_transaction,
                 public_invoice,
                 InvoiceEventType::Paid,
             )
             .await?;
         }
 
-        dao_transaction
-            .commit()
+        Ok(())
+    }
+
+    #[cfg(test)]
+    async fn store_transaction(
+        &self,
+        transaction: IncomingTransaction,
+        invoice_status: InvoiceStatus,
+        total_received_amount: Decimal,
+    ) -> Result<(), TransactionsRecorderError> {
+        let dao_transaction = self
+            .dao
+            .begin_transaction()
             .await
             .map_err(|_e| TransactionsRecorderError::DaoTransactionError)?;
 
-        Ok(())
+        self.store_transaction_in(
+            &dao_transaction,
+            transaction,
+            invoice_status,
+            total_received_amount,
+        )
+        .await?;
+
+        dao_transaction
+            .commit()
+            .await
+            .map_err(|_e| TransactionsRecorderError::DaoTransactionError)
+    }
+
+    pub(crate) async fn process_invoice_transaction_in(
+        &self,
+        dao_transaction: &D::Transaction,
+        invoice: &InvoiceWithReceivedAmount,
+        transaction: IncomingTransaction,
+    ) -> Result<(InvoiceWithReceivedAmount, Decimal), TransactionsRecorderError> {
+        let updated_received_amount =
+            invoice.total_received_amount + transaction.transfer_info.amount;
+
+        let underpayment_tolerance = self
+            .config
+            .get_asset_underpayment_tolerance(
+                invoice.invoice.chain,
+                &invoice.invoice.asset_id,
+            );
+        let min_paid_amount = invoice.invoice.amount - underpayment_tolerance;
+
+        let overpayment_tolerance = self
+            .config
+            .get_asset_overpayment_tolerance(
+                invoice.invoice.chain,
+                &invoice.invoice.asset_id,
+            );
+        let max_paid_amount = invoice.invoice.amount + overpayment_tolerance;
+
+        let is_underpaid = updated_received_amount < min_paid_amount;
+        let is_overpaid = updated_received_amount > max_paid_amount;
+
+        let updated_status = if !is_underpaid && !is_overpaid {
+            InvoiceStatus::Paid
+        } else if is_underpaid {
+            InvoiceStatus::PartiallyPaid
+        } else {
+            InvoiceStatus::OverPaid
+        };
+
+        self.store_transaction_in(
+            dao_transaction,
+            transaction,
+            updated_status,
+            updated_received_amount,
+        )
+        .await?;
+
+        let mut updated_invoice = invoice.clone();
+        updated_invoice.invoice.status = updated_status;
+        updated_invoice.total_received_amount = updated_received_amount;
+
+        Ok((updated_invoice, min_paid_amount))
+    }
+
+    pub(crate) async fn apply_recorded_invoice_update(
+        &self,
+        invoice: &mut InvoiceWithReceivedAmount,
+        updated_invoice: InvoiceWithReceivedAmount,
+        min_paid_amount: Decimal,
+    ) {
+        let updated_status = updated_invoice.invoice.status;
+        let updated_received_amount = updated_invoice.total_received_amount;
+
+        match updated_status {
+            InvoiceStatus::Paid | InvoiceStatus::OverPaid => {
+                tracing::info!(
+                    invoice_id = %updated_invoice.invoice.id,
+                    filled_amount = %updated_received_amount,
+                    min_fill_amount = %min_paid_amount,
+                    "Invoice has been paid, removing from registry, stop monitoring"
+                );
+
+                self.registry
+                    .remove_invoice(&updated_invoice.invoice.id)
+                    .await;
+            },
+            InvoiceStatus::PartiallyPaid => {
+                tracing::info!(
+                    invoice_id = %updated_invoice.invoice.id,
+                    filled_amount = %updated_received_amount,
+                    min_fill_amount = %min_paid_amount,
+                    "Invoice has been partially paid, updating filled amount in registry"
+                );
+
+                self.registry
+                    .update_filled_amount(
+                        &updated_invoice.invoice.id,
+                        updated_received_amount,
+                        updated_status,
+                    )
+                    .await;
+            },
+            _ => {
+                tracing::error!(
+                    invoice_id = %updated_invoice.invoice.id,
+                    invoice_status = %updated_status,
+                    "Recorded invoice transaction produced an unexpected status"
+                );
+                return;
+            },
+        }
+
+        *invoice = updated_invoice;
     }
 
     #[tracing::instrument(skip_all)]
@@ -244,92 +363,23 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
         // address. We'll be able to init balance and transactions refetch and
         // will need to create only refund but not payout. So we'll need to respect the
         // invoice status and probably allow transition `Paid` -> `Overpaid`.
-        let &mut InvoiceWithReceivedAmount {
-            ref mut invoice,
-            ref mut total_received_amount,
-        } = invoice;
+        let dao_transaction = self
+            .dao
+            .begin_transaction()
+            .await
+            .map_err(|_e| TransactionsRecorderError::DaoTransactionError)?;
 
-        let updated_received_amount = *total_received_amount + transaction.transfer_info.amount;
-
-        let underpayment_tolerance = self
-            .config
-            .get_asset_underpayment_tolerance(invoice.chain, &invoice.asset_id);
-        let min_paid_amount = invoice.amount - underpayment_tolerance;
-
-        let overpayment_tolerance = self
-            .config
-            .get_asset_overpayment_tolerance(invoice.chain, &invoice.asset_id);
-        let max_paid_amount = invoice.amount + overpayment_tolerance;
-
-        let is_underpaid = updated_received_amount < min_paid_amount;
-        let is_overpaid = updated_received_amount > max_paid_amount;
-
-        let updated_status = if !is_underpaid && !is_overpaid {
-            InvoiceStatus::Paid
-        } else if is_underpaid {
-            InvoiceStatus::PartiallyPaid
-        } else {
-            InvoiceStatus::OverPaid
-        };
-
-        match self
-            .store_transaction(
-                transaction,
-                updated_status,
-                updated_received_amount,
-            )
+        let (updated_invoice, min_paid_amount) = match self
+            .process_invoice_transaction_in(&dao_transaction, invoice, transaction)
             .await
         {
-            Ok(())
-                if matches!(
-                    updated_status,
-                    InvoiceStatus::Paid | InvoiceStatus::OverPaid
-                ) =>
-            {
-                tracing::info!(
-                    invoice_id = %invoice.id,
-                    filled_amount = %updated_received_amount,
-                    min_fill_amount = %min_paid_amount,
-                    "Invoice has been paid, removing from registry, stop monitoring"
-                );
-
-                self.registry
-                    .remove_invoice(&invoice.id)
-                    .await;
-
-                invoice.status = updated_status;
-                *total_received_amount = updated_received_amount;
-            },
-            Ok(()) if updated_status == InvoiceStatus::PartiallyPaid => {
-                tracing::info!(
-                    invoice_id = %invoice.id,
-                    filled_amount = %updated_received_amount,
-                    min_fill_amount = %min_paid_amount,
-                    "Invoice has been partially paid, updating filled amount in registry"
-                );
-
-                self.registry
-                    .update_filled_amount(
-                        &invoice.id,
-                        updated_received_amount,
-                        updated_status,
-                    )
-                    .await;
-
-                invoice.status = updated_status;
-                *total_received_amount = updated_received_amount;
-            },
-            #[expect(
-                clippy::unreachable,
-                reason = "pre-existing panic site, grandfathered when the panic gate landed; see the panic-gate backlog in docs/conventions.md"
-            )]
-            Ok(()) => unreachable!(),
+            Ok(update) => update,
             Err(TransactionsRecorderError::TransactionDuplication {
                 chain,
                 general_transaction_id,
             }) => {
                 tracing::debug!(
-                    invoice_id = %invoice.id,
+                    invoice_id = %invoice.invoice.id,
                     ?chain,
                     transaction_id = ?general_transaction_id,
                     "Transaction is already presented in database, skip it"
@@ -344,13 +394,28 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
             },
             Err(TransactionsRecorderError::DaoTransactionError) => {
                 tracing::error!(
-                    invoice_id = %invoice.id,
+                    invoice_id = %invoice.invoice.id,
                     "Error while storing transaction for invoice"
                 );
 
                 return Err(TransactionsRecorderError::DaoTransactionError);
             },
+        };
+
+        if dao_transaction.commit().await.is_err() {
+            tracing::error!(
+                invoice_id = %invoice.invoice.id,
+                "Error while committing transaction for invoice"
+            );
+            return Err(TransactionsRecorderError::DaoTransactionError);
         }
+
+        self.apply_recorded_invoice_update(
+            invoice,
+            updated_invoice,
+            min_paid_amount,
+        )
+        .await;
 
         Ok(())
     }
@@ -358,7 +423,7 @@ impl<D: DaoInterface + 'static> TransactionsRecorder<D> {
 
 #[cfg(test)]
 mockall::mock! {
-    pub TransactionsRecorder<D: 'static> {
+    pub TransactionsRecorder<D: DaoInterface + 'static> {
         pub fn new(
             dao: D,
             registry: InvoiceRegistry,
@@ -370,9 +435,23 @@ mockall::mock! {
             invoice: &mut InvoiceWithReceivedAmount,
             transaction: IncomingTransaction,
         ) -> Result<(), TransactionsRecorderError>;
+
+        pub async fn process_invoice_transaction_in(
+            &self,
+            dao_transaction: &D::Transaction,
+            invoice: &InvoiceWithReceivedAmount,
+            transaction: IncomingTransaction,
+        ) -> Result<(InvoiceWithReceivedAmount, Decimal), TransactionsRecorderError>;
+
+        pub async fn apply_recorded_invoice_update(
+            &self,
+            invoice: &mut InvoiceWithReceivedAmount,
+            updated_invoice: InvoiceWithReceivedAmount,
+            min_paid_amount: Decimal,
+        );
     }
 
-    impl<D> Clone for TransactionsRecorder<D> {
+    impl<D: DaoInterface + 'static> Clone for TransactionsRecorder<D> {
         fn clone(&self) -> Self;
     }
 }
@@ -1231,6 +1310,80 @@ mod tests {
                     .is_zero()
             );
         }
+    }
+
+    #[tokio::test]
+    async fn transaction_scoped_adjustment_records_the_shortfall_once() {
+        let invoice = Invoice {
+            amount: Decimal::ONE_HUNDRED,
+            chain: ChainType::PolkadotAssetHub,
+            ..default_invoice()
+        };
+        let invoice_id = invoice.id;
+        let recorded_amount = Decimal::new(3, 0);
+        let adjustment = Decimal::new(7, 0);
+        let expected_total = Decimal::TEN;
+        let invoice_with_amount = invoice
+            .clone()
+            .with_amount(recorded_amount);
+
+        let mut dao_transaction = MockDaoTransactionInterface::default();
+        dao_transaction
+            .expect_create_transaction()
+            .once()
+            .returning(Ok);
+
+        let updated_invoice = Invoice {
+            status: InvoiceStatus::PartiallyPaid,
+            ..invoice
+        };
+        dao_transaction
+            .expect_update_invoice_status()
+            .once()
+            .with(
+                eq(invoice_id),
+                eq(InvoiceStatus::PartiallyPaid),
+            )
+            .return_once(move |_, _| Ok(updated_invoice));
+        dao_transaction
+            .expect_create_webhook_event()
+            .once()
+            .returning(Ok);
+
+        // The caller owns this transaction so the scoped recorder must neither
+        // begin another one nor commit before reconciliation has finished.
+        let recorder = TransactionsRecorder::new(
+            MockDaoInterface::default(),
+            InvoiceRegistry::new(),
+            default_payments_config(),
+        );
+
+        let mut transaction = default_incoming_transaction(invoice_id);
+        transaction.transfer_info.chain = ChainType::PolkadotAssetHub;
+        transaction.transfer_info.amount = adjustment;
+        transaction.transaction_id = GeneralTransactionId {
+            block_number: None,
+            position_in_block: None,
+            tx_hash: None,
+        };
+
+        let (result, _) = recorder
+            .process_invoice_transaction_in(
+                &dao_transaction,
+                &invoice_with_amount,
+                transaction,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.total_received_amount,
+            expected_total
+        );
+        assert_eq!(
+            result.invoice.status,
+            InvoiceStatus::PartiallyPaid
+        );
     }
 
     /// A payout that cannot be built must not roll back the payment.

--- a/daemon/src/swaps/tracker.rs
+++ b/daemon/src/swaps/tracker.rs
@@ -12,12 +12,14 @@ use crate::clients::{
 };
 use crate::dao::{
     DaoInterface,
+    DaoSwapError,
     DaoTransactionInterface,
 };
 use crate::types::{
     PayoutStatus,
     RefundStatus,
     Swap,
+    SwapStatus,
     TransactionOriginVariant,
 };
 use crate::utils::logging::{
@@ -66,6 +68,77 @@ impl TrackedSwaps {
     ) {
         self.swaps.remove(&swap_id);
     }
+}
+
+/// Apply the result of re-reading a hashless tracked swap.
+///
+/// Kept separate from the database call so the tracker-store behavior can be
+/// tested without constructing its unrelated provider and chain clients.
+fn apply_hashless_swap_reload(
+    store: &mut TrackedSwaps,
+    swap: &Swap,
+    reload_result: Result<Option<Swap>, DaoSwapError>,
+) -> Option<Swap> {
+    let reloaded = match reload_result {
+        Ok(Some(reloaded)) => reloaded,
+        Ok(None) => {
+            tracing::warn!(
+                swap_id = %swap.id,
+                invoice_id = %swap.request.invoice_id,
+                "Tracked swap has disappeared from the database, dropping it from the tracker"
+            );
+            store.remove_swap(swap.id);
+            return None;
+        },
+        Err(e) => {
+            tracing::warn!(
+                swap_id = %swap.id,
+                invoice_id = %swap.request.invoice_id,
+                error = ?e,
+                "Failed to re-read a swap with no transaction hash, will retry next round"
+            );
+            return None;
+        },
+    };
+
+    if reloaded
+        .swap_details
+        .transaction_hash
+        .is_none()
+    {
+        if matches!(
+            reloaded.status,
+            SwapStatus::Completed | SwapStatus::Failed | SwapStatus::Abandoned
+        ) {
+            // Loud on purpose: the swap was marked `Submitted` before the
+            // external call, so funds may have been in flight with nothing
+            // recorded to track them by. Remove it after this signal because a
+            // terminal row can never acquire a hash on a later refresh.
+            tracing::warn!(
+                swap_id = %swap.id,
+                invoice_id = %swap.request.invoice_id,
+                swap_status = %reloaded.status,
+                "Tracked swap reached a terminal status without a transaction hash; manual reconciliation may be required, dropping it from the tracker"
+            );
+            store.remove_swap(swap.id);
+            return None;
+        }
+
+        // Loud on purpose: the swap was marked `Submitted` before the external
+        // call, so funds may be in flight with nothing recorded to track them
+        // by.
+        tracing::warn!(
+            swap_id = %swap.id,
+            invoice_id = %swap.request.invoice_id,
+            swap_status = %reloaded.status,
+            "Tracked swap still has no transaction hash and cannot be polled — if this persists, its submission needs manual reconciliation"
+        );
+        return None;
+    }
+
+    store.add_swaps(vec![reloaded.clone()]);
+
+    Some(reloaded)
 }
 
 pub struct SwapsTracker<D: DaoInterface + 'static> {
@@ -297,49 +370,8 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
         &mut self,
         swap: &Swap,
     ) -> Option<Swap> {
-        let reloaded = match self.dao.get_swap_by_id(swap.id).await {
-            Ok(Some(reloaded)) => reloaded,
-            Ok(None) => {
-                tracing::warn!(
-                    swap_id = %swap.id,
-                    invoice_id = %swap.request.invoice_id,
-                    "Tracked swap has disappeared from the database, dropping it from the tracker"
-                );
-                self.store.remove_swap(swap.id);
-                return None;
-            },
-            Err(e) => {
-                tracing::warn!(
-                    swap_id = %swap.id,
-                    invoice_id = %swap.request.invoice_id,
-                    error = ?e,
-                    "Failed to re-read a swap with no transaction hash, will retry next round"
-                );
-                return None;
-            },
-        };
-
-        if reloaded
-            .swap_details
-            .transaction_hash
-            .is_none()
-        {
-            // Loud on purpose: the swap was marked `Submitted` before the
-            // external call, so funds may be in flight with nothing recorded
-            // to track them by.
-            tracing::warn!(
-                swap_id = %swap.id,
-                invoice_id = %swap.request.invoice_id,
-                swap_status = %reloaded.status,
-                "Tracked swap still has no transaction hash and cannot be polled — if this persists, its submission needs manual reconciliation"
-            );
-            return None;
-        }
-
-        self.store
-            .add_swaps(vec![reloaded.clone()]);
-
-        Some(reloaded)
+        let reload_result = self.dao.get_swap_by_id(swap.id).await;
+        apply_hashless_swap_reload(&mut self.store, swap, reload_result)
     }
 
     async fn check_swaps(&mut self) {
@@ -506,5 +538,60 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
         tokio::spawn(async move {
             self.perform(token).await;
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dao::DaoSwapError;
+    use crate::types::{
+        SwapStatus,
+        default_swap,
+    };
+
+    use super::*;
+
+    #[test]
+    fn terminal_hashless_swap_is_dropped_after_reload() {
+        let mut swap = default_swap(Uuid::new_v4());
+        swap.status = SwapStatus::Submitted;
+
+        let mut failed = swap.clone();
+        failed.status = SwapStatus::Failed;
+
+        let mut store = TrackedSwaps::new();
+        store.add_swaps(vec![swap.clone()]);
+
+        assert!(apply_hashless_swap_reload(&mut store, &swap, Ok(Some(failed))).is_none());
+        assert!(!store.swaps.contains_key(&swap.id));
+    }
+
+    #[test]
+    fn transient_hashless_swap_states_remain_tracked_for_retry() {
+        let mut swap = default_swap(Uuid::new_v4());
+        swap.status = SwapStatus::Submitted;
+
+        let mut store = TrackedSwaps::new();
+        store.add_swaps(vec![swap.clone()]);
+
+        assert!(
+            apply_hashless_swap_reload(
+                &mut store,
+                &swap,
+                Ok(Some(swap.clone()))
+            )
+            .is_none()
+        );
+        assert!(store.swaps.contains_key(&swap.id));
+
+        assert!(
+            apply_hashless_swap_reload(
+                &mut store,
+                &swap,
+                Err(DaoSwapError::DatabaseError)
+            )
+            .is_none()
+        );
+        assert!(store.swaps.contains_key(&swap.id));
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,9 +58,9 @@ Client interface: `KeyringClient` (mockable via `mockall_double`).
 
 ### `daemon/src/chain/` — Chain Monitoring & Execution
 - **`transfer_tracker.rs`** (`TransfersTracker`): Subscribes to finalized blocks per chain, detects incoming transfers, and notifies `TransactionsRecorder`. Failed subscriptions and streams that end before delivering an event use a cancellation-aware exponential retry delay (1–60 seconds). Retry state resets only after a stream delivers an event; degradation is reported on entry and at most once per minute, with recovery reported separately.
-- **`transactions_recorder.rs`** (`TransactionsRecorder`): Records detected transactions to DB, updates `InvoiceRegistry`
+- **`transactions_recorder.rs`** (`TransactionsRecorder`): Records detected transactions to DB, updates `InvoiceRegistry`. Its transaction-scoped recording path lets Asset Hub balance reconciliation read the persisted received total and write a synthetic adjustment in one SQLite transaction; payout/refund/webhook/status side effects use that same path and the registry changes only after commit.
 - **`executor.rs`** (`TransfersExecutor`): Builds and submits payout transactions for both chains. Single executor instance handles Asset Hub + Polygon.
-- **`invoice_registry.rs`** (`InvoiceRegistry`): In-memory tracking of active invoices and their expected amounts. Thread-safe (internal `RwLock`).
+- **`invoice_registry.rs`** (`InvoiceRegistry`): In-memory tracking of active invoices and their expected amounts. Thread-safe (internal `RwLock`). Invoice-data refreshes update only records that are still present, preserving the received amount; they never reinsert an invoice removed concurrently after reaching a terminal status.
 
 ### `daemon/src/expiration_detector.rs` — ExpirationDetector
 Periodic background task. Checks for expired invoices, handles cleanup and status transitions.
@@ -111,6 +111,7 @@ Both are deterministic: same seed + same invoice params = same payment account.
 1. **Invoice created** via API → AppState derives payment address via Keyring → saves to DB → adds to InvoiceRegistry
 2. **Customer pays** to payment address on-chain
 3. **TransfersTracker** detects incoming transfer in finalized block → TransactionsRecorder saves transaction to DB, updates invoice status in InvoiceRegistry
+   - Asset Hub balance recovery re-reads the transaction sum inside the same transaction that writes its coordinate-less adjustment. A transfer committed after the chain balance fetch is therefore included before the delta is calculated, while a genuine positive shortfall is still recorded.
 4. **TransfersExecutor** picks up payouts from DB → builds transaction → signs via Keyring → submits to chain → records result
 5. **ExpirationDetector** periodically checks for expired invoices → updates status
 6. **WebhookSender** periodically sends unsent webhook events to configured URLs

--- a/docs/swaps.md
+++ b/docs/swaps.md
@@ -132,7 +132,10 @@ going back. Consequences:
   arrive are still detected by the chain transfer subscription.
 - A rejected submission marks the swap `Failed` with the executor's error
   message. If the rejection was spurious (e.g. a timeout after acceptance),
-  incoming funds are again caught by the transfer subscription.
+  incoming funds are again caught by the transfer subscription. When the
+  tracker reloads this terminal hashless row, it emits the manual-reconciliation
+  warning once and drops the row from its in-memory store. Hashless non-terminal
+  rows and database read errors remain tracked for the next polling round.
 - If the hash write fails after a successful submission, the caller still gets
   `Ok` — a retry could double-submit — but it receives the post-`Submitted` row,
   never the pre-submission one, so the reported status matches what was


### PR DESCRIPTION
All three share one root theme: state committed, cached or tracked without a consistent view of what else may have changed it. Each was confirmed against the code before being fixed, and each regression test was observed failing first.

H1 — the swap tracker leaked stuck submissions forever. Since fd91ca9 a swap is persisted `Submitted` before the external call, so a provider rejection leaves a terminal row with no transaction hash. `refresh_hashless_swap` dropped a tracked swap only when its row vanished from the database, so a terminal hashless row was re-read and re-warned every API round — ~1200 warnings/hour per stuck swap against an uncapped HashMap. Terminal rows now emit the manual-reconciliation warning once and leave the tracker; non-terminal rows and database read errors still retry.

H2 — invoice update propagation could resurrect a paid invoice. `update_invoice` commits before refreshing the registry, and `refresh_invoice` inserted unconditionally when no entry existed. If payment processing committed `Paid` and removed the invoice in that window, the stale `Waiting`/zero-received snapshot went back in; a later transfer was then matched against a final invoice and computed from zero, which the `Paid -> Paid` trigger permits — a second payout and webhook, with overpayment handling concealed. The guard is on the invariant, not the window: refreshes now update only still-tracked records. New invoices enter through `add_invoice`, so no caller relied on the insert.

H3 — Asset Hub reconciliation could double-record a transfer. The synthetic adjustment carries all-NULL chain coordinates and is therefore deliberately outside both partial uniqueness indexes, so the whole safety argument rested on a `delta <= 0` check computed from a stale in-memory total. A transfer committed by the live subscription after the balance fetch was invisible to it and got counted twice. The received total is now re-read inside the same transaction that writes the adjustment; payout, refund, webhook and status behavior are unchanged, and the registry is updated only after commit. A zero delta is also no longer reported as "received exceeds balance" — that error is now reserved for a real negative shortfall.

No migration and no public API change. The SQLite-backed DAO tests could not be run locally (this machine's SQLite predates 3.47.0 and fails the migrations); the interleavings are covered by deterministic mock tests.

Found in the pre-release review for 0.9.4.