### PR TITLE
fix(swaps): verify settlement before a swap can direct a refund

### DIFF
--- a/daemon/src/chain_client.rs
+++ b/daemon/src/chain_client.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 use crate::types::{
     ChainType,
     GeneralTransactionId,
+    SwapChainType,
     TransferInfo,
 };
 
@@ -102,6 +103,39 @@ pub struct GeneralChainTransfer {
     pub transaction_hash: Option<String>,
     // TODO: use DateTime<Utc> for consistency
     pub timestamp: u64, // milliseconds since epoch
+}
+
+/// An ERC-20 transfer decoded from a destination-chain transaction receipt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettlementTransfer {
+    pub token_address: String,
+    pub recipient_address: String,
+    pub amount_units: Option<u128>,
+}
+
+/// Destination-chain evidence used to independently confirm swap settlement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwapSettlement {
+    pub chain: SwapChainType,
+    pub transfers: Vec<SettlementTransfer>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum SettlementVerificationError {
+    #[error("invalid transaction hash")]
+    InvalidTransactionHash,
+    #[error("destination-chain receipt is not available")]
+    ReceiptUnavailable,
+}
+
+/// Reads destination-chain settlement evidence independently of swap providers.
+#[cfg_attr(test, mockall::automock)]
+#[trait_variant::make(Send)]
+pub trait SwapSettlementVerifier: Sync {
+    async fn get_swap_settlement(
+        &self,
+        transaction_hash: &str,
+    ) -> Result<SwapSettlement, SettlementVerificationError>;
 }
 
 impl GeneralChainTransfer {

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -58,14 +58,19 @@ use super::{
     GeneralTransactionId,
     KeyringClient,
     QueryError,
+    SettlementTransfer,
+    SettlementVerificationError,
     SignPermitRequestData,
     SignedTransaction,
     SignedTransactionUtils,
     SubscriptionError,
+    SwapSettlement,
+    SwapSettlementVerifier,
     TransactionError,
     TransfersStream,
     UnsignedTransaction,
 };
+use crate::types::SwapChainType;
 
 use super::keyring::SignTransactionRequestData;
 
@@ -1468,6 +1473,54 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
                 transaction_id: op_hash,
             },
         )
+    }
+}
+
+impl SwapSettlementVerifier for PolygonClient {
+    #[tracing::instrument(skip(self))]
+    async fn get_swap_settlement(
+        &self,
+        transaction_hash: &str,
+    ) -> Result<SwapSettlement, SettlementVerificationError> {
+        let transaction_hash = transaction_hash
+            .parse::<TxHash>()
+            .map_err(|_| SettlementVerificationError::InvalidTransactionHash)?;
+        let receipt = self
+            .provider
+            .get_transaction_receipt(transaction_hash)
+            .await
+            .inspect_err(|error| {
+                tracing::debug!(
+                    error.source = ?error,
+                    %transaction_hash,
+                    "Failed to fetch swap settlement receipt"
+                );
+            })
+            .map_err(|_| SettlementVerificationError::ReceiptUnavailable)?
+            .ok_or(SettlementVerificationError::ReceiptUnavailable)?;
+
+        let transfers = receipt
+            .inner
+            .logs()
+            .iter()
+            .filter_map(|log| {
+                let decoded = log
+                    .log_decode::<IERC20::Transfer>()
+                    .ok()?;
+                let amount_units = u128::try_from(decoded.inner.data.value).ok();
+
+                Some(SettlementTransfer {
+                    token_address: log.address().to_string(),
+                    recipient_address: decoded.inner.data.to.to_string(),
+                    amount_units,
+                })
+            })
+            .collect();
+
+        Ok(SwapSettlement {
+            chain: SwapChainType::Polygon,
+            transfers,
+        })
     }
 }
 

