### PR TITLE
fix: recover stranded transfers, validate the webhook URL, and enforce admin authorization

### DIFF
--- a/daemon/src/api/admin.rs
+++ b/daemon/src/api/admin.rs
@@ -448,11 +448,17 @@ mod tests {
             )
             .route_layer(middleware::from_fn(require_owner));
 
+        // Built the way production builds it — viewer routes first, then
+        // `.merge(owner_routes)` — rather than folding them onto the
+        // already-layered owner router. Otherwise the harness would depend on
+        // `route_layer` not reaching routes added after it, and could start
+        // gating viewer paths, or stop gating owner ones, on an axum upgrade.
         let api_routes = VIEWER_PATHS
             .iter()
-            .fold(owner_routes, |router, path| {
+            .fold(Router::new(), |router, path| {
                 router.route(path, get(|| async { StatusCode::OK }))
             })
+            .merge(owner_routes)
             .fallback(|| async { StatusCode::NOT_FOUND });
 
         // Stands in for the SPA fallback the real router carries, but with a

--- a/daemon/src/api/admin.rs
+++ b/daemon/src/api/admin.rs
@@ -1,19 +1,20 @@
 //! Admin namespace — protected by session middleware + CSRF middleware when
 //! auth is enabled.
 
-use axum::extract::State;
+use axum::extract::{
+    Request,
+    State,
+};
 use axum::http::StatusCode;
 use axum::response::{
     IntoResponse,
     Response,
 };
-use axum::routing::{
-    get,
-    post,
-};
+use axum::routing::get;
 use axum::{
     Extension,
     Router,
+    middleware,
 };
 use serde::{
     Deserialize,
@@ -28,6 +29,7 @@ use uuid::Uuid;
 use kalatori_client::types::ApiResultStructured;
 
 use crate::api::utils::ErrorWrapper;
+use crate::auth::errors::SessionError;
 use crate::auth::session::AuthenticatedUser;
 use crate::auth::token::Role;
 use crate::dao::{
@@ -54,10 +56,12 @@ use crate::types::{
 use super::ApiState;
 use super::utils::{
     ApiResult,
-    AppJson,
     AppQuery,
     SuccessWrapper,
 };
+
+const INTEGRATION_SETTINGS_PATH: &str = "/integration-settings";
+const GET_PLUGIN_PATH: &str = "/get-plugin";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct InvoiceIdParam {
@@ -153,25 +157,6 @@ async fn get_payout_handler(
         .ok_or(DaoPayoutError::NotFound {
             payout_id,
         })?;
-
-    Ok(payout.into())
-}
-
-// ============================================================================
-// POST /admin/payouts/initiate
-// ============================================================================
-
-#[tracing::instrument(skip_all)]
-async fn initiate_payout_handler(
-    State(state): State<ApiState>,
-    Extension(_user): Extension<AuthenticatedUser>,
-    AppJson(param): AppJson<InvoiceIdParam>,
-) -> ApiResult<Payout, DaoInvoiceError> {
-    let invoice_id = param.invoice_id;
-
-    let payout = state
-        .initiate_payout(invoice_id)
-        .await?;
 
     Ok(payout.into())
 }
@@ -290,10 +275,21 @@ async fn kalatori_integration_settings_handler(
     State(state): State<ApiState>,
     Extension(_user): Extension<AuthenticatedUser>,
 ) -> SuccessWrapper<KalatoriIntegrationSettings> {
-    // TODO: restrict visibility by user's role
     state
         .get_kalatori_integration_settings()
         .into()
+}
+
+async fn require_owner(
+    Extension(user): Extension<AuthenticatedUser>,
+    request: Request,
+    next: middleware::Next,
+) -> Result<Response, ErrorWrapper<SessionError>> {
+    if user.claims.role != Role::Owner {
+        return Err(SessionError::InsufficientRole.into());
+    }
+
+    Ok(next.run(request).await)
 }
 
 #[tracing::instrument(skip_all)]
@@ -335,53 +331,51 @@ async fn get_plugin_handler(
 
 /// Admin routes.
 pub fn routes() -> Router<ApiState> {
-    Router::new()
-        .route("/api/whoami", get(whoami_handler))
+    let owner_routes = Router::new()
         .route(
-            "/api/invoice/list",
+            INTEGRATION_SETTINGS_PATH,
+            get(kalatori_integration_settings_handler),
+        )
+        .route(GET_PLUGIN_PATH, get(get_plugin_handler))
+        .route_layer(middleware::from_fn(require_owner));
+
+    let api_routes = Router::new()
+        .route("/whoami", get(whoami_handler))
+        .route(
+            "/invoice/list",
             get(list_invoices_handler),
         )
+        .route("/invoice/get", get(get_invoice_handler))
         .route(
-            "/api/invoice/get",
-            get(get_invoice_handler),
-        )
-        .route(
-            "/api/payout/list",
+            "/payout/list",
             get(list_payouts_handler),
         )
+        .route("/payout/get", get(get_payout_handler))
+        // Payout initiation is intentionally out of service: it uses a hardcoded
+        // amount, and the correct amount semantics are deferred to follow-up work.
         .route(
-            "/api/payout/get",
-            get(get_payout_handler),
-        )
-        .route(
-            "/api/payout/initiate",
-            post(initiate_payout_handler),
-        )
-        .route(
-            "/api/transaction/list",
+            "/transaction/list",
             get(list_transactions_handler),
         )
         .route(
-            "/api/transaction/get",
+            "/transaction/get",
             get(get_transaction_handler),
         )
+        .route("/swap/list", get(list_swaps_handler))
+        .route("/swap/get", get(get_swap_handler))
         .route(
-            "/api/swap/list",
-            get(list_swaps_handler),
-        )
-        .route("/api/swap/get", get(get_swap_handler))
-        .route(
-            "/api/settings",
+            "/settings",
             get(kalatori_settings_handler),
         )
-        .route(
-            "/api/integration-settings",
-            get(kalatori_integration_settings_handler),
-        )
-        .route(
-            "/api/get-plugin",
-            get(get_plugin_handler),
-        )
+        .merge(owner_routes)
+        // A nested router inherits the outer fallback unless it sets its own,
+        // so without this an unknown `/admin/api/*` path — `payout/initiate`
+        // included — would be answered with the admin SPA's index.html and a
+        // 200. An API path that does not exist must say so.
+        .fallback(|| async { StatusCode::NOT_FOUND });
+
+    Router::new()
+        .nest("/api", api_routes)
         .route_service(
             "/",
             ServeFile::new("static/admin/index.html"),
@@ -393,4 +387,148 @@ pub fn routes() -> Router<ApiState> {
             "/assets",
             ServeDir::new("static/admin/assets"),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{
+        Body,
+        to_bytes,
+    };
+    use axum::http::Request;
+    use chrono::{
+        Duration,
+        Utc,
+    };
+    use tower::ServiceExt;
+
+    use crate::auth::token::TokenClaims;
+
+    use super::*;
+
+    const VIEWER_PATHS: &[&str] = &[
+        "/whoami",
+        "/invoice/list",
+        "/invoice/get",
+        "/payout/list",
+        "/payout/get",
+        "/transaction/list",
+        "/transaction/get",
+        "/swap/list",
+        "/swap/get",
+        "/settings",
+    ];
+
+    fn user(role: Role) -> AuthenticatedUser {
+        let now = Utc::now();
+        AuthenticatedUser {
+            claims: TokenClaims {
+                iss: "https://auth.example.com".to_string(),
+                sub: "user".to_string(),
+                email: "user@example.com".to_string(),
+                picture: None,
+                aud: "kalatori".to_string(),
+                role,
+                iat: now,
+                exp: now + Duration::hours(1),
+                raw_token: "token".to_string(),
+            },
+        }
+    }
+
+    fn authorization_test_router() -> Router {
+        let owner_routes = Router::new()
+            .route(
+                INTEGRATION_SETTINGS_PATH,
+                get(|| async { StatusCode::OK }),
+            )
+            .route(
+                GET_PLUGIN_PATH,
+                get(|| async { StatusCode::OK }),
+            )
+            .route_layer(middleware::from_fn(require_owner));
+
+        let api_routes = VIEWER_PATHS
+            .iter()
+            .fold(owner_routes, |router, path| {
+                router.route(path, get(|| async { StatusCode::OK }))
+            })
+            .fallback(|| async { StatusCode::NOT_FOUND });
+
+        // Stands in for the SPA fallback the real router carries, but with a
+        // status the API never returns. `ServeFile` would be useless here:
+        // `static/admin/` is a build artefact absent from a source checkout,
+        // so it 404s too and the assertion below could not tell a real 404
+        // from the fallback swallowing the request.
+        Router::new()
+            .nest("/api", api_routes)
+            .fallback(|| async { StatusCode::IM_A_TEAPOT })
+    }
+
+    async fn request(
+        path: &str,
+        role: Role,
+    ) -> Response {
+        authorization_test_router()
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .extension(user(role))
+                    .body(Body::empty())
+                    .expect("request uses a valid URI"),
+            )
+            .await
+            .expect("router always responds")
+    }
+
+    #[tokio::test]
+    async fn secret_routes_are_owner_only() {
+        for path in [INTEGRATION_SETTINGS_PATH, GET_PLUGIN_PATH] {
+            let path = format!("/api{path}");
+            assert_eq!(
+                request(&path, Role::Owner)
+                    .await
+                    .status(),
+                StatusCode::OK
+            );
+
+            for role in [Role::Operator, Role::Viewer, Role::Support] {
+                let response = request(&path, role).await;
+                assert_eq!(response.status(), StatusCode::FORBIDDEN);
+                let body = to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .expect("response body collects");
+                let json: serde_json::Value =
+                    serde_json::from_slice(&body).expect("error response is JSON");
+                assert_eq!(
+                    json["error"]["code"],
+                    "INSUFFICIENT_ROLE"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn every_authenticated_role_can_reach_non_gated_admin_api_routes() {
+        for path in VIEWER_PATHS {
+            let path = format!("/api{path}");
+            for role in [Role::Owner, Role::Operator, Role::Viewer, Role::Support] {
+                assert_eq!(
+                    request(&path, role).await.status(),
+                    StatusCode::OK,
+                    "{role:?} should retain access to {path}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn payout_initiate_route_is_absent() {
+        assert_eq!(
+            request("/api/payout/initiate", Role::Owner)
+                .await
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+    }
 }

--- a/daemon/src/auth/errors.rs
+++ b/daemon/src/auth/errors.rs
@@ -148,7 +148,6 @@ pub enum SessionError {
     #[error("Duplicate session cookies detected")]
     DuplicateCookie,
 
-    #[expect(dead_code)]
     /// Insufficient role for the requested action.
     #[error("Insufficient permissions")]
     InsufficientRole,

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -512,6 +512,55 @@ mod tests {
     const USDT_LOWER: &str = "0xc2132d05d31c914a87c6611c10748aeb04b58e8f";
     const USDT_CHECKSUMMED: &str = "0xc2132D05D31c914a87C6611C10748AEb04B58e8F";
 
+    fn shop_config_with_webhook(value: Option<&str>) -> ShopConfig {
+        ShopConfig {
+            invoices_webhook_url: value.map(ToString::to_string),
+            signature_max_age_secs: default_signature_max_age_secs(),
+            private_api_base_url: None,
+            meta: ShopMetaConfig {
+                shop_name: String::new(),
+                shop_url: String::new(),
+                logo_url: None,
+                reown_project_id: String::new(),
+                ankr_api_token: None,
+            },
+            shop_platform: DetectedShopPlatform::default(),
+        }
+    }
+
+    #[test]
+    fn validates_invoices_webhook_url() {
+        for value in [
+            None,
+            Some("https://webhook.example.com/events"),
+            Some("http://localhost:8080/webhook"),
+        ] {
+            assert!(
+                shop_config_with_webhook(value)
+                    .validate_invoices_webhook_url()
+                    .is_ok(),
+                "expected {value:?} to be accepted"
+            );
+        }
+
+        for value in [
+            "",
+            "webhook.example.com",
+            "ftp://webhook.example.com/events",
+            "file:///tmp/webhook",
+            "https://?event=invoice",
+        ] {
+            let error = shop_config_with_webhook(Some(value))
+                .validate_invoices_webhook_url()
+                .unwrap_err();
+            let quoted_value = format!("`{value}`");
+            assert!(
+                error.contains(&quoted_value),
+                "`{error}` does not name `{value}`"
+            );
+        }
+    }
+
     #[test]
     fn test_canonicalize_payments_evm_asset_ids() {
         let slippage = SlippageParams {
@@ -981,6 +1030,31 @@ pub struct ShopConfig {
     pub meta: ShopMetaConfig,
     #[serde(default)]
     pub shop_platform: DetectedShopPlatform,
+}
+
+impl ShopConfig {
+    pub fn validate_invoices_webhook_url(&self) -> Result<(), String> {
+        let Some(value) = self.invoices_webhook_url.as_deref() else {
+            return Ok(());
+        };
+
+        let url = url::Url::parse(value)
+            .map_err(|error| format!("Invalid invoices webhook URL `{value}`: {error}"))?;
+
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err(format!(
+                "Invalid invoices webhook URL `{value}`: scheme must be http or https"
+            ));
+        }
+
+        if url.host_str().is_none() {
+            return Err(format!(
+                "Invalid invoices webhook URL `{value}`: URL must include a host"
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 fn default_log_directives() -> String {

--- a/daemon/src/dao/interface.rs
+++ b/daemon/src/dao/interface.rs
@@ -216,6 +216,9 @@ pub trait DaoInterface: Send + Sync + 'static {
 
     // === Payout Methods ===
 
+    /// Recover payouts claimed by a previous daemon process.
+    async fn recover_in_progress_payouts(&self) -> Result<usize, DaoPayoutError>;
+
     /// Create a new payout record.
     async fn create_payout(
         &self,
@@ -369,6 +372,9 @@ pub trait DaoInterface: Send + Sync + 'static {
     ) -> Result<u32, DaoSwapError>;
 
     // === Refund Methods ===
+
+    /// Recover refunds claimed by a previous daemon process.
+    async fn recover_in_progress_refunds(&self) -> Result<usize, DaoRefundError>;
 
     async fn create_refund(
         &self,
@@ -848,6 +854,10 @@ impl DaoInterface for DAO {
         DaoPayoutMethods::create_payout(self, payout).await
     }
 
+    async fn recover_in_progress_payouts(&self) -> Result<usize, DaoPayoutError> {
+        DaoPayoutMethods::recover_in_progress_payouts(self).await
+    }
+
     async fn get_all_payouts(&self) -> Result<Vec<Payout>, DaoPayoutError> {
         DaoPayoutMethods::get_all_payouts(self).await
     }
@@ -1040,6 +1050,10 @@ impl DaoInterface for DAO {
         refund: Refund,
     ) -> Result<Refund, DaoRefundError> {
         DaoRefundMethods::create_refund(self, refund).await
+    }
+
+    async fn recover_in_progress_refunds(&self) -> Result<usize, DaoRefundError> {
+        DaoRefundMethods::recover_in_progress_refunds(self).await
     }
 
     async fn get_refund_by_id(

--- a/daemon/src/dao/payout.rs
+++ b/daemon/src/dao/payout.rs
@@ -127,6 +127,34 @@ impl crate::api::ApiErrorExt for DaoPayoutError {
 }
 
 pub trait DaoPayoutMethods: DaoExecutor + 'static {
+    /// Reset payouts left claimed by a previous daemon process.
+    ///
+    /// This recovery is safe only while a single daemon instance owns the
+    /// database. A concurrent instance could have live `InProgress` work reset.
+    async fn recover_in_progress_payouts(&self) -> Result<usize, DaoPayoutError> {
+        let query = sqlx::query_as::<_, (Uuid,)>(
+            "UPDATE payouts
+            SET status = 'FailedRetriable',
+                next_retry_at = datetime('now'),
+                updated_at = datetime('now')
+            WHERE status = 'InProgress'
+            RETURNING id",
+        );
+
+        self.fetch_all::<_, (Uuid,)>(query)
+            .await
+            .map(|rows| rows.len())
+            .map_err(|e| {
+                tracing::debug!(
+                    error.category = "dao.payout",
+                    error.operation = "recover_in_progress_payouts",
+                    error.source = ?e,
+                    "Failed to recover in-progress payouts"
+                );
+                DaoPayoutError::DatabaseError
+            })
+    }
+
     async fn create_payout(
         &self,
         payout: Payout,
@@ -635,6 +663,88 @@ mod tests {
         assert_eq!(
             pending_all[1].status,
             PayoutStatus::InProgress
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_in_progress_payouts() {
+        let dao = create_test_dao().await;
+        let invoice = dao
+            .create_invoice(default_create_invoice_data())
+            .await
+            .unwrap();
+
+        let mut in_progress = default_payout(invoice.id);
+        in_progress.status = PayoutStatus::InProgress;
+        in_progress.updated_at = Utc::now() - chrono::Duration::hours(1);
+        let in_progress = dao
+            .create_payout(in_progress)
+            .await
+            .unwrap();
+
+        let waiting = dao
+            .create_payout(default_payout(invoice.id))
+            .await
+            .unwrap();
+
+        let mut completed = default_payout(invoice.id);
+        completed.status = PayoutStatus::Completed;
+        let completed = dao
+            .create_payout(completed)
+            .await
+            .unwrap();
+
+        let mut failed = default_payout(invoice.id);
+        failed.status = PayoutStatus::Failed;
+        let failed = dao.create_payout(failed).await.unwrap();
+
+        assert_eq!(
+            dao.recover_in_progress_payouts()
+                .await
+                .unwrap(),
+            1
+        );
+
+        let all = dao.get_all_payouts().await.unwrap();
+        let recovered = all
+            .iter()
+            .find(|payout| payout.id == in_progress.id)
+            .unwrap();
+        assert_eq!(
+            recovered.status,
+            PayoutStatus::FailedRetriable
+        );
+        assert!(
+            recovered
+                .retry_meta
+                .next_retry_at
+                .is_some()
+        );
+        assert!(recovered.updated_at > in_progress.updated_at);
+        assert_eq!(
+            all.iter()
+                .find(|payout| payout.id == waiting.id),
+            Some(&waiting)
+        );
+        assert_eq!(
+            all.iter()
+                .find(|payout| payout.id == completed.id),
+            Some(&completed)
+        );
+        assert_eq!(
+            all.iter()
+                .find(|payout| payout.id == failed.id),
+            Some(&failed)
+        );
+
+        let pending = dao
+            .get_pending_payouts(10)
+            .await
+            .unwrap();
+        assert!(
+            pending
+                .iter()
+                .any(|payout| payout.id == in_progress.id)
         );
     }
 

--- a/daemon/src/dao/refund.rs
+++ b/daemon/src/dao/refund.rs
@@ -64,6 +64,34 @@ impl StatusTransitionError for RefundStatus {
 }
 
 pub trait DaoRefundMethods: DaoExecutor + 'static {
+    /// Reset refunds left claimed by a previous daemon process.
+    ///
+    /// This recovery is safe only while a single daemon instance owns the
+    /// database. A concurrent instance could have live `InProgress` work reset.
+    async fn recover_in_progress_refunds(&self) -> Result<usize, DaoRefundError> {
+        let query = sqlx::query_as::<_, (Uuid,)>(
+            "UPDATE refunds
+            SET status = 'FailedRetriable',
+                next_retry_at = datetime('now'),
+                updated_at = datetime('now')
+            WHERE status = 'InProgress'
+            RETURNING id",
+        );
+
+        self.fetch_all::<_, (Uuid,)>(query)
+            .await
+            .map(|rows| rows.len())
+            .map_err(|e| {
+                tracing::debug!(
+                    error.category = "dao.refund",
+                    error.operation = "recover_in_progress_refunds",
+                    error.source = ?e,
+                    "Failed to recover in-progress refunds"
+                );
+                DaoRefundError::DatabaseError
+            })
+    }
+
     async fn create_refund(
         &self,
         refund: Refund,
@@ -490,6 +518,88 @@ mod tests {
         assert_eq!(
             pending_all[1].status,
             RefundStatus::InProgress
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_in_progress_refunds() {
+        let dao = create_test_dao().await;
+        let invoice = dao
+            .create_invoice(default_create_invoice_data())
+            .await
+            .unwrap();
+
+        let mut in_progress = default_refund(invoice.id);
+        in_progress.status = RefundStatus::InProgress;
+        in_progress.updated_at = Utc::now() - chrono::Duration::hours(1);
+        let in_progress = dao
+            .create_refund(in_progress)
+            .await
+            .unwrap();
+
+        let waiting = dao
+            .create_refund(default_refund(invoice.id))
+            .await
+            .unwrap();
+
+        let mut completed = default_refund(invoice.id);
+        completed.status = RefundStatus::Completed;
+        let completed = dao
+            .create_refund(completed)
+            .await
+            .unwrap();
+
+        let mut failed = default_refund(invoice.id);
+        failed.status = RefundStatus::Failed;
+        let failed = dao.create_refund(failed).await.unwrap();
+
+        assert_eq!(
+            dao.recover_in_progress_refunds()
+                .await
+                .unwrap(),
+            1
+        );
+
+        let all = dao.get_all_refunds().await.unwrap();
+        let recovered = all
+            .iter()
+            .find(|refund| refund.id == in_progress.id)
+            .unwrap();
+        assert_eq!(
+            recovered.status,
+            RefundStatus::FailedRetriable
+        );
+        assert!(
+            recovered
+                .retry_meta
+                .next_retry_at
+                .is_some()
+        );
+        assert!(recovered.updated_at > in_progress.updated_at);
+        assert_eq!(
+            all.iter()
+                .find(|refund| refund.id == waiting.id),
+            Some(&waiting)
+        );
+        assert_eq!(
+            all.iter()
+                .find(|refund| refund.id == completed.id),
+            Some(&completed)
+        );
+        assert_eq!(
+            all.iter()
+                .find(|refund| refund.id == failed.id),
+            Some(&failed)
+        );
+
+        let pending = dao
+            .get_pending_refunds(10)
+            .await
+            .unwrap();
+        assert!(
+            pending
+                .iter()
+                .any(|refund| refund.id == in_progress.id)
         );
     }
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -293,7 +293,13 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
     let recovered_payouts = dao
         .recover_in_progress_payouts()
         .await
-        .map_err(|_| Error::Fatal)?;
+        .map_err(|error| {
+            tracing::error!(
+                error.source = ?error,
+                "Could not recover in-progress payouts, refusing to start"
+            );
+            Error::Fatal
+        })?;
     if recovered_payouts > 0 {
         tracing::info!(
             count = recovered_payouts,
@@ -304,7 +310,13 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
     let recovered_refunds = dao
         .recover_in_progress_refunds()
         .await
-        .map_err(|_| Error::Fatal)?;
+        .map_err(|error| {
+            tracing::error!(
+                error.source = ?error,
+                "Could not recover in-progress refunds, refusing to start"
+            );
+            Error::Fatal
+        })?;
     if recovered_refunds > 0 {
         tracing::info!(
             count = recovered_refunds,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -43,6 +43,7 @@ use chain_client::{
 use configs::{
     ChainsConfig,
     PaymentsConfig,
+    ShopConfig,
     auth_config_with_prefix,
     chains_config_with_prefix,
     database_config_with_prefix,
@@ -168,8 +169,16 @@ async fn init_invoice_registry(dao: &impl DaoInterface) -> Result<InvoiceRegistr
 fn validate_and_extend_configs(
     chains_config: &mut ChainsConfig,
     payments_config: &mut PaymentsConfig,
+    shop_config: &ShopConfig,
     restored_asset_ids: HashMap<ChainType, HashSet<String>>,
 ) -> Result<(), Error> {
+    shop_config
+        .validate_invoices_webhook_url()
+        .map_err(|error| {
+            tracing::error!(%error, "Invalid shop config");
+            Error::Fatal
+        })?;
+
     // Ensure that we have recipients for all chains from restored invoices and for
     // default chain
     let mut required_recipients: Vec<_> = restored_asset_ids
@@ -279,11 +288,36 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
     // Initialize DAO for SQLite database operations
     let dao = DAO::new(database_config.clone()).await?;
 
+    // Recovery must finish before any executor is ignited: once workers can claim
+    // rows, a sweep could reset work claimed by this process.
+    let recovered_payouts = dao
+        .recover_in_progress_payouts()
+        .await
+        .map_err(|_| Error::Fatal)?;
+    if recovered_payouts > 0 {
+        tracing::info!(
+            count = recovered_payouts,
+            "Recovered in-progress payouts"
+        );
+    }
+
+    let recovered_refunds = dao
+        .recover_in_progress_refunds()
+        .await
+        .map_err(|_| Error::Fatal)?;
+    if recovered_refunds > 0 {
+        tracing::info!(
+            count = recovered_refunds,
+            "Recovered in-progress refunds"
+        );
+    }
+
     let invoice_registry = init_invoice_registry(&dao).await?;
 
     validate_and_extend_configs(
         &mut chains_config,
         &mut payments_config,
+        &shop_config,
         invoice_registry.used_asset_ids().await,
     )?;
 

--- a/daemon/src/state.rs
+++ b/daemon/src/state.rs
@@ -458,6 +458,13 @@ impl<D: DaoInterface> AppState<D> {
     }
 
     #[tracing::instrument(skip_all)]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "admin payout initiation is deferred until follow-up work defines the correct amount semantics"
+        )
+    )]
     pub async fn initiate_payout(
         &self,
         invoice_id: Uuid,

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -59,6 +59,10 @@ Transfers from payment address to merchant's wallet.
 | next_retry_at, last_attempt_at | TEXT | Retry scheduling |
 
 `FailedRetriable` -> `InProgress` allows retry. `Completed` and `Failed` are terminal.
+On startup, before background workers begin claiming rows, any payout or refund
+left `InProgress` by an interrupted run is moved to immediately eligible
+`FailedRetriable`. This recovery assumes exactly one daemon instance owns the
+database; sharing one database between live instances is unsupported.
 
 ### refunds
 Refunds from payment address back to customer.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,12 @@ Axum server with four namespaces:
 - `/public` — Publicly accessible, no auth, sanitized responses
 - `/private` — HMAC-authenticated merchant endpoints
 - `/internal` — Internal operations
+- `/admin` — OAuth-session authenticated admin UI and API. Owner-only routes are
+  `/api/integration-settings` and `/api/get-plugin`, because both disclose the
+  merchant HMAC secret (the plugin embeds it). Read-only settings, identity,
+  invoice, payout, transaction, and swap routes are available to Owner,
+  Operator, Viewer, and Support. `/api/payout/initiate` is out of service while
+  its hardcoded amount is replaced with product-defined amount semantics.
 - `/dev` — Development/debug endpoints (feature-gated via `dev_api`)
 
 `ApiErrorExt` trait in `api.rs` provides `category()`, `code()`, `message()`, `http_status_code()` for structured error responses. Request IDs via `x-request-id` header (UUID, auto-generated).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,8 +39,9 @@ Axum server with four namespaces:
   `/api/integration-settings` and `/api/get-plugin`, because both disclose the
   merchant HMAC secret (the plugin embeds it). Read-only settings, identity,
   invoice, payout, transaction, and swap routes are available to Owner,
-  Operator, Viewer, and Support. `/api/payout/initiate` is out of service while
-  its hardcoded amount is replaced with product-defined amount semantics.
+  Operator, Viewer, and Support. `/api/payout/initiate` is not routed at all —
+  it answers 404, not an error status or a feature flag — until its hardcoded
+  amount is replaced with product-defined amount semantics.
 - `/dev` — Development/debug endpoints (feature-gated via `dev_api`)
 
 `ApiErrorExt` trait in `api.rs` provides `category()`, `code()`, `message()`, `http_status_code()` for structured error responses. Request IDs via `x-request-id` header (UUID, auto-generated).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,6 +194,10 @@ endpoints currently cannot be supplied by environment variable at all
 
 Example configs in `configs/` directory.
 
+When configured, the shop webhook URL is validated at startup as an absolute
+HTTP(S) URL with a host. Validation is structural only and performs no network
+reachability check.
+
 At startup, the daemon always runs SQLite's `PRAGMA integrity_check` before migrations. Set
 `require_existing` (or `KALATORI_DATABASE_REQUIRE_EXISTING`) to refuse startup when the configured
 database file is missing or empty; this is incompatible with temporary in-memory mode.


### PR DESCRIPTION
Four small hardening fixes for the final 0.9 point release, batched to spare four rounds of CI on ten-line changes. They are independent; the two commits split them into the operational pair and the admin pair.

## Orphaned in-flight payouts and refunds

A payout or refund flips to `InProgress` the moment it is claimed. If the daemon died between the claim and the terminal update — crash, OOM, container eviction — nothing ever reset the row: the pending query selects only `Waiting` and due `FailedRetriable`. The money owed was stranded silently, with no retry and no signal.

Startup now sweeps both tables back to `FailedRetriable` with an immediate `next_retry_at`, before any executor can claim work. No migration was needed: the status-transition triggers in `20250104000001_initial_schema.sql` already permit `InProgress -> FailedRetriable` for both tables. The sweep is only correct while a single daemon owns the database, which is recorded on the DAO methods and in `docs/DATABASE.md`.

## Webhook URL never validated

`build_request` already declines to panic on a malformed URL, so the daemon would start clean, look healthy, and fail to build every webhook request for the life of the process while events piled up undelivered. The URL is a startup config field, so it is now checked alongside the recipient validation and a bad value refuses to boot.

Structural only — scheme and host, no reachability probe — so startup does not depend on the receiver being up. `None` remains valid; webhooks are optional.

## `/admin/api/payout/initiate` sends a hardcoded 0.21

The handler built every payout with `Decimal::new(21, 2)` and the executor sent that on-chain, for any invoice, with no TODO marking it a stub. Every other payout path uses the amount actually received.

The endpoint could not do anything correct, so it is removed from the router rather than given new amount semantics in a point release. The state method survives behind an expectation recording the deferral — what the amount *should* be is a product question for 0.10.

## Admin roles parsed but never enforced

All twelve handlers bound `Extension(_user)` and ignored it, and `SessionError::InsufficientRole` was dead code — so a Viewer or Support token could do whatever an Owner could. `/admin` is internet-exposed in at least one deployment, and both `integration-settings` and `get-plugin` hand back the raw merchant HMAC secret, which is enough to forge `/private` calls and webhook signatures indefinitely, surviving session revocation.

Both are now Owner-only via a `require_owner` layer. The read-only listing and get routes stay open to every authenticated role — a Viewer must still be able to view.

## One thing worth a reviewer's attention

The API routes are nested under `/api` with **their own 404 fallback**. A nested axum router inherits the outer fallback unless it sets one, and this router ends with `.fallback_service(ServeFile::new("static/admin/index.html"))` — so without the inner fallback, a request to the removed payout endpoint would have been answered with the admin SPA's HTML and a 200 rather than a 404.

The test harness stands in a distinctive status for that fallback instead of using `ServeFile`. That is deliberate: `static/admin/` is a build artefact absent from a source checkout, so `ServeFile` 404s regardless, and the assertion could not have failed. With the marker status it was mutation-checked in both directions — it passes with the inner fallback and fails without it.

## Verification

318 tests pass locally against SQLite 3.51 (the version the migrations require), plus strict clippy and nightly fmt. New coverage: the two DAO recovery sweeps, the webhook URL validator across accepted and rejected forms, role rejection on each gated route, every role reaching the non-gated routes, and the payout endpoint returning 404.

## Downstream consequence for kokpitti

Gating `integration-settings` and `get-plugin` to Owner has a visible effect on the admin frontend. kokpitti's settings route carries no role guard (`src/app/app.routes.ts`, `path: 'settings'` — no `canActivate`), and `src/app/features/settings/integration.page.ts` calls `integration-settings` unconditionally. A Viewer or Support user opening Settings → Integration will now get `INSUFFICIENT_ROLE` where they previously got the merchant HMAC secret.

That is the intended security outcome — the roadmap review flagged separately that kokpitti renders the secret to every admin role — but the page will surface an error rather than being hidden. Hiding or guarding it is a kokpitti-side follow-up and is deliberately not in this PR.
