### PR TITLE
chore(release): 0.9.4, pinned to front-end 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 **Please note:**
 This is a public beta release of the Kalatori daemon. While it adheres to the [API specs](https://kalapaja.github.io/kalatori-api), it is still under active development. We encourage you to test it and provide feedback.
 
+## [0.9.4] - 2026-08-04
+
+Patch release fixing payment dead ends found while reviewing everything merged
+since 0.9.3. Requires the Kassette 0.1.0 front-end, which this release pins.
+
+### 🐛 Bug Fixes
+
+- Across quotes: a `gas` of `"0"` is now treated as absent rather than
+  forwarded. Across sends `gas: "0"` — not an omitted key — when its simulation
+  fails, which it does for every ERC-20 payer who has not yet granted an
+  approval. The zero reached the payer's wallet and produced a transaction that
+  could never be mined. A zero `max_fee_per_gas` is normalized the same way and
+  drops the priority fee with it; a zero priority fee alongside a real cap, and
+  a zero `value`, are both legitimate and preserved (#372)
+- Swap provider outages are no longer reported to the payer as rejections: the
+  Across and Bungee clients now fall back to the transport status when the error
+  body carries none, matching the fix 0.9.3 applied only to 0x (#373)
+- Terminal swaps with no transaction hash are dropped from the tracker after one
+  warning, instead of being reloaded and re-warned every polling round with no
+  upper bound on the tracker's size (#374)
+- An invoice update can no longer resurrect a paid invoice in the in-memory
+  registry, nor revert a concurrently recorded payment status while keeping its
+  received amount (#374)
+- Asset Hub balance reconciliation reads the received total inside the
+  transaction that writes its adjustment, so a transfer committed between the
+  balance fetch and the write is no longer counted twice (#374)
+
+### 📚 Documentation
+
+- `docs/swaps.md` records Across's zero-gas sentinel and why 0x is treated
+  differently; `CONTRIBUTING.md` MSRV corrected to 1.91 (#372, #373)
+
 ## [0.9.3] - 2026-07-18
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "kalatori"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "alloy",
  "async-lock",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalatori"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "A non-custodial crypto payment-gateway daemon."
 homepage = "https://github.com/Kalapaja/Kalatori"

--- a/docs/swaps.md
+++ b/docs/swaps.md
@@ -102,7 +102,9 @@ This supersedes the earlier decision (same day) to reject such quotes with
 converted the fields unguarded via `BigInt(swapTx.gas)`, which threw in the
 payer's browser when a field was absent. Kassette#50 fixed that half; this is
 the other half. **The relaxed daemon must not ship ahead of a Kassette build
-containing #50** — an older Kassette still throws on an omitted key.
+containing #50** — an older Kassette still throws on an omitted key. Satisfied
+as of 0.9.4, which pins front-end 0.1.0 (`front-end.mk`); do not lower that pin
+below 0.1.0 while the daemon omits gas keys.
 
 `UnusableQuote` itself remains, for quote expiry timestamps outside the
 representable range (`daemon/src/clients/swaps/across/types.rs`,

--- a/front-end.mk
+++ b/front-end.mk
@@ -4,4 +4,4 @@
 # for the `static/` directory, so bumping the front-end version busts only that
 # cache and leaves the tool cache untouched.
 
-front_end_version := 0.0.25
+front_end_version := 0.1.0


### PR DESCRIPTION
Patch release closing the payment dead ends found while reviewing everything merged since 0.9.3.

The front-end pin is the load-bearing part. 0.9.4 omits Across gas keys when the provider sends its `"0"` sentinel, and a Kassette older than 0.1.0 converts an absent key with `BigInt(undefined)` and throws in the payer's browser. `docs/swaps.md` recorded that ordering constraint as a release blocker; pinning 0.1.0 satisfies it, and the note now says so, with a warning not to lower the pin while the daemon omits gas keys.

Verified against the pinned build: `make download-front-end` fetches and unpacks the 0.1.0 release, the daemon reports "Kalatori 0.9.4 is starting...", and the suite is 290 passed / 0 failed with clippy clean under the CI invocation.