--- a/daemon/src/dao/interface.rs
+++ b/daemon/src/dao/interface.rs
@@ -337,6 +337,7 @@ pub trait DaoInterface: Send + Sync + 'static {
     async fn update_swap_completed(
         &self,
         swap_id: Uuid,
+        settlement_verified: bool,
     ) -> Result<Swap, DaoSwapError>;
 
     async fn update_swap_failed(
@@ -614,6 +615,7 @@ pub trait DaoTransactionInterface {
     async fn update_swap_completed(
         &self,
         swap_id: Uuid,
+        settlement_verified: bool,
     ) -> Result<Swap, DaoSwapError>;
 
     async fn update_swap_failed(
@@ -995,8 +997,9 @@ impl DaoInterface for DAO {
     async fn update_swap_completed(
         &self,
         swap_id: Uuid,
+        settlement_verified: bool,
     ) -> Result<Swap, DaoSwapError> {
-        DaoSwapMethods::update_swap_completed(self, swap_id).await
+        DaoSwapMethods::update_swap_completed(self, swap_id, settlement_verified).await
     }
 
     async fn update_swap_failed(
@@ -1373,8 +1376,9 @@ impl DaoTransactionInterface for DaoTransaction {
     async fn update_swap_completed(
         &self,
         swap_id: Uuid,
+        settlement_verified: bool,
     ) -> Result<Swap, DaoSwapError> {
-        DaoSwapMethods::update_swap_completed(self, swap_id).await
+        DaoSwapMethods::update_swap_completed(self, swap_id, settlement_verified).await
     }
 
     async fn update_swap_failed(

--- a/daemon/src/dao/swap.rs
+++ b/daemon/src/dao/swap.rs
@@ -675,13 +675,18 @@ pub trait DaoSwapMethods: DaoExecutor + 'static {
     async fn update_swap_completed(
         &self,
         swap_id: Uuid,
+        settlement_verified: bool,
     ) -> Result<Swap, DaoSwapError> {
         let query = sqlx::query_as::<_, SwapRow>(
             "UPDATE swaps
-            SET status = 'Completed', finished_at = datetime('now')
+            SET status = 'Completed',
+                error_message = CASE WHEN ? THEN ? ELSE error_message END,
+                finished_at = datetime('now')
             WHERE id = ?
             RETURNING *",
         )
+        .bind(settlement_verified)
+        .bind(crate::types::VERIFIED_SETTLEMENT_MARKER)
         .bind(swap_id);
 
         self.fetch_one(query)
@@ -753,10 +758,14 @@ pub trait DaoSwapMethods: DaoExecutor + 'static {
     ) -> Result<Vec<Swap>, DaoSwapError> {
         let query = sqlx::query_as::<_, SwapRow>(
             "SELECT * FROM swaps
-            WHERE status = 'Completed' AND direction = 'Incoming' AND invoice_id = ?
+            WHERE status = 'Completed'
+              AND direction = 'Incoming'
+              AND invoice_id = ?
+              AND error_message = ?
             ORDER BY created_at ASC",
         )
-        .bind(invoice_id);
+        .bind(invoice_id)
+        .bind(crate::types::VERIFIED_SETTLEMENT_MARKER);
 
         self.fetch_all(query)
             .await
@@ -996,7 +1005,7 @@ mod tests {
         assert_eq!(pending, expected_pending);
 
         let mut completed = dao
-            .update_swap_completed(swap_id)
+            .update_swap_completed(swap_id, false)
             .await
             .unwrap();
         completed.trunc_timestamps();
@@ -1021,7 +1030,7 @@ mod tests {
         assert_eq!(result, swap);
 
         let completed_err = dao
-            .update_swap_completed(swap_id)
+            .update_swap_completed(swap_id, false)
             .await
             .unwrap_err();
         assert_eq!(
@@ -1063,7 +1072,7 @@ mod tests {
         assert_eq!(submitted, expected_submitted);
 
         let completed_err = dao
-            .update_swap_completed(swap_id)
+            .update_swap_completed(swap_id, false)
             .await
             .unwrap_err();
         assert_eq!(
@@ -1109,7 +1118,7 @@ mod tests {
         );
 
         let result = dao
-            .update_swap_completed(swap_id)
+            .update_swap_completed(swap_id, false)
             .await
             .unwrap_err();
         assert_eq!(
@@ -1187,6 +1196,71 @@ mod tests {
                 swap_id: missing
             }
         );
+    }
+
+    #[tokio::test]
+    async fn only_verified_completed_incoming_swaps_are_refund_eligible() {
+        let dao = create_test_dao().await;
+        let invoice = default_create_invoice_data();
+        let invoice_id = invoice.id;
+        dao.create_invoice(invoice)
+            .await
+            .unwrap();
+
+        let verified = default_swap(invoice_id);
+        let verified_id = verified.id;
+        dao.create_swap(verified).await.unwrap();
+        dao.update_swap_submitted(verified_id)
+            .await
+            .unwrap();
+
+        let unverified = default_swap(invoice_id);
+        let unverified_id = unverified.id;
+        dao.create_swap(unverified)
+            .await
+            .unwrap();
+        dao.update_swap_submitted(unverified_id)
+            .await
+            .unwrap();
+
+        dao.get_submitted_swaps().await.unwrap();
+        let completed_verified = dao
+            .update_swap_completed(verified_id, true)
+            .await
+            .unwrap();
+        let completed_unverified = dao
+            .update_swap_completed(unverified_id, false)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            completed_verified
+                .error_message
+                .as_deref(),
+            Some(crate::types::VERIFIED_SETTLEMENT_MARKER)
+        );
+        assert_eq!(
+            completed_verified.status,
+            SwapStatus::Completed
+        );
+        // This models Across: it still reaches Completed normally, but without
+        // destination-chain verification it cannot become refund-eligible.
+        assert_eq!(
+            completed_unverified.status,
+            SwapStatus::Completed
+        );
+        assert!(
+            completed_unverified
+                .error_message
+                .is_none()
+        );
+
+        let eligible = dao
+            .get_completed_incoming_swaps_by_invoice(invoice_id)
+            .await
+            .unwrap();
+        assert_eq!(eligible.len(), 1);
+        assert_eq!(eligible[0].id, verified_id);
     }
 
     #[tokio::test]
@@ -1408,7 +1482,7 @@ mod tests {
             .await
             .unwrap();
         dao.get_submitted_swaps().await.unwrap();
-        dao.update_swap_completed(s_id)
+        dao.update_swap_completed(s_id, false)
             .await
             .unwrap();
 
@@ -1455,7 +1529,7 @@ mod tests {
             .await
             .unwrap();
         dao.get_submitted_swaps().await.unwrap();
-        dao.update_swap_completed(s_id)
+        dao.update_swap_completed(s_id, false)
             .await
             .unwrap();
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -451,6 +451,8 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
 
     let swaps_executor = SwapsExecutor::new(dao.clone(), swaps_clients.clone());
 
+    let swap_settlement_verifier = polygon_client.clone();
+
     let refund_destination_detector = RefundDestinationDetector::new(dao.clone());
 
     // Single executor handles both chains
@@ -477,6 +479,7 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
         dao.clone(),
         swaps_clients,
         balance_checker,
+        swap_settlement_verifier,
     );
 
     let swaps_tracker_handle = swaps_tracker.ignite(shutdown_notification.token.clone());

--- a/daemon/src/swaps/tracker.rs
+++ b/daemon/src/swaps/tracker.rs
@@ -6,6 +6,11 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::balance_checker::BalanceChecker;
+use crate::chain_client::{
+    PolygonClient,
+    SwapSettlement,
+    SwapSettlementVerifier,
+};
 use crate::clients::{
     ExecutorSwapStatus,
     SwapsClientError,
@@ -19,6 +24,8 @@ use crate::types::{
     PayoutStatus,
     RefundStatus,
     Swap,
+    SwapDirection,
+    SwapExecutorType,
     SwapStatus,
     TransactionOriginVariant,
 };
@@ -33,6 +40,11 @@ const SWAPS_EXECUTOR_API_POLLING_INTERVAL_MILLIS: u64 = 3000;
 const SWAPS_EXECUTOR_DATABASE_POLLING_INTERVAL_MILLIS: u64 = 100;
 const SWAPS_EXECUTOR_PENDING_RELOAD_RETRY_MILLIS: u64 = 5000;
 const SWAPS_EXECUTOR_PENDING_RELOAD_MAX_ATTEMPTS: u32 = 12;
+
+fn requires_settlement_verification(swap: &Swap) -> bool {
+    swap.request.direction == SwapDirection::Incoming
+        && swap.request.swap_executor == SwapExecutorType::ZeroEx
+}
 
 struct TrackedSwaps {
     swaps: HashMap<Uuid, Swap>,
@@ -141,11 +153,15 @@ fn apply_hashless_swap_reload(
     Some(reloaded)
 }
 
-pub struct SwapsTracker<D: DaoInterface + 'static> {
+pub struct SwapsTracker<
+    D: DaoInterface + 'static,
+    V: SwapSettlementVerifier + 'static = PolygonClient,
+> {
     dao: D,
     store: TrackedSwaps,
     clients: SwapsClients,
     balance_checker: BalanceChecker,
+    settlement_verifier: V,
 }
 
 #[expect(clippy::enum_variant_names)]
@@ -162,24 +178,124 @@ impl From<SwapsClientError> for SwapsTrackerError {
     }
 }
 
-impl<D: DaoInterface + 'static> SwapsTracker<D> {
+impl<D: DaoInterface + 'static, V: SwapSettlementVerifier + 'static> SwapsTracker<D, V> {
     pub fn new(
         dao: D,
         clients: SwapsClients,
         balance_checker: BalanceChecker,
+        settlement_verifier: V,
     ) -> Self {
         Self {
             dao,
             clients,
             balance_checker,
+            settlement_verifier,
             store: TrackedSwaps::new(),
         }
+    }
+
+    fn settlement_matches(
+        swap: &Swap,
+        settlement: &SwapSettlement,
+    ) -> bool {
+        if settlement.chain != swap.request.to_chain {
+            return false
+        }
+
+        settlement
+            .transfers
+            .iter()
+            .any(|transfer| {
+                transfer
+                    .token_address
+                    .eq_ignore_ascii_case(&swap.request.to_token_address)
+                    && transfer
+                        .recipient_address
+                        .eq_ignore_ascii_case(&swap.request.to_address)
+            })
+    }
+
+    async fn verify_executed_swap(
+        &mut self,
+        swap: &Swap,
+    ) -> Result<bool, SwapsTrackerError> {
+        let transaction_hash = swap
+            .swap_details
+            .transaction_hash
+            .as_deref()
+            .ok_or(SwapsTrackerError::ApiError)?;
+        let settlement = self
+            .settlement_verifier
+            .get_swap_settlement(transaction_hash)
+            .await
+            .map_err(|error| {
+                tracing::warn!(
+                    swap_id = %swap.id,
+                    invoice_id = %swap.request.invoice_id,
+                    provider = %swap.request.swap_executor,
+                    claimed_transaction_hash = transaction_hash,
+                    error = %error,
+                    "Destination-chain settlement evidence is temporarily unavailable"
+                );
+                SwapsTrackerError::ApiError
+            })?;
+
+        if !Self::settlement_matches(swap, &settlement) {
+            tracing::error!(
+                swap_id = %swap.id,
+                invoice_id = %swap.request.invoice_id,
+                provider = %swap.request.swap_executor,
+                claimed_transaction_hash = transaction_hash,
+                expected_chain = %swap.request.to_chain,
+                expected_recipient = %swap.request.to_address,
+                expected_token = %swap.request.to_token_address,
+                expected_amount_units = swap.request.expected_to_amount_units,
+                actual_chain = %settlement.chain,
+                actual_transfers = ?settlement.transfers,
+                "Provider reported an executed swap whose on-chain settlement does not match; marking it failed for manual reconciliation"
+            );
+            self.handle_swap_failed(swap).await?;
+            return Ok(false)
+        }
+
+        let delivered_amount = settlement
+            .transfers
+            .iter()
+            .filter(|transfer| {
+                transfer
+                    .token_address
+                    .eq_ignore_ascii_case(&swap.request.to_token_address)
+                    && transfer
+                        .recipient_address
+                        .eq_ignore_ascii_case(&swap.request.to_address)
+            })
+            .filter_map(|transfer| transfer.amount_units)
+            .fold(0_u128, u128::saturating_add);
+
+        if delivered_amount < swap.request.expected_to_amount_units {
+            // Swap rows do not persist the quote's slippage allowance (and do
+            // not persist destination-token decimals), so no defensible unit
+            // lower bound can be reconstructed here. Recipient/token/chain are
+            // security-critical and strict; amount is deliberately advisory.
+            tracing::warn!(
+                swap_id = %swap.id,
+                invoice_id = %swap.request.invoice_id,
+                provider = %swap.request.swap_executor,
+                claimed_transaction_hash = transaction_hash,
+                expected_amount_units = swap.request.expected_to_amount_units,
+                delivered_amount_units = delivered_amount,
+                "Verified swap settlement amount is below the requested amount; accepting because the stored swap has no reconstructible slippage bound"
+            );
+        }
+
+        Ok(true)
     }
 
     #[tracing::instrument(skip_all)]
     async fn handle_swap_executed(
         &mut self,
         swap: &Swap,
+        settlement_verified: bool,
     ) -> Result<(), SwapsTrackerError> {
         // TODO: check error, if it's Invoice not found, skip monitoring (shouldn't
         // happen though)
@@ -215,7 +331,7 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
             .map_err(|_| SwapsTrackerError::DatabaseError)?;
 
         dao_transaction
-            .update_swap_completed(swap.id)
+            .update_swap_completed(swap.id, settlement_verified)
             .await
             .map_err(|_| SwapsTrackerError::DatabaseError)?;
 
@@ -346,7 +462,12 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
                 tracing::trace!("Swap still has pending status, keep watching")
             },
             ExecutorSwapStatus::Executed => {
-                self.handle_swap_executed(swap).await?;
+                let requires_verification = requires_settlement_verification(swap);
+
+                if !requires_verification || self.verify_executed_swap(swap).await? {
+                    self.handle_swap_executed(swap, requires_verification)
+                        .await?;
+                }
             },
             ExecutorSwapStatus::Failed => {
                 self.handle_swap_failed(swap).await?;
@@ -543,8 +664,13 @@ impl<D: DaoInterface + 'static> SwapsTracker<D> {
 
 #[cfg(test)]
 mod tests {
+    use crate::chain_client::{
+        SettlementTransfer,
+        SwapSettlement,
+    };
     use crate::dao::DaoSwapError;
     use crate::types::{
+        SwapChainType,
         SwapStatus,
         default_swap,
     };
@@ -593,5 +719,109 @@ mod tests {
             .is_none()
         );
         assert!(store.swaps.contains_key(&swap.id));
+    }
+
+    fn settlement_for(
+        swap: &Swap,
+        amount_units: u128,
+    ) -> SwapSettlement {
+        SwapSettlement {
+            chain: swap.request.to_chain,
+            transfers: vec![SettlementTransfer {
+                token_address: swap
+                    .request
+                    .to_token_address
+                    .to_lowercase(),
+                recipient_address: swap.request.to_address.to_uppercase(),
+                amount_units: Some(amount_units),
+            }],
+        }
+    }
+
+    #[test]
+    fn unrelated_successful_transaction_is_not_valid_settlement() {
+        let swap = default_swap(Uuid::new_v4());
+        let settlement = SwapSettlement {
+            chain: swap.request.to_chain,
+            transfers: vec![SettlementTransfer {
+                token_address: swap.request.to_token_address.clone(),
+                recipient_address: "0x0000000000000000000000000000000000000001".to_string(),
+                amount_units: Some(swap.request.expected_to_amount_units),
+            }],
+        };
+
+        assert!(!SwapsTracker::<crate::dao::DAO>::settlement_matches(&swap, &settlement));
+    }
+
+    #[test]
+    fn matching_settlement_is_accepted_case_insensitively() {
+        let swap = default_swap(Uuid::new_v4());
+        let settlement = settlement_for(
+            &swap,
+            swap.request.expected_to_amount_units,
+        );
+
+        assert!(SwapsTracker::<crate::dao::DAO>::settlement_matches(&swap, &settlement));
+    }
+
+    #[test]
+    fn matching_settlement_below_expected_amount_remains_eligible() {
+        let swap = default_swap(Uuid::new_v4());
+        let settlement = settlement_for(
+            &swap,
+            swap.request
+                .expected_to_amount_units
+                .saturating_sub(1),
+        );
+
+        assert!(SwapsTracker::<crate::dao::DAO>::settlement_matches(&swap, &settlement));
+    }
+
+    #[test]
+    fn wrong_token_is_not_valid_settlement() {
+        let swap = default_swap(Uuid::new_v4());
+        let mut settlement = settlement_for(
+            &swap,
+            swap.request.expected_to_amount_units,
+        );
+        settlement.transfers[0].token_address =
+            "0x0000000000000000000000000000000000000001".to_string();
+
+        assert!(!SwapsTracker::<crate::dao::DAO>::settlement_matches(&swap, &settlement));
+    }
+
+    #[test]
+    fn wrong_chain_is_not_valid_settlement() {
+        let swap = default_swap(Uuid::new_v4());
+        let mut settlement = settlement_for(
+            &swap,
+            swap.request.expected_to_amount_units,
+        );
+        settlement.chain = SwapChainType::Base;
+
+        assert!(!SwapsTracker::<crate::dao::DAO>::settlement_matches(&swap, &settlement));
+    }
+
+    #[test]
+    fn incoming_zero_ex_requires_verification_but_across_does_not() {
+        let mut zero_ex = default_swap(Uuid::new_v4());
+        zero_ex.request.direction = SwapDirection::Incoming;
+        zero_ex.request.swap_executor = SwapExecutorType::ZeroEx;
+        assert!(requires_settlement_verification(
+            &zero_ex
+        ));
+
+        let mut across = zero_ex.clone();
+        across.request.swap_executor = SwapExecutorType::Across;
+        assert!(!requires_settlement_verification(
+            &across
+        ));
+
+        let mut gasless = zero_ex;
+        gasless.request.direction = SwapDirection::Outgoing;
+        gasless.request.swap_executor = SwapExecutorType::ZeroExGasless;
+        assert!(!requires_settlement_verification(
+            &gasless
+        ));
     }
 }

--- a/daemon/src/types/swap.rs
+++ b/daemon/src/types/swap.rs
@@ -31,6 +31,10 @@ use super::{
     TransactionOrigin,
 };
 
+/// Persisted marker proving that the tracker independently verified the
+/// destination-chain settlement before completing the swap.
+pub const VERIFIED_SETTLEMENT_MARKER: &str = "destination_chain_settlement_verified";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CreateFrontEndSwapParams {
     pub invoice_id: Uuid,

--- a/daemon/src/utils/refund_destination_detector.rs
+++ b/daemon/src/utils/refund_destination_detector.rs
@@ -49,9 +49,15 @@ impl<D: DaoInterface + 'static> RefundDestinationDetector<D> {
         &self,
         swaps: &[Swap],
         same_chain: bool,
+        invoice_payment_address: &str,
     ) -> Option<TransferDestinationParams> {
         for swap in swaps {
-            if (swap.request.from_chain == swap.request.to_chain) == same_chain {
+            if swap
+                .request
+                .to_address
+                .eq_ignore_ascii_case(invoice_payment_address)
+                && (swap.request.from_chain == swap.request.to_chain) == same_chain
+            {
                 let destination_params = TransferDestinationParams {
                     destination_address: swap.request.from_address.clone(),
                     destination_asset_id: swap.request.from_token_address.clone(),
@@ -113,7 +119,12 @@ impl<D: DaoInterface + 'static> RefundDestinationDetector<D> {
                 RefundDestinationDetectorError::DatabaseError
             })?;
 
-        if let Some(params) = self.find_destination_in_swaps(&swaps, true) {
+        if let Some(params) = self.find_destination_in_swaps(
+            &swaps,
+            true,
+            // Refund::from_invoice persists the invoice payment address here.
+            &refund.source_address,
+        ) {
             return Ok(params)
         }
 
@@ -368,23 +379,42 @@ mod tests {
                 .clone(),
         };
 
+        let payment_address = swap_1.request.to_address.clone();
         let mut swaps = vec![swap_1, swap_2, swap_3];
-
-        let result = detector.find_destination_in_swaps(&swaps, true);
+        let result = detector.find_destination_in_swaps(&swaps, true, &payment_address);
         assert_eq!(result, Some(swap_1_destination));
 
-        let result = detector.find_destination_in_swaps(&swaps, false);
+        let result = detector.find_destination_in_swaps(&swaps, false, &payment_address);
         assert_eq!(result, Some(swap_3_destination));
 
         swaps.remove(0);
 
-        let result = detector.find_destination_in_swaps(&swaps, true);
+        let result = detector.find_destination_in_swaps(&swaps, true, &payment_address);
         assert_eq!(result, Some(swap_2_destination));
 
         swaps.remove(1);
 
-        let result = detector.find_destination_in_swaps(&swaps, false);
+        let result = detector.find_destination_in_swaps(&swaps, false, &payment_address);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn completed_swap_with_wrong_invoice_destination_is_not_a_refund_destination() {
+        let dao = MockDaoInterface::default();
+        let detector = RefundDestinationDetector::new(dao);
+        let mut swap = default_swap(Uuid::new_v4());
+        swap.request.from_chain = swap.request.to_chain;
+        swap.request.to_address = "0x0000000000000000000000000000000000000001".to_string();
+
+        assert!(
+            detector
+                .find_destination_in_swaps(
+                    &[swap],
+                    true,
+                    "0x0000000000000000000000000000000000000002",
+                )
+                .is_none()
+        );
     }
 
     #[test]
@@ -439,6 +469,7 @@ mod tests {
         {
             let mut returned_swap = default_swap(invoice_id);
             returned_swap.request.to_chain = returned_swap.request.from_chain;
+            returned_swap.request.to_address = refund.source_address.clone();
 
             let expected_destination_params = TransferDestinationParams {
                 destination_address: returned_swap

--- a/docs/swaps.md
+++ b/docs/swaps.md
@@ -4,6 +4,44 @@ Decision records and behavioral notes for the swaps subsystem
 (`daemon/src/swaps/`, `daemon/src/clients/swaps/`). Not yet a full subsystem
 overview — see [architecture.md](architecture.md) for the component map.
 
+## Executed swaps require destination-chain settlement evidence (2026-08-07)
+
+A provider reporting `Executed` is not sufficient to make a swap eligible as a
+refund destination. Incoming same-chain swaps use normal 0x, whose stored hash
+is the Polygon transaction hash. Before completing one, the tracker reads that
+receipt and requires an ERC-20 `Transfer` whose contract and recipient exactly
+match the stored `to_token_address` and `to_address`; EVM address spelling is
+compared case-insensitively. The observed chain must exactly match `to_chain`.
+
+A 0x mismatch is terminally marked `Failed` and logged at error level with the
+swap, invoice, provider, claimed hash, expected settlement, and all observed
+transfers for manual reconciliation. Receipt/RPC unavailability is retried and
+does not make a terminal decision. Verified-ness is persisted without a schema
+change as an internal marker in the existing `error_message` column, written in
+the same update that marks the swap `Completed`; it therefore survives restarts
+and excludes pre-rule completed rows. Refund destination detection requires the
+marker and also ignores a swap unless its stored destination matches the invoice
+payment address persisted on the refund.
+
+Incoming cross-chain swaps use Across, whose stored identifier is the
+source-chain deposit reference rather than a Polygon fill hash. Across swaps
+therefore complete normally, without receipt verification or behavior change,
+but never receive the marker and are permanently refund-ineligible. They fall
+through to transaction-based detection or manual handling. Provider-specific
+destination-hash resolution was deliberately deferred. Bungee is unreachable
+because executor selection never chooses it; 0x gasless is outgoing-only and
+cannot be selected by the incoming-swap refund query.
+
+Amount is advisory for existing rows. `Swap` persists the requested destination
+units but neither the quote's slippage allowance nor destination-token decimals,
+so it cannot reconstruct a defensible unit lower bound. A below-requested amount
+is logged but does not by itself reject strict recipient/token/chain evidence.
+Persisting quote slippage can make this a lower-bound check later.
+
+Binding public swap-mutation endpoints to a per-invoice token is deliberately
+deferred to a separate authorization-hardening change; this rule does not alter
+the external HTTP API.
+
 ## Payer signatures are validated and claimed atomically (2026-08-04)
 
 A gasless 0x quote can require two signatures — the trade and a token approval


### PR DESCRIPTION
Swap endpoints are unauthenticated, and a refund with no explicit destination preferred the earliest completed incoming swap's `from_address`. Nothing tied that swap to the invoice being refunded: an attacker who knew an invoice id could create a swap with their own `from_address`, submit a publicly-obtainable transaction hash, and collect someone else's refund. For normal 0x the status check was `get_transaction_receipt(hash).status()`, so any successful Polygon transaction did it.

Only two executors can reach an incoming swap — `detect` assigns 0x normal same-chain and Across cross-chain — so those are what this covers. Gasless is outgoing-only and already excluded by the refund query's direction filter; Bungee is unreachable, as nothing constructs it.

0x normal now has its Polygon receipt decoded before completion: the settlement must carry an ERC-20 transfer of the stored token, on the stored chain, to the stored recipient, or the swap is failed with the detail an operator needs. Across keeps completing exactly as before — its stored reference identifies a source-chain deposit, not the Polygon fill, so nothing here can verify it — but it never earns the marker, and the refund-eligibility query requires one. Unverifiable settlements therefore fall through to manual handling rather than paying out on evidence nobody checked. The detector separately refuses any swap whose destination is not the invoice's payment address.

The amount is deliberately advisory: the stored swap carries neither the quoted slippage allowance nor the destination token's decimals, so no honest lower bound exists yet. A legitimate fill landing slightly short completes and warns rather than stranding the payment; recipient, token and chain are what close the theft.

The marker lives in `error_message` to avoid a migration. That is sound only because `Failed` is terminal in the schema trigger and the two writers of that column are this completion path and the failure path, which always sets `Failed` — so a `Completed` row cannot carry a forged marker. It is not exposed in `PublicSwap`. A dedicated column belongs in the next migration.