### PR TITLE
fix(startup): degrade an unreachable chain instead of exiting

### DIFF
--- a/daemon/src/balance_checker.rs
+++ b/daemon/src/balance_checker.rs
@@ -47,8 +47,10 @@ pub struct BalanceChecker<
 > {
     dao: D,
     registry: InvoiceRegistry,
-    asset_hub_client: AH,
-    polygon_client: PG,
+    /// `None` when the chain's client did not come up at startup. See the
+    /// degraded-chain section of [`docs/architecture.md`].
+    asset_hub_client: Option<AH>,
+    polygon_client: Option<PG>,
     etherscan_client: EtherscanClient,
     transactions_recorder: TransactionsRecorder<D>,
 }
@@ -62,8 +64,8 @@ impl<
     pub fn new(
         dao: D,
         registry: InvoiceRegistry,
-        asset_hub_client: AH,
-        polygon_client: PG,
+        asset_hub_client: Option<AH>,
+        polygon_client: Option<PG>,
         etherscan_client: EtherscanClient,
         transactions_recorder: TransactionsRecorder<D>,
     ) -> Self {
@@ -99,9 +101,27 @@ impl<
             BalanceCheckerError::FetchBalanceFailed
         };
 
+        // A chain whose client did not come up at startup has no balances to
+        // report for the rest of this run. Both callers already treat a failed
+        // fetch as "leave the invoice alone and look again later", which is
+        // the right thing to do here too, so this needs no variant of its own
+        // — only a log line that says which of the two it was.
+        let unavailable = || {
+            tracing::warn!(
+                error.category = category::BALANCE_CHECKER,
+                error.operation = operation::FETCH_BALANCE,
+                %chain,
+                "Balance fetch skipped: this chain's client is unavailable for the lifetime of this daemon run"
+            );
+
+            BalanceCheckerError::FetchBalanceFailed
+        };
+
         match chain {
             ChainType::PolkadotAssetHub => {
                 self.asset_hub_client
+                    .as_ref()
+                    .ok_or_else(unavailable)?
                     .fetch_asset_balance(
                         asset_id
                             .parse()
@@ -114,6 +134,8 @@ impl<
             },
             ChainType::Polygon => {
                 self.polygon_client
+                    .as_ref()
+                    .ok_or_else(unavailable)?
                     .fetch_asset_balance(
                         asset_id
                             .parse()
@@ -474,8 +496,10 @@ mod tests {
         BalanceChecker::new(
             MockDaoInterface::default(),
             InvoiceRegistry::new(),
-            MockBlockChainClient::<AssetHubChainConfig>::default(),
-            MockBlockChainClient::<PolygonChainConfig>::default(),
+            Some(MockBlockChainClient::<
+                AssetHubChainConfig,
+            >::default()),
+            Some(MockBlockChainClient::<PolygonChainConfig>::default()),
             EtherscanClient::new(EtherscanClientConfig {
                 requests_per_second: NonZeroU32::MIN,
                 api_key: String::new().into(),
@@ -521,6 +545,54 @@ mod tests {
         }
     }
 
+    /// A chain that never came up has no balance to report for the rest of the
+    /// run, and must not be asked. The chain that did come up answers as
+    /// usual — one missing client degrades one chain, not the checker.
+    #[tokio::test]
+    async fn an_unavailable_chain_reports_no_balance_without_calling_rpc() {
+        let mut asset_hub_client = MockBlockChainClient::<AssetHubChainConfig>::default();
+
+        asset_hub_client
+            .expect_fetch_asset_balance()
+            .once()
+            .returning(|_, _| Ok(Decimal::TEN));
+
+        let checker = BalanceChecker::new(
+            MockDaoInterface::default(),
+            InvoiceRegistry::new(),
+            Some(asset_hub_client),
+            None::<MockBlockChainClient<PolygonChainConfig>>,
+            EtherscanClient::new(EtherscanClientConfig {
+                requests_per_second: NonZeroU32::MIN,
+                api_key: String::new().into(),
+            }),
+            TransactionsRecorder::<MockDaoInterface>::default(),
+        );
+
+        assert!(matches!(
+            checker
+                .get_account_balance(
+                    ChainType::Polygon,
+                    "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+                    "0x45f077823C8d036a1a9f7Cd28e86Bd98191dF2b7",
+                )
+                .await,
+            Err(BalanceCheckerError::FetchBalanceFailed)
+        ));
+
+        assert_eq!(
+            checker
+                .get_account_balance(
+                    ChainType::PolkadotAssetHub,
+                    "1337",
+                    "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+                )
+                .await
+                .expect("the available chain still answers"),
+            Decimal::TEN
+        );
+    }
+
     #[tokio::test]
     async fn asset_hub_reconciliation_observes_transfer_committed_after_balance_fetch() {
         let mut stale_invoice = default_invoice().with_amount(Decimal::ZERO);
@@ -563,8 +635,10 @@ mod tests {
         let checker = BalanceChecker::new(
             dao,
             InvoiceRegistry::new(),
-            MockBlockChainClient::<AssetHubChainConfig>::default(),
-            MockBlockChainClient::<PolygonChainConfig>::default(),
+            Some(MockBlockChainClient::<
+                AssetHubChainConfig,
+            >::default()),
+            Some(MockBlockChainClient::<PolygonChainConfig>::default()),
             EtherscanClient::new(EtherscanClientConfig {
                 requests_per_second: NonZeroU32::MIN,
                 api_key: String::new().into(),
@@ -651,8 +725,10 @@ mod tests {
         let checker = BalanceChecker::new(
             dao,
             InvoiceRegistry::new(),
-            MockBlockChainClient::<AssetHubChainConfig>::default(),
-            MockBlockChainClient::<PolygonChainConfig>::default(),
+            Some(MockBlockChainClient::<
+                AssetHubChainConfig,
+            >::default()),
+            Some(MockBlockChainClient::<PolygonChainConfig>::default()),
             EtherscanClient::new(EtherscanClientConfig {
                 requests_per_second: NonZeroU32::MIN,
                 api_key: String::new().into(),

--- a/daemon/src/chain/executor.rs
+++ b/daemon/src/chain/executor.rs
@@ -1660,6 +1660,10 @@ mod tests {
             let asset_id = 1337;
 
             let mut request: OutgoingTransferRequest = default_payout(Uuid::new_v4()).into();
+            // `default_payout` is a Polygon payout. Without this the request
+            // dispatches to the Polygon client left installed by test case 1
+            // and the Asset Hub path is never exercised at all.
+            request.chain = ChainType::PolkadotAssetHub;
             request.source_address = source_address.to_string();
             request
                 .destination_params
@@ -1668,6 +1672,7 @@ mod tests {
 
             asset_hub_client
                 .expect_build_transfer()
+                .once()
                 .with(
                     eq(source_address),
                     eq(destination_address),

--- a/daemon/src/chain/executor.rs
+++ b/daemon/src/chain/executor.rs
@@ -1822,6 +1822,94 @@ mod tests {
         assert_eq!(queue.len(), 1);
     }
 
+    /// The startup WARN says *direct* payouts and refunds are frozen on an
+    /// unavailable chain — not that every transfer is. `send_transfer` routes a
+    /// same-chain, different-asset transfer to `schedule_swap`, which never
+    /// touches a chain client (`SwapsExecutor` holds only the DAO and the
+    /// provider HTTP clients), so it still executes.
+    ///
+    /// Pin both halves through `send_transfer` rather than
+    /// `schedule_chain_transfer`, because the routing decision is what makes
+    /// the log message true or false. If the direct case stops being held, or
+    /// the swap case starts being blocked, the message becomes a lie.
+    #[tokio::test]
+    async fn an_unavailable_chain_holds_direct_transfers_but_not_provider_routed_swaps() {
+        let mut executor = setup_executor();
+        let mut queue = FuturesUnordered::new();
+
+        executor.polygon_client = None;
+
+        // Same chain, same asset: a direct transfer, which needs our node.
+        let mut direct: OutgoingTransferRequest = default_payout(Uuid::new_v4()).into();
+        direct.chain = ChainType::Polygon;
+        direct
+            .destination_params
+            .destination_asset_id = direct.asset_id.clone();
+
+        let direct_id = direct.id;
+        let expected_held = ChainExecutorError::ChainUnavailable {
+            chain: ChainType::Polygon,
+        }
+        .to_string();
+
+        executor
+            .dao
+            .expect_update_payout_retry()
+            .once()
+            .withf(
+                move |payout_id, retry_meta, is_retriable| {
+                    *payout_id == direct_id
+                        && *is_retriable
+                        && retry_meta.failure_message.as_deref() == Some(expected_held.as_str())
+                },
+            )
+            .returning(|_, _, _| Ok(default_payout(Uuid::new_v4())));
+
+        let () = executor
+            .send_transfer(direct, &mut queue)
+            .await;
+        assert!(queue.is_empty());
+
+        // Same chain, different asset: routed to the swap provider. Failing it
+        // inside the swap path is what proves the path was entered at all —
+        // the recorded failure is the provider's, not `ChainUnavailable`.
+        let mut swap_shaped: OutgoingTransferRequest = default_payout(Uuid::new_v4()).into();
+        swap_shaped.chain = ChainType::Polygon;
+        swap_shaped.amount = Decimal::ONE;
+        swap_shaped
+            .destination_params
+            .destination_asset_id = "0xc2132D05D31c914a87C6611C10748AEb04B58e8F".to_string();
+
+        executor
+            .swaps_executor
+            .expect_create_swap()
+            .once()
+            .returning(|_| Err(SwapsExecutorError::DatabaseError));
+
+        let swap_id = swap_shaped.id;
+        let expected_routed = ChainExecutorError::BuildTransfer {
+            reason: SwapsExecutorError::DatabaseError.to_string(),
+        }
+        .to_string();
+
+        executor
+            .dao
+            .expect_update_payout_retry()
+            .once()
+            .withf(
+                move |payout_id, retry_meta, _is_retriable| {
+                    *payout_id == swap_id
+                        && retry_meta.failure_message.as_deref() == Some(expected_routed.as_str())
+                },
+            )
+            .returning(|_, _, _| Ok(default_payout(Uuid::new_v4())));
+
+        let () = executor
+            .send_transfer(swap_shaped, &mut queue)
+            .await;
+        assert!(queue.is_empty());
+    }
+
     #[tokio::test]
     async fn test_schedule_swap() {
         let mut executor = setup_executor();

--- a/daemon/src/chain/executor.rs
+++ b/daemon/src/chain/executor.rs
@@ -75,6 +75,11 @@ pub enum ChainExecutorError {
         from_chain: SwapChainType,
         to_chain: SwapChainType,
     },
+    // The chain's client did not come up at startup, so nothing can be submitted to it
+    // until the daemon is restarted. Retriable on purpose: the transfer has to stay
+    // claimable rather than be failed for good because of an RPC outage.
+    #[error("Chain {chain} is unavailable for the lifetime of this daemon run")]
+    ChainUnavailable { chain: ChainType },
 }
 
 impl ChainExecutorError {
@@ -92,6 +97,12 @@ impl ChainExecutorError {
             UnsupportedSwapDirection {
                 ..
             } => false,
+            // Recovering from a chain that failed to initialize takes a
+            // restart, and the retry backoff is what keeps the row claimable
+            // across one.
+            ChainUnavailable {
+                ..
+            } => true,
         }
     }
 }
@@ -175,8 +186,10 @@ pub struct TransfersExecutor<
     PG: BlockChainClient<PolygonChainConfig> + 'static = PolygonClient,
 > {
     refund_destination_detector: RefundDestinationDetector<D>,
-    asset_hub_client: Arc<AH>,
-    polygon_client: Arc<PG>,
+    /// `None` when the chain's client did not come up at startup. See the
+    /// degraded-chain section of [`docs/architecture.md`].
+    asset_hub_client: Option<Arc<AH>>,
+    polygon_client: Option<Arc<PG>>,
     dao: D,
     swaps_executor: SwapsExecutor<D>,
     keyring_client: KeyringClient,
@@ -520,14 +533,25 @@ impl<
         // it will be added to span at the prepare_transfer call
         let transaction_id = Uuid::new_v4();
 
-        let transfer = match request.chain {
+        let chain = request.chain;
+        let unavailable = || ChainExecutorError::ChainUnavailable {
+            chain,
+        };
+
+        let transfer = match chain {
             ChainType::PolkadotAssetHub => {
-                let client = self.asset_hub_client.clone();
+                let client = self
+                    .asset_hub_client
+                    .clone()
+                    .ok_or_else(unavailable)?;
                 self.prepare_transfer(client, request, transaction_id)
                     .await
             },
             ChainType::Polygon => {
-                let client = self.polygon_client.clone();
+                let client = self
+                    .polygon_client
+                    .clone()
+                    .ok_or_else(unavailable)?;
                 self.prepare_transfer(client, request, transaction_id)
                     .await
             },
@@ -1059,7 +1083,21 @@ impl<
             POLLING_INTERVAL_MILLIS,
         ));
 
-        tracing::info!("Transfers executor started for AssetHub and Polygon chains.");
+        // Name the chains this executor can actually submit to. Claiming both
+        // when one client never came up is how the startup bug this replaced
+        // stayed invisible for so long.
+        let mut chains: Vec<&str> = Vec::new();
+        if self.asset_hub_client.is_some() {
+            chains.push("AssetHub");
+        }
+        if self.polygon_client.is_some() {
+            chains.push("Polygon");
+        }
+
+        tracing::info!(
+            chains = chains.join(", "),
+            "Transfers executor started"
+        );
 
         loop {
             tokio::select! {
@@ -1099,16 +1137,16 @@ impl<
 
     pub fn new(
         refund_destination_detector: RefundDestinationDetector<D>,
-        asset_hub_client: AH,
-        polygon_client: PG,
+        asset_hub_client: Option<AH>,
+        polygon_client: Option<PG>,
         dao: D,
         keyring_client: KeyringClient,
         swaps_executor: SwapsExecutor<D>,
     ) -> Self {
         Self {
             refund_destination_detector,
-            asset_hub_client: Arc::new(asset_hub_client),
-            polygon_client: Arc::new(polygon_client),
+            asset_hub_client: asset_hub_client.map(Arc::new),
+            polygon_client: polygon_client.map(Arc::new),
             dao,
             swaps_executor,
             keyring_client,
@@ -1171,8 +1209,8 @@ mod tests {
 
         TransfersExecutor::new(
             refund_destination_detector,
-            asset_hub_client,
-            polygon_client,
+            Some(asset_hub_client),
+            Some(polygon_client),
             dao,
             keyring_client,
             swaps_executor,
@@ -1197,8 +1235,8 @@ mod tests {
 
         let executor = TransfersExecutor::new(
             refund_destination_detector,
-            asset_hub_client,
-            polygon_client,
+            Some(asset_hub_client),
+            Some(polygon_client),
             dao,
             keyring_client,
             swaps_executor,
@@ -1595,7 +1633,7 @@ mod tests {
                     })
                 });
 
-            executor.polygon_client = Arc::new(polygon_client);
+            executor.polygon_client = Some(Arc::new(polygon_client));
 
             let result = executor
                 .schedule_chain_transfer(request.clone(), &mut queue)
@@ -1642,7 +1680,7 @@ mod tests {
                     })
                 });
 
-            executor.asset_hub_client = Arc::new(asset_hub_client);
+            executor.asset_hub_client = Some(Arc::new(asset_hub_client));
 
             let result = executor
                 .schedule_chain_transfer(request.clone(), &mut queue)
@@ -1690,7 +1728,7 @@ mod tests {
                     })
                 });
 
-            executor.polygon_client = Arc::new(polygon_client);
+            executor.polygon_client = Some(Arc::new(polygon_client));
 
             executor
                 .dao
@@ -1706,6 +1744,77 @@ mod tests {
             assert!(result.is_ok());
             assert_eq!(queue.len(), 1);
         }
+    }
+
+    /// A chain whose client never came up must neither take the daemon down
+    /// nor swallow the transfer: the request comes back as `ChainUnavailable`,
+    /// which is retriable, so the row stays claimable and a restart with the
+    /// chain reachable still pays it out. The chain that *did* come up keeps
+    /// working in the same executor.
+    #[tokio::test]
+    async fn a_transfer_on_an_unavailable_chain_is_retriable_and_the_other_chain_still_works() {
+        let mut executor = setup_executor();
+        let mut queue = FuturesUnordered::new();
+
+        executor.asset_hub_client = None;
+
+        let mut asset_hub_request: OutgoingTransferRequest = default_payout(Uuid::new_v4()).into();
+        asset_hub_request.chain = ChainType::PolkadotAssetHub;
+
+        let error = executor
+            .schedule_chain_transfer(asset_hub_request, &mut queue)
+            .await
+            .expect_err("a transfer on a chain with no client cannot be scheduled");
+
+        assert_eq!(
+            error,
+            ChainExecutorError::ChainUnavailable {
+                chain: ChainType::PolkadotAssetHub,
+            }
+        );
+        assert!(
+            error.is_retriable(),
+            "an unreachable chain must not fail a payout for good"
+        );
+        assert!(queue.is_empty());
+
+        // The healthy chain is untouched by its neighbour being down.
+        let mut polygon_client = MockBlockChainClient::<PolygonChainConfig>::default();
+
+        polygon_client
+            .expect_build_transfer()
+            .once()
+            .returning(|_, _, _, _| {
+                Ok(UnsignedTransaction {
+                    transaction: default_polygon_unsigned_transaction(),
+                })
+            });
+        polygon_client
+            .expect_sign_transaction()
+            .once()
+            .returning(|_, _, _| {
+                Ok(SignedTransaction {
+                    transaction: default_polygon_signed_transaction(),
+                })
+            });
+
+        executor.polygon_client = Some(Arc::new(polygon_client));
+        executor
+            .dao
+            .expect_create_transaction()
+            .once()
+            .returning(Ok);
+
+        let mut polygon_request: OutgoingTransferRequest = default_payout(Uuid::new_v4()).into();
+        polygon_request.chain = ChainType::Polygon;
+
+        assert!(
+            executor
+                .schedule_chain_transfer(polygon_request, &mut queue)
+                .await
+                .is_ok()
+        );
+        assert_eq!(queue.len(), 1);
     }
 
     #[tokio::test]
@@ -2108,7 +2217,7 @@ mod tests {
                     })
                 });
 
-            executor.polygon_client = Arc::new(polygon_client);
+            executor.polygon_client = Some(Arc::new(polygon_client));
 
             executor
                 .dao
@@ -2146,7 +2255,7 @@ mod tests {
             .times(2)
             .returning(move |_, _, _, _| Err(returned_error.clone()));
 
-        executor.polygon_client = Arc::new(polygon_client);
+        executor.polygon_client = Some(Arc::new(polygon_client));
 
         // Test case 3:
         // - Unsuccessful flow

--- a/daemon/src/chain_client.rs
+++ b/daemon/src/chain_client.rs
@@ -54,6 +54,28 @@ pub use polygon::{
 pub type TransfersStream<T> =
     Pin<Box<dyn stream::Stream<Item = Result<Vec<ChainTransfer<T>>, SubscriptionError>> + Send>>;
 
+/// How long one endpoint gets to prove itself before we move to the next.
+///
+/// Neither dependency bounds this for us, and both leave a half-open peer able
+/// to hang forever. subxt reaches jsonrpsee, whose 10s `connection_timeout`
+/// covers `TcpStream::connect` only — the TLS handshake and the WebSocket
+/// upgrade sit outside it. alloy's `WsConnect` retry budget
+/// (`WS_RECONNECT_MAX_RETRIES`) governs *reconnects* of an established socket
+/// and does not apply to the initial connect at all, which is a single
+/// unbounded `tokio_tungstenite::connect_async`. A blackholed address
+/// therefore costs the OS TCP timeout — ~127s per resolved address, doubled on
+/// a dual-stack host.
+///
+/// That was survivable while a client tried exactly one endpoint. Now that
+/// connecting walks the whole list, an unbounded per-endpoint cost multiplies
+/// by the endpoint count, so the cap has to be ours. It bounds startup at
+/// `endpoints × this` per connect phase, and a chain that blows through it is
+/// reported as unavailable rather than stalling the daemon.
+///
+/// Generous on purpose: this is a "the node is gone" cap, not a latency
+/// budget, and must not fail a slow-but-working node on a congested link.
+pub const ENDPOINT_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
 pub trait SignedTransactionUtils {
     /// Encode transaction to raw string. It might be hex-encoded bytes or json
     /// value depending on implementation

--- a/daemon/src/chain_client/asset_hub.rs
+++ b/daemon/src/chain_client/asset_hub.rs
@@ -232,34 +232,59 @@ impl AssetHubClient {
         // TODO: implement circuit breaker for endpoints
         // (should be another wrapper structure with endpoints hidden behind sync
         // primitives with error counters and usage timeouts)
-        let endpoint = config
-            .get_random_requests_endpoint()
-            .ok_or(ClientError::InvalidConfiguration {
+        let endpoints = config.shuffled_requests_endpoints();
+
+        if endpoints.is_empty() {
+            return Err(ClientError::InvalidConfiguration {
                 field: "endpoints".to_string(),
-            })?;
-
-        tracing::debug!(
-            url = endpoint,
-            chain = %Self::chain_type(),
-            "Trying to connect to endpoint...",
-        );
-
-        let client = if config.allow_insecure_endpoints {
-            SubxtAssetHubClient::from_insecure_url(&endpoint).await
-        } else {
-            SubxtAssetHubClient::from_url(&endpoint).await
+            })
         }
-        .inspect_err(|e| {
+
+        // Walk every configured endpoint before declaring the chain
+        // unreachable: one node restarting is an outage of that node, not of
+        // the chain, and `AllEndpointsUnreachable` has to mean what it says.
+        let mut client = None;
+
+        for endpoint in &endpoints {
             tracing::debug!(
+                url = endpoint,
+                chain = %Self::chain_type(),
+                "Trying to connect to endpoint...",
+            );
+
+            let connected = if config.allow_insecure_endpoints {
+                SubxtAssetHubClient::from_insecure_url(endpoint).await
+            } else {
+                SubxtAssetHubClient::from_url(endpoint).await
+            };
+
+            match connected {
+                Ok(connected) => {
+                    client = Some(connected);
+                    break
+                },
+                Err(e) => tracing::debug!(
+                    error.category = crate::utils::logging::category::CHAIN_CLIENT,
+                    error.operation = crate::utils::logging::operation::CONNECT_CLIENT,
+                    error.source = ?e,
+                    chain = %Self::chain_type(),
+                    endpoint = %endpoint,
+                    "Failed to connect to Asset Hub RPC endpoint"
+                ),
+            }
+        }
+
+        let client = client.ok_or_else(|| {
+            tracing::warn!(
                 error.category = crate::utils::logging::category::CHAIN_CLIENT,
                 error.operation = crate::utils::logging::operation::CONNECT_CLIENT,
-                error.source = ?e,
                 chain = %Self::chain_type(),
-                endpoint = %endpoint,
-                "Failed to connect to Asset Hub RPC endpoint"
+                tried_endpoints = endpoints.len(),
+                "Every configured Asset Hub RPC endpoint is unreachable"
             );
-        })
-        .map_err(|_| ClientError::AllEndpointsUnreachable)?;
+
+            ClientError::AllEndpointsUnreachable
+        })?;
 
         Ok(AssetHubClient {
             config: config.clone(),

--- a/daemon/src/chain_client/asset_hub.rs
+++ b/daemon/src/chain_client/asset_hub.rs
@@ -229,6 +229,26 @@ impl AssetHubClient {
         config: &crate::configs::ChainConfig,
         asset_info_store: AssetInfoStore<AssetHubChainConfig>,
     ) -> Result<Self, ClientError> {
+        Self::from_config_with_timeout(
+            config,
+            asset_info_store,
+            super::ENDPOINT_CONNECT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// The endpoint walk, with the per-attempt budget as a parameter.
+    ///
+    /// Only the timeout is injected, and only so a test can drive the
+    /// give-up path against a peer that stalls mid-handshake without waiting
+    /// out the production budget. Everything else — endpoint selection, the
+    /// loop, the give-up condition — is the real code path, exercised against
+    /// real sockets.
+    async fn from_config_with_timeout(
+        config: &crate::configs::ChainConfig,
+        asset_info_store: AssetInfoStore<AssetHubChainConfig>,
+        connect_timeout: std::time::Duration,
+    ) -> Result<Self, ClientError> {
         // TODO: implement circuit breaker for endpoints
         // (should be another wrapper structure with endpoints hidden behind sync
         // primitives with error counters and usage timeouts)
@@ -256,7 +276,7 @@ impl AssetHubClient {
             // nothing else, so a peer that completes the TCP handshake and
             // then stalls the TLS or WebSocket upgrade would hang here and
             // never let the loop reach the remaining endpoints.
-            let connected = tokio::time::timeout(super::ENDPOINT_CONNECT_TIMEOUT, async {
+            let connected = tokio::time::timeout(connect_timeout, async {
                 if config.allow_insecure_endpoints {
                     SubxtAssetHubClient::from_insecure_url(endpoint).await
                 } else {
@@ -283,7 +303,7 @@ impl AssetHubClient {
                     error.operation = crate::utils::logging::operation::CONNECT_CLIENT,
                     chain = %Self::chain_type(),
                     endpoint = %endpoint,
-                    timeout_seconds = super::ENDPOINT_CONNECT_TIMEOUT.as_secs(),
+                    timeout_seconds = connect_timeout.as_secs(),
                     "Asset Hub RPC endpoint did not finish connecting in time, moving on"
                 ),
             }
@@ -1048,5 +1068,128 @@ impl BlockChainClient<AssetHubChainConfig> for AssetHubClient {
             #[expect(clippy::cast_sign_loss)]
             timestamp: chrono::Utc::now().timestamp_millis() as u64,
         })
+    }
+}
+
+#[cfg(test)]
+mod endpoint_loop_tests {
+    use std::time::Duration;
+
+    use crate::configs::{
+        ChainConfig as ChainEndpointsConfig,
+        ChainEndpoint,
+        EndpointAllowedOperation,
+    };
+
+    use super::*;
+
+    /// A bound-but-never-accepted port. The OS completes the TCP handshake from
+    /// the backlog, so the peer looks alive and then stalls mid-handshake —
+    /// the case neither jsonrpsee's connect budget nor alloy's retry budget
+    /// covers, and the one `ENDPOINT_CONNECT_TIMEOUT` exists for. The listener
+    /// is returned so the caller keeps the port bound for the test's duration.
+    fn stalling_endpoint() -> (std::net::TcpListener, String) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        (
+            listener,
+            format!("ws://127.0.0.1:{port}"),
+        )
+    }
+
+    fn config(urls: &[&str]) -> ChainEndpointsConfig {
+        ChainEndpointsConfig {
+            endpoints: urls
+                .iter()
+                .map(|url| ChainEndpoint::Universal((*url).to_string()))
+                .collect(),
+            allow_insecure_endpoints: true,
+            ..ChainEndpointsConfig::default()
+        }
+    }
+
+    /// The failover loop against real sockets: two closed ports must both be
+    /// tried, and the result must be `AllEndpointsUnreachable` rather than a
+    /// hang. Before the endpoint walk landed, one unlucky pick decided this.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn every_endpoint_is_tried_before_the_chain_is_called_unreachable() {
+        // Port 1 and 2 are privileged and never bound by a normal process, so
+        // both refuse immediately and deterministically.
+        let result = AssetHubClient::from_config(
+            &config(&["ws://127.0.0.1:1", "ws://127.0.0.1:2"]),
+            AssetInfoStore::new(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::AllEndpointsUnreachable)
+        ));
+        // The verdict alone does not prove the walk happened — returning it
+        // after trying nothing would look identical. Both endpoints have to
+        // appear in the attempt log.
+        assert!(logs_contain("127.0.0.1:1"));
+        assert!(logs_contain("127.0.0.1:2"));
+    }
+
+    /// No endpoint at all is a configuration error, not an outage: retrying
+    /// will never fix it, so it must not be reported as unreachable.
+    #[tokio::test]
+    async fn an_empty_endpoint_list_is_a_configuration_error() {
+        let result = AssetHubClient::from_config(&config(&[]), AssetInfoStore::new()).await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::InvalidConfiguration { field }) if field == "endpoints"
+        ));
+    }
+
+    /// An endpoint list that exists but allows only subscriptions leaves the
+    /// request connect with nothing to try — also configuration, not outage.
+    #[tokio::test]
+    async fn endpoints_that_forbid_requests_are_a_configuration_error() {
+        let chain_config = ChainEndpointsConfig {
+            endpoints: vec![ChainEndpoint::Specific {
+                url: "ws://127.0.0.1:1".to_string(),
+                operations: vec![EndpointAllowedOperation::Subscriptions],
+            }],
+            allow_insecure_endpoints: true,
+            ..ChainEndpointsConfig::default()
+        };
+
+        let result = AssetHubClient::from_config(&chain_config, AssetInfoStore::new()).await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::InvalidConfiguration { field }) if field == "endpoints"
+        ));
+    }
+
+    /// A peer that accepts and then goes mute must not hold startup open. This
+    /// is the half-open case: without our own budget the connect hangs
+    /// indefinitely and the loop never reaches the remaining endpoints.
+    #[tokio::test]
+    async fn a_stalled_handshake_gives_up_and_moves_on() {
+        let (_first, first_url) = stalling_endpoint();
+        let (_second, second_url) = stalling_endpoint();
+
+        let started = tokio::time::Instant::now();
+        let result = AssetHubClient::from_config_with_timeout(
+            &config(&[&first_url, &second_url]),
+            AssetInfoStore::new(),
+            Duration::from_millis(150),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::AllEndpointsUnreachable)
+        ));
+        // Both endpoints were waited on and both gave up: at least two budgets
+        // elapsed, and the whole walk stayed bounded rather than hanging.
+        assert!(started.elapsed() >= Duration::from_millis(300));
+        assert!(started.elapsed() < Duration::from_secs(10));
     }
 }

--- a/daemon/src/chain_client/asset_hub.rs
+++ b/daemon/src/chain_client/asset_hub.rs
@@ -252,24 +252,39 @@ impl AssetHubClient {
                 "Trying to connect to endpoint...",
             );
 
-            let connected = if config.allow_insecure_endpoints {
-                SubxtAssetHubClient::from_insecure_url(endpoint).await
-            } else {
-                SubxtAssetHubClient::from_url(endpoint).await
-            };
+            // jsonrpsee's own 10s budget covers `TcpStream::connect` and
+            // nothing else, so a peer that completes the TCP handshake and
+            // then stalls the TLS or WebSocket upgrade would hang here and
+            // never let the loop reach the remaining endpoints.
+            let connected = tokio::time::timeout(super::ENDPOINT_CONNECT_TIMEOUT, async {
+                if config.allow_insecure_endpoints {
+                    SubxtAssetHubClient::from_insecure_url(endpoint).await
+                } else {
+                    SubxtAssetHubClient::from_url(endpoint).await
+                }
+            })
+            .await;
 
             match connected {
-                Ok(connected) => {
+                Ok(Ok(connected)) => {
                     client = Some(connected);
                     break
                 },
-                Err(e) => tracing::debug!(
+                Ok(Err(e)) => tracing::debug!(
                     error.category = crate::utils::logging::category::CHAIN_CLIENT,
                     error.operation = crate::utils::logging::operation::CONNECT_CLIENT,
                     error.source = ?e,
                     chain = %Self::chain_type(),
                     endpoint = %endpoint,
                     "Failed to connect to Asset Hub RPC endpoint"
+                ),
+                Err(_elapsed) => tracing::warn!(
+                    error.category = crate::utils::logging::category::CHAIN_CLIENT,
+                    error.operation = crate::utils::logging::operation::CONNECT_CLIENT,
+                    chain = %Self::chain_type(),
+                    endpoint = %endpoint,
+                    timeout_seconds = super::ENDPOINT_CONNECT_TIMEOUT.as_secs(),
+                    "Asset Hub RPC endpoint did not finish connecting in time, moving on"
                 ),
             }
         }

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -445,13 +445,16 @@ impl PolygonClient {
     /// endpoint, so both steps have to pass before we keep it. Returns `None`
     /// when this endpoint is unusable, leaving the caller free to try the
     /// next one.
-    async fn connect_and_identify(endpoint: &str) -> Option<(PolygonProvider, u64)> {
+    async fn connect_and_identify(
+        endpoint: &str,
+        connect_timeout: Duration,
+    ) -> Option<(PolygonProvider, u64)> {
         // One budget covers the connect and the probe together: both are
         // unbounded on their own — alloy's retry budget applies to reconnects
         // of an established socket, not to this first connect, and the RPC
         // client sets no request timeout — so either could hang the endpoint
         // loop before it reaches the remaining endpoints.
-        let connected = tokio::time::timeout(ENDPOINT_CONNECT_TIMEOUT, async {
+        let connected = tokio::time::timeout(connect_timeout, async {
             let provider = Self::connect_provider(endpoint).await?;
 
             tracing::debug!(
@@ -480,7 +483,7 @@ impl PolygonClient {
         match connected {
             Ok(connected) => connected,
             Err(_elapsed) => {
-                Self::warn_connect_timed_out(endpoint);
+                Self::warn_connect_timed_out(endpoint, connect_timeout);
 
                 None
             },
@@ -511,13 +514,16 @@ impl PolygonClient {
             .ok()
     }
 
-    fn warn_connect_timed_out(endpoint: &str) {
+    fn warn_connect_timed_out(
+        endpoint: &str,
+        connect_timeout: Duration,
+    ) {
         tracing::warn!(
             error.category = CHAIN_CLIENT,
             error.operation = "connect_client",
             chain = %Self::chain_type(),
             endpoint = %endpoint,
-            timeout_seconds = ENDPOINT_CONNECT_TIMEOUT.as_secs(),
+            timeout_seconds = connect_timeout.as_secs(),
             "Polygon RPC endpoint did not finish connecting in time, moving on"
         );
     }
@@ -527,6 +533,26 @@ impl PolygonClient {
     async fn from_config(
         config: &crate::configs::ChainConfig,
         asset_info_store: AssetInfoStore<PolygonChainConfig>,
+    ) -> Result<Self, ClientError> {
+        Self::from_config_with_timeout(
+            config,
+            asset_info_store,
+            ENDPOINT_CONNECT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// The endpoint walk, with the per-attempt budget as a parameter.
+    ///
+    /// Only the timeout is injected, and only so a test can drive the give-up
+    /// path against a peer that stalls mid-handshake without waiting out the
+    /// production budget. Everything else — endpoint selection, both loops,
+    /// the give-up conditions — is the real code path, exercised against real
+    /// sockets.
+    async fn from_config_with_timeout(
+        config: &crate::configs::ChainConfig,
+        asset_info_store: AssetInfoStore<PolygonChainConfig>,
+        connect_timeout: Duration,
     ) -> Result<Self, ClientError> {
         // Walk every configured endpoint before declaring the chain
         // unreachable: one node restarting is an outage of that node, not of
@@ -548,7 +574,7 @@ impl PolygonClient {
                 "Trying to connect to endpoint...",
             );
 
-            match Self::connect_and_identify(endpoint).await {
+            match Self::connect_and_identify(endpoint, connect_timeout).await {
                 Some(provider_and_chain_id) => {
                     connected = Some(provider_and_chain_id);
                     break
@@ -581,7 +607,7 @@ impl PolygonClient {
 
         for endpoint in &subscription_endpoints {
             match tokio::time::timeout(
-                ENDPOINT_CONNECT_TIMEOUT,
+                connect_timeout,
                 Self::connect_provider(endpoint),
             )
             .await
@@ -598,7 +624,7 @@ impl PolygonClient {
                 },
                 // `connect_provider` already logged why.
                 Ok(None) => {},
-                Err(_elapsed) => Self::warn_connect_timed_out(endpoint),
+                Err(_elapsed) => Self::warn_connect_timed_out(endpoint, connect_timeout),
             }
         }
 
@@ -1807,5 +1833,120 @@ mod tests {
             "alloy would still be retrying after {worst_case:?}, past our own \
              {WS_MESSAGES_TIMEOUT_DURATION:?} timeout, blocking endpoint rotation",
         );
+    }
+}
+
+#[cfg(test)]
+mod endpoint_loop_tests {
+    use crate::configs::{
+        ChainConfig as ChainEndpointsConfig,
+        ChainEndpoint,
+        EndpointAllowedOperation,
+    };
+
+    use super::*;
+
+    /// See the twin module in `asset_hub.rs`: a bound-but-never-accepted port
+    /// completes the TCP handshake from the backlog and then goes mute, which
+    /// is the half-open case alloy's retry budget does not cover — it governs
+    /// reconnects of an established socket, not the initial connect.
+    fn stalling_endpoint() -> (std::net::TcpListener, String) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        (
+            listener,
+            format!("ws://127.0.0.1:{port}"),
+        )
+    }
+
+    fn config(urls: &[&str]) -> ChainEndpointsConfig {
+        ChainEndpointsConfig {
+            endpoints: urls
+                .iter()
+                .map(|url| ChainEndpoint::Universal((*url).to_string()))
+                .collect(),
+            allow_insecure_endpoints: true,
+            ..ChainEndpointsConfig::default()
+        }
+    }
+
+    /// Port 1 and 2 are privileged and never bound by a normal process, so both
+    /// refuse immediately: the walk covers every endpoint and reports the chain
+    /// unreachable rather than letting one unlucky pick decide.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn every_endpoint_is_tried_before_the_chain_is_called_unreachable() {
+        let result = PolygonClient::from_config(
+            &config(&["ws://127.0.0.1:1", "ws://127.0.0.1:2"]),
+            AssetInfoStore::new(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::AllEndpointsUnreachable)
+        ));
+        // The verdict alone does not prove the walk happened — returning it
+        // after trying nothing would look identical. Both endpoints have to
+        // appear in the attempt log.
+        assert!(logs_contain("127.0.0.1:1"));
+        assert!(logs_contain("127.0.0.1:2"));
+    }
+
+    #[tokio::test]
+    async fn an_empty_endpoint_list_is_a_configuration_error() {
+        let result = PolygonClient::from_config(&config(&[]), AssetInfoStore::new()).await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::InvalidConfiguration { field }) if field == "endpoints"
+        ));
+    }
+
+    /// Polygon connects twice — request providers then subscription providers.
+    /// An endpoint list that allows only subscriptions leaves the request phase
+    /// with nothing to try, which is configuration rather than an outage.
+    #[tokio::test]
+    async fn endpoints_that_forbid_requests_are_a_configuration_error() {
+        let chain_config = ChainEndpointsConfig {
+            endpoints: vec![ChainEndpoint::Specific {
+                url: "ws://127.0.0.1:1".to_string(),
+                operations: vec![EndpointAllowedOperation::Subscriptions],
+            }],
+            allow_insecure_endpoints: true,
+            ..ChainEndpointsConfig::default()
+        };
+
+        let result = PolygonClient::from_config(&chain_config, AssetInfoStore::new()).await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::InvalidConfiguration { field }) if field == "endpoints"
+        ));
+    }
+
+    /// A peer that accepts and then goes mute must not hold startup open.
+    #[tokio::test]
+    async fn a_stalled_handshake_gives_up_and_moves_on() {
+        let (_first, first_url) = stalling_endpoint();
+        let (_second, second_url) = stalling_endpoint();
+
+        let started = tokio::time::Instant::now();
+        let result = PolygonClient::from_config_with_timeout(
+            &config(&[&first_url, &second_url]),
+            AssetInfoStore::new(),
+            Duration::from_millis(150),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::AllEndpointsUnreachable)
+        ));
+        // Both endpoints were waited on and both gave up, and the walk stayed
+        // bounded rather than hanging on the first mute peer.
+        assert!(started.elapsed() >= Duration::from_millis(300));
+        assert!(started.elapsed() < Duration::from_secs(10));
     }
 }

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -430,28 +430,18 @@ pub struct PolygonClient {
 }
 
 impl PolygonClient {
-    /// Create a new Polygon client from configuration
-    #[instrument(skip(config, asset_info_store))]
-    async fn from_config(
-        config: &crate::configs::ChainConfig,
-        asset_info_store: AssetInfoStore<PolygonChainConfig>,
-    ) -> Result<Self, ClientError> {
-        let endpoint = config
-            .get_random_requests_endpoint()
-            .ok_or(ClientError::InvalidConfiguration {
-                field: "endpoints".to_string(),
-            })?;
-
-        tracing::debug!(
-            url = endpoint,
-            chain = %Self::chain_type(),
-            "Trying to connect to endpoint...",
-        );
-
-        // Test connection and get chain ID
-        let ws_connect = WsConnect::new(&endpoint)
+    /// Connect to one request endpoint and read its chain id.
+    ///
+    /// The chain id read doubles as a liveness probe: a socket that accepts
+    /// the connection but cannot answer `eth_chainId` is not a usable
+    /// endpoint, so both steps have to pass before we keep it. Returns `None`
+    /// when this endpoint is unusable, leaving the caller free to try the
+    /// next one.
+    async fn connect_and_identify(endpoint: &str) -> Option<(PolygonProvider, u64)> {
+        let ws_connect = WsConnect::new(endpoint)
             .with_max_retries(WS_RECONNECT_MAX_RETRIES)
             .with_retry_interval(WS_RECONNECT_RETRY_INTERVAL);
+
         let provider = ProviderBuilder::new()
             .connect_ws(ws_connect)
             .await
@@ -465,7 +455,7 @@ impl PolygonClient {
                     "Failed to connect to Polygon RPC endpoint"
                 );
             })
-            .map_err(|_| ClientError::AllEndpointsUnreachable)?;
+            .ok()?;
 
         tracing::debug!(
             url = endpoint,
@@ -473,7 +463,6 @@ impl PolygonClient {
             "Connection successful"
         );
 
-        // Get chain ID for transaction signing
         let chain_id = provider
             .get_chain_id()
             .await
@@ -481,41 +470,113 @@ impl PolygonClient {
                 tracing::debug!(
                     error.category = CHAIN_CLIENT,
                     error.source = ?e,
+                    endpoint = %endpoint,
                     "Failed to get chain ID"
                 );
             })
-            .map_err(|_| ClientError::MetadataFetchFailed)?;
+            .ok()?;
 
-        let endpoint = config
-            .get_random_subscriptions_endpoint()
-            .ok_or(ClientError::InvalidConfiguration {
+        Some((provider, chain_id))
+    }
+
+    /// Create a new Polygon client from configuration
+    #[instrument(skip(config, asset_info_store))]
+    async fn from_config(
+        config: &crate::configs::ChainConfig,
+        asset_info_store: AssetInfoStore<PolygonChainConfig>,
+    ) -> Result<Self, ClientError> {
+        // Walk every configured endpoint before declaring the chain
+        // unreachable: one node restarting is an outage of that node, not of
+        // the chain, and `AllEndpointsUnreachable` has to mean what it says.
+        let request_endpoints = config.shuffled_requests_endpoints();
+
+        if request_endpoints.is_empty() {
+            return Err(ClientError::InvalidConfiguration {
                 field: "endpoints".to_string(),
-            })?;
+            })
+        }
 
-        // Test connection and get chain ID
-        let ws_connect = WsConnect::new(&endpoint)
-            .with_max_retries(WS_RECONNECT_MAX_RETRIES)
-            .with_retry_interval(WS_RECONNECT_RETRY_INTERVAL);
-        let subscription_provider = ProviderBuilder::new()
-            .connect_ws(ws_connect)
-            .await
-            .inspect_err(|e| {
-                tracing::debug!(
+        let mut connected = None;
+
+        for endpoint in &request_endpoints {
+            tracing::debug!(
+                url = endpoint,
+                chain = %Self::chain_type(),
+                "Trying to connect to endpoint...",
+            );
+
+            match Self::connect_and_identify(endpoint).await {
+                Some(provider_and_chain_id) => {
+                    connected = Some(provider_and_chain_id);
+                    break
+                },
+                None => continue,
+            }
+        }
+
+        let (provider, chain_id) = connected.ok_or_else(|| {
+            tracing::warn!(
+                error.category = CHAIN_CLIENT,
+                error.operation = "connect_client",
+                chain = %Self::chain_type(),
+                tried_endpoints = request_endpoints.len(),
+                "Every configured Polygon RPC endpoint is unreachable"
+            );
+
+            ClientError::AllEndpointsUnreachable
+        })?;
+
+        let subscription_endpoints = config.shuffled_subscriptions_endpoints();
+
+        if subscription_endpoints.is_empty() {
+            return Err(ClientError::InvalidConfiguration {
+                field: "endpoints".to_string(),
+            })
+        }
+
+        let mut subscription_provider = None;
+
+        for endpoint in &subscription_endpoints {
+            let ws_connect = WsConnect::new(endpoint)
+                .with_max_retries(WS_RECONNECT_MAX_RETRIES)
+                .with_retry_interval(WS_RECONNECT_RETRY_INTERVAL);
+
+            match ProviderBuilder::new()
+                .connect_ws(ws_connect)
+                .await
+            {
+                Ok(provider) => {
+                    tracing::info!(
+                        chain_id = chain_id,
+                        endpoint = %endpoint,
+                        "Connected to Polygon network"
+                    );
+
+                    subscription_provider = Some(provider);
+                    break
+                },
+                Err(e) => tracing::debug!(
                     error.category = CHAIN_CLIENT,
                     error.operation = "connect_client",
                     error.source = ?e,
                     endpoint = %endpoint,
                     chain = %Self::chain_type(),
                     "Failed to connect to Polygon RPC endpoint"
-                );
-            })
-            .map_err(|_| ClientError::AllEndpointsUnreachable)?;
+                ),
+            }
+        }
 
-        tracing::info!(
-            chain_id = chain_id,
-            endpoint = %endpoint,
-            "Connected to Polygon network"
-        );
+        let subscription_provider = subscription_provider.ok_or_else(|| {
+            tracing::warn!(
+                error.category = CHAIN_CLIENT,
+                error.operation = "connect_client",
+                chain = %Self::chain_type(),
+                tried_endpoints = subscription_endpoints.len(),
+                "Every configured Polygon subscription endpoint is unreachable"
+            );
+
+            ClientError::AllEndpointsUnreachable
+        })?;
 
         Ok(Self {
             config: config.clone(),

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -55,6 +55,7 @@ use super::{
     ChainConfig,
     ChainTransfer,
     ClientError,
+    ENDPOINT_CONNECT_TIMEOUT,
     GeneralTransactionId,
     KeyringClient,
     QueryError,
@@ -180,6 +181,13 @@ impl ConfirmationBuffer {
 /// comfortably inside `WS_MESSAGES_TIMEOUT_DURATION`, so alloy gives up while
 /// our own supervision is still waiting rather than after it has given up.
 /// `ws_reconnect_budget_stays_within_our_own_timeout` pins that relationship.
+///
+/// **This budget bounds reconnects only.** Verified against alloy 2.1.1:
+/// `alloy-pubsub`'s initial `connect` is a single attempt, and these two
+/// numbers are merely stored on the returned handle for
+/// `reconnect_with_retries` to consume once a connection already exists. The
+/// initial connect is bounded by `ENDPOINT_CONNECT_TIMEOUT` instead — do not
+/// read the 6s figure as a startup cost.
 const WS_RECONNECT_MAX_RETRIES: u32 = 3;
 const WS_RECONNECT_RETRY_INTERVAL: Duration = Duration::from_secs(2);
 
@@ -438,11 +446,56 @@ impl PolygonClient {
     /// when this endpoint is unusable, leaving the caller free to try the
     /// next one.
     async fn connect_and_identify(endpoint: &str) -> Option<(PolygonProvider, u64)> {
+        // One budget covers the connect and the probe together: both are
+        // unbounded on their own — alloy's retry budget applies to reconnects
+        // of an established socket, not to this first connect, and the RPC
+        // client sets no request timeout — so either could hang the endpoint
+        // loop before it reaches the remaining endpoints.
+        let connected = tokio::time::timeout(ENDPOINT_CONNECT_TIMEOUT, async {
+            let provider = Self::connect_provider(endpoint).await?;
+
+            tracing::debug!(
+                url = endpoint,
+                chain = %Self::chain_type(),
+                "Connection successful"
+            );
+
+            let chain_id = provider
+                .get_chain_id()
+                .await
+                .inspect_err(|e| {
+                    tracing::debug!(
+                        error.category = CHAIN_CLIENT,
+                        error.source = ?e,
+                        endpoint = %endpoint,
+                        "Failed to get chain ID"
+                    );
+                })
+                .ok()?;
+
+            Some((provider, chain_id))
+        })
+        .await;
+
+        match connected {
+            Ok(connected) => connected,
+            Err(_elapsed) => {
+                Self::warn_connect_timed_out(endpoint);
+
+                None
+            },
+        }
+    }
+
+    /// Open one WebSocket provider. `Ok` from alloy means the full TCP, TLS
+    /// and WebSocket handshake completed, so a returned provider is a live
+    /// endpoint rather than a lazily-connecting handle.
+    async fn connect_provider(endpoint: &str) -> Option<PolygonProvider> {
         let ws_connect = WsConnect::new(endpoint)
             .with_max_retries(WS_RECONNECT_MAX_RETRIES)
             .with_retry_interval(WS_RECONNECT_RETRY_INTERVAL);
 
-        let provider = ProviderBuilder::new()
+        ProviderBuilder::new()
             .connect_ws(ws_connect)
             .await
             .inspect_err(|e| {
@@ -455,28 +508,18 @@ impl PolygonClient {
                     "Failed to connect to Polygon RPC endpoint"
                 );
             })
-            .ok()?;
+            .ok()
+    }
 
-        tracing::debug!(
-            url = endpoint,
+    fn warn_connect_timed_out(endpoint: &str) {
+        tracing::warn!(
+            error.category = CHAIN_CLIENT,
+            error.operation = "connect_client",
             chain = %Self::chain_type(),
-            "Connection successful"
+            endpoint = %endpoint,
+            timeout_seconds = ENDPOINT_CONNECT_TIMEOUT.as_secs(),
+            "Polygon RPC endpoint did not finish connecting in time, moving on"
         );
-
-        let chain_id = provider
-            .get_chain_id()
-            .await
-            .inspect_err(|e| {
-                tracing::debug!(
-                    error.category = CHAIN_CLIENT,
-                    error.source = ?e,
-                    endpoint = %endpoint,
-                    "Failed to get chain ID"
-                );
-            })
-            .ok()?;
-
-        Some((provider, chain_id))
     }
 
     /// Create a new Polygon client from configuration
@@ -537,15 +580,13 @@ impl PolygonClient {
         let mut subscription_provider = None;
 
         for endpoint in &subscription_endpoints {
-            let ws_connect = WsConnect::new(endpoint)
-                .with_max_retries(WS_RECONNECT_MAX_RETRIES)
-                .with_retry_interval(WS_RECONNECT_RETRY_INTERVAL);
-
-            match ProviderBuilder::new()
-                .connect_ws(ws_connect)
-                .await
+            match tokio::time::timeout(
+                ENDPOINT_CONNECT_TIMEOUT,
+                Self::connect_provider(endpoint),
+            )
+            .await
             {
-                Ok(provider) => {
+                Ok(Some(provider)) => {
                     tracing::info!(
                         chain_id = chain_id,
                         endpoint = %endpoint,
@@ -555,14 +596,9 @@ impl PolygonClient {
                     subscription_provider = Some(provider);
                     break
                 },
-                Err(e) => tracing::debug!(
-                    error.category = CHAIN_CLIENT,
-                    error.operation = "connect_client",
-                    error.source = ?e,
-                    endpoint = %endpoint,
-                    chain = %Self::chain_type(),
-                    "Failed to connect to Polygon RPC endpoint"
-                ),
+                // `connect_provider` already logged why.
+                Ok(None) => {},
+                Err(_elapsed) => Self::warn_connect_timed_out(endpoint),
             }
         }
 

--- a/daemon/src/configs/types.rs
+++ b/daemon/src/configs/types.rs
@@ -141,20 +141,33 @@ impl ChainConfig {
             })
     }
 
-    pub fn get_random_requests_endpoint(&self) -> Option<String> {
-        let mut rng = rand::rng();
-
-        self.get_endpoints_with_allowed_operation(EndpointAllowedOperation::Requests)
-            .choose(&mut rng)
+    /// Every endpoint allowed for `op`, in a randomized order.
+    ///
+    /// Callers connect by walking this list and keeping the first endpoint
+    /// that answers, so the shuffle spreads load the way picking one at random
+    /// used to, while a dead or restarting node no longer decides the outcome
+    /// on its own. An empty result means the chain has no endpoint for `op` at
+    /// all, which is a configuration error rather than an outage.
+    fn shuffled_endpoints_with_allowed_operation(
+        &self,
+        op: EndpointAllowedOperation,
+    ) -> Vec<String> {
+        let mut endpoints: Vec<String> = self
+            .get_endpoints_with_allowed_operation(op)
             .cloned()
+            .collect();
+
+        endpoints.shuffle(&mut rand::rng());
+
+        endpoints
     }
 
-    pub fn get_random_subscriptions_endpoint(&self) -> Option<String> {
-        let mut rng = rand::rng();
+    pub fn shuffled_requests_endpoints(&self) -> Vec<String> {
+        self.shuffled_endpoints_with_allowed_operation(EndpointAllowedOperation::Requests)
+    }
 
-        self.get_endpoints_with_allowed_operation(EndpointAllowedOperation::Subscriptions)
-            .choose(&mut rng)
-            .cloned()
+    pub fn shuffled_subscriptions_endpoints(&self) -> Vec<String> {
+        self.shuffled_endpoints_with_allowed_operation(EndpointAllowedOperation::Subscriptions)
     }
 }
 
@@ -716,9 +729,9 @@ mod tests {
 
         for chain in ChainType::iter() {
             assert!(
-                config.chains[&chain]
-                    .get_random_requests_endpoint()
-                    .is_some(),
+                !config.chains[&chain]
+                    .shuffled_requests_endpoints()
+                    .is_empty(),
                 "{chain} was left without endpoints"
             );
         }
@@ -750,8 +763,8 @@ mod tests {
         config.set_default_chains_if_missing();
 
         assert_eq!(
-            config.chains[&ChainType::Polygon].get_random_requests_endpoint(),
-            Some(url.to_string()),
+            config.chains[&ChainType::Polygon].shuffled_requests_endpoints(),
+            vec![url.to_string()],
         );
         logs_assert(|logs| {
             assert_not_warned(logs, ChainType::Polygon)?;
@@ -774,8 +787,8 @@ mod tests {
         config.set_default_chains_if_missing();
 
         assert_eq!(
-            config.chains[&ChainType::PolkadotAssetHub].get_random_requests_endpoint(),
-            Some(url.to_string()),
+            config.chains[&ChainType::PolkadotAssetHub].shuffled_requests_endpoints(),
+            vec![url.to_string()],
         );
         logs_assert(|logs| {
             assert_not_warned(logs, ChainType::PolkadotAssetHub)?;
@@ -801,11 +814,53 @@ mod tests {
         config.set_default_chains_if_missing();
 
         assert!(
-            config.chains[&ChainType::Polygon]
-                .get_random_requests_endpoint()
-                .is_some()
+            !config.chains[&ChainType::Polygon]
+                .shuffled_requests_endpoints()
+                .is_empty()
         );
         logs_assert(|logs| assert_warned_once(logs, ChainType::Polygon));
+    }
+
+    /// Connecting used to pick one endpoint at random and give up if it did
+    /// not answer, so a single restarting node took the whole chain down. The
+    /// shuffled list has to offer *every* usable endpoint, not just a
+    /// different one each run.
+    #[test]
+    fn shuffled_endpoints_offer_every_endpoint_allowed_for_the_operation() {
+        let config = ChainConfig {
+            endpoints: vec![
+                ChainEndpoint::Universal("wss://both.example".to_string()),
+                ChainEndpoint::Specific {
+                    url: "wss://requests-only.example".to_string(),
+                    operations: vec![EndpointAllowedOperation::Requests],
+                },
+                ChainEndpoint::Specific {
+                    url: "wss://subscriptions-only.example".to_string(),
+                    operations: vec![EndpointAllowedOperation::Subscriptions],
+                },
+            ],
+            ..ChainConfig::default()
+        };
+
+        let sorted = |mut endpoints: Vec<String>| {
+            endpoints.sort();
+            endpoints
+        };
+
+        assert_eq!(
+            sorted(config.shuffled_requests_endpoints()),
+            vec![
+                "wss://both.example".to_string(),
+                "wss://requests-only.example".to_string(),
+            ]
+        );
+        assert_eq!(
+            sorted(config.shuffled_subscriptions_endpoints()),
+            vec![
+                "wss://both.example".to_string(),
+                "wss://subscriptions-only.example".to_string(),
+            ]
+        );
     }
 
     /// Exercise the loader rather than the method directly, so the file/env
@@ -821,9 +876,9 @@ mod tests {
 
         for chain in ChainType::iter() {
             assert!(
-                config.chains[&chain]
-                    .get_random_requests_endpoint()
-                    .is_some(),
+                !config.chains[&chain]
+                    .shuffled_requests_endpoints()
+                    .is_empty(),
                 "{chain} was left without endpoints"
             );
         }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -21,6 +21,8 @@ use std::collections::{
 };
 use std::process::ExitCode;
 
+use futures::future::OptionFuture;
+use kalatori_client::strum::IntoEnumIterator;
 use kalatori_client::types::ChainType;
 use kalatori_client::utils::HmacConfig;
 use secrecy::ExposeSecret;
@@ -217,6 +219,129 @@ fn validate_and_extend_configs(
     Ok(())
 }
 
+/// Bring one chain client up, or report the chain as unavailable.
+///
+/// Failing to reach a chain is degraded state, not a fatal one: the daemon
+/// keeps serving every chain that did come up. Deciding whether what came up
+/// is enough to run on is [`report_chain_availability`]'s job, not this one's.
+async fn init_chain_client<T, C>(
+    chain_config: &configs::ChainConfig,
+    assets: &[String],
+) -> Option<C>
+where
+    T: chain_client::ChainConfig,
+    C: BlockChainClient<T>,
+{
+    let chain = T::CHAIN_TYPE;
+
+    match C::new(chain_config).await {
+        Ok(client) => finish_chain_client(client, assets).await,
+        Err(error) => {
+            tracing::warn!(
+                error.category = utils::logging::category::CHAIN_CLIENT,
+                error.operation = utils::logging::operation::CONNECT_CLIENT,
+                error.source = ?error,
+                %chain,
+                "Failed to connect the chain client, continuing without this chain"
+            );
+
+            None
+        },
+    }
+}
+
+/// The half of chain-client startup that runs once a connection exists.
+///
+/// A client whose asset metadata cannot be read is as unusable as one that
+/// never connected — transfers on it could not be priced or matched — so it
+/// degrades the chain the same way.
+async fn finish_chain_client<T, C>(
+    client: C,
+    assets: &[String],
+) -> Option<C>
+where
+    T: chain_client::ChainConfig,
+    C: BlockChainClient<T>,
+{
+    let chain = T::CHAIN_TYPE;
+
+    if let Err(error) = client.init_asset_info(assets).await {
+        tracing::warn!(
+            error.category = utils::logging::category::CHAIN_CLIENT,
+            error.operation = utils::logging::operation::FETCH_ASSET_INFO,
+            error.source = ?error,
+            %chain,
+            "Failed to initialize chain asset info, continuing without this chain"
+        );
+
+        return None
+    }
+
+    tracing::info!(%chain, "Chain client initialized");
+
+    Some(client)
+}
+
+/// Report which chains came up, and decide whether that is enough to run on.
+///
+/// Two cases are fatal, and only two:
+///
+/// - **No chain came up.** There is nothing to serve; a gateway that cannot
+///   reach any chain is not usefully running.
+/// - **The default chain did not come up.** Every invoice is created on
+///   `default_chain` and every swap settles there, so the daemon could accept
+///   no payment at all — it would answer requests while being unable to do the
+///   one thing it exists for.
+///
+/// Anything else is degraded: the chains that came up are served normally, and
+/// the ones that did not are reported by name. There is no reconnection path —
+/// a chain that failed here stays unavailable until the daemon is restarted —
+/// so the warnings say that outright rather than implying a recovery that does
+/// not exist.
+fn report_chain_availability(
+    available_chains: &HashSet<ChainType>,
+    default_chain: ChainType,
+    chains_with_active_invoices: &HashSet<ChainType>,
+) -> Result<(), Error> {
+    if available_chains.is_empty() {
+        tracing::error!("No chain client could be initialized, refusing to start");
+
+        return Err(Error::Fatal)
+    }
+
+    if !available_chains.contains(&default_chain) {
+        tracing::error!(
+            chain = %default_chain,
+            "The configured default chain is unavailable, refusing to start: \
+             every invoice would be created on a chain this daemon cannot reach"
+        );
+
+        return Err(Error::Fatal)
+    }
+
+    for chain in ChainType::iter() {
+        if available_chains.contains(&chain) {
+            continue
+        }
+
+        tracing::warn!(
+            %chain,
+            "Running without this chain: no transfers will be tracked and no payouts or \
+             refunds will be submitted on it until the daemon is restarted"
+        );
+
+        if chains_with_active_invoices.contains(&chain) {
+            tracing::warn!(
+                %chain,
+                "Active invoices restored from the database are on this unavailable chain; \
+                 payments to them will not be detected until the daemon is restarted"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 #[expect(clippy::too_many_lines)]
 async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(), Error> {
     // This must stay the first statement in the function, and in particular
@@ -326,11 +451,20 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
 
     let invoice_registry = init_invoice_registry(&dao).await?;
 
+    let restored_asset_ids = invoice_registry.used_asset_ids().await;
+    // Kept for the availability report below: an operator whose restored
+    // invoices sit on a chain that did not come up needs to be told so by
+    // name, not left to infer it.
+    let restored_chains: HashSet<ChainType> = restored_asset_ids
+        .keys()
+        .copied()
+        .collect();
+
     validate_and_extend_configs(
         &mut chains_config,
         &mut payments_config,
         &shop_config,
-        invoice_registry.used_asset_ids().await,
+        restored_asset_ids,
     )?;
 
     // Initialize Asset Hub client
@@ -354,20 +488,8 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
         .assets
         .as_ref();
 
-    let asset_hub_client = AssetHubClient::new(asset_hub_chain_config)
-        .await
-        .map_err(|_| {
-            tracing::warn!("Failed to initialize Asset Hub client, continuing without it");
-            Error::Fatal
-        })?;
-
-    asset_hub_client
-        .init_asset_info(asset_hub_assets)
-        .await
-        .map_err(|_| {
-            tracing::warn!("Failed to initialize Asset Hub asset info");
-            Error::Fatal
-        })?;
+    let asset_hub_client =
+        init_chain_client::<_, AssetHubClient>(asset_hub_chain_config, asset_hub_assets).await;
 
     // Initialize Polygon client
     #[expect(
@@ -390,52 +512,48 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
         .assets
         .as_ref();
 
-    let polygon_client = PolygonClient::new(polygon_chain_config)
-        .await
-        .map_err(|e| {
-            tracing::warn!(error = ?e, "Failed to initialize Polygon client, continuing without it");
-            Error::Fatal
-        })?;
+    let polygon_client =
+        init_chain_client::<_, PolygonClient>(polygon_chain_config, polygon_assets).await;
 
-    polygon_client
-        .init_asset_info(polygon_assets)
-        .await
-        .map_err(|e| {
-            tracing::warn!(error = ?e, "Failed to initialize Polygon asset info");
-            Error::Fatal
-        })?;
+    let mut available_chains = HashSet::new();
+    if asset_hub_client.is_some() {
+        available_chains.insert(ChainType::PolkadotAssetHub);
+    }
+    if polygon_client.is_some() {
+        available_chains.insert(ChainType::Polygon);
+    }
 
-    // Collect asset names from both chains
-    let mut asset_names_map = asset_hub_client
-        .asset_info_store()
-        .asset_names_map()
-        .await;
+    report_chain_availability(
+        &available_chains,
+        payments_config.default_chain,
+        &restored_chains,
+    )?;
 
-    asset_names_map.extend(
-        polygon_client
-            .asset_info_store()
-            .asset_names_map()
-            .await,
-    );
+    // Collect asset names from the chains that came up. An unavailable chain
+    // contributes nothing, which is why the default chain has to be available:
+    // invoice creation reads its asset name and decimals from these maps.
+    let mut asset_names_map = HashMap::new();
+    let mut asset_decimals_map = HashMap::new();
 
-    // Collect asset decimals per chain (used to convert invoice amounts to
-    // smallest units for swaps)
-    let asset_decimals_map = HashMap::from([
-        (
+    if let Some(client) = asset_hub_client.as_ref() {
+        let store = client.asset_info_store();
+
+        asset_names_map.extend(store.asset_names_map().await);
+        asset_decimals_map.insert(
             ChainType::PolkadotAssetHub,
-            asset_hub_client
-                .asset_info_store()
-                .asset_decimals_map()
-                .await,
-        ),
-        (
+            store.asset_decimals_map().await,
+        );
+    }
+
+    if let Some(client) = polygon_client.as_ref() {
+        let store = client.asset_info_store();
+
+        asset_names_map.extend(store.asset_names_map().await);
+        asset_decimals_map.insert(
             ChainType::Polygon,
-            polygon_client
-                .asset_info_store()
-                .asset_decimals_map()
-                .await,
-        ),
-    ]);
+            store.asset_decimals_map().await,
+        );
+    }
 
     let keyring = Keyring::new(secrets_config.seed);
     // Please don't keep keyring_client in this scope, it must be moved in order to
@@ -469,29 +587,31 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
     let expiration_detector_handle =
         expiration_detector.ignite(shutdown_notification.token.clone());
 
-    // Start Asset Hub transfers tracker
-    let asset_hub_tracker = TransfersTracker::new(
-        asset_hub_client.clone(),
-        invoice_registry.clone(),
-        transactions_recorder.clone(),
-    );
+    // Start a transfers tracker per available chain. A chain that did not come
+    // up gets no tracker at all rather than one that can never subscribe.
+    let asset_hub_tracker_handle = asset_hub_client.clone().map(|client| {
+        TransfersTracker::new(
+            client,
+            invoice_registry.clone(),
+            transactions_recorder.clone(),
+        )
+        .ignite(
+            asset_hub_assets,
+            shutdown_notification.token.clone(),
+        )
+    });
 
-    let asset_hub_tracker_handle = asset_hub_tracker.ignite(
-        asset_hub_assets,
-        shutdown_notification.token.clone(),
-    );
-
-    // Start Polygon transfers tracker
-    let polygon_tracker = TransfersTracker::new(
-        polygon_client.clone(),
-        invoice_registry.clone(),
-        transactions_recorder,
-    );
-
-    let polygon_tracker_handle = polygon_tracker.ignite(
-        polygon_assets,
-        shutdown_notification.token.clone(),
-    );
+    let polygon_tracker_handle = polygon_client.clone().map(|client| {
+        TransfersTracker::new(
+            client,
+            invoice_registry.clone(),
+            transactions_recorder,
+        )
+        .ignite(
+            polygon_assets,
+            shutdown_notification.token.clone(),
+        )
+    });
 
     let swaps_clients = SwapsClients::new(swaps_config).await;
 
@@ -579,8 +699,8 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
                 keyring_handle,
                 transfer_executor_handle,
                 expiration_detector_handle,
-                asset_hub_tracker_handle,
-                polygon_tracker_handle,
+                OptionFuture::from(asset_hub_tracker_handle),
+                OptionFuture::from(polygon_tracker_handle),
                 webhook_sender_handle,
                 swaps_tracker_handle,
                 api_handle,
@@ -609,4 +729,125 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use chain_client::{
+        ClientError,
+        MockBlockChainClient,
+        PolygonChainConfig,
+    };
+
+    use super::*;
+
+    fn chains(chains: &[ChainType]) -> HashSet<ChainType> {
+        chains.iter().copied().collect()
+    }
+
+    #[test]
+    fn no_chain_at_all_is_fatal() {
+        assert!(matches!(
+            report_chain_availability(
+                &HashSet::new(),
+                ChainType::Polygon,
+                &HashSet::new()
+            ),
+            Err(Error::Fatal)
+        ));
+    }
+
+    #[test]
+    fn an_unavailable_default_chain_is_fatal() {
+        assert!(matches!(
+            report_chain_availability(
+                &chains(&[ChainType::PolkadotAssetHub]),
+                ChainType::Polygon,
+                &HashSet::new()
+            ),
+            Err(Error::Fatal)
+        ));
+    }
+
+    /// The defect this replaced: the daemon logged "continuing without it" and
+    /// then returned `Error::Fatal`, so a Polygon-only merchant could not boot
+    /// while Polkadot RPC was down. One healthy chain — the default one — is
+    /// enough to run on.
+    #[test]
+    #[tracing_test::traced_test]
+    fn a_non_default_chain_going_missing_is_degraded_not_fatal() {
+        assert!(
+            report_chain_availability(
+                &chains(&[ChainType::Polygon]),
+                ChainType::Polygon,
+                &HashSet::new()
+            )
+            .is_ok()
+        );
+
+        // Naming the missing chain is the point of the line, and so is not
+        // promising a reconnection the daemon does not implement.
+        assert!(logs_contain(
+            "Running without this chain"
+        ));
+        assert!(logs_contain("PolkadotAssetHub"));
+        assert!(logs_contain(
+            "until the daemon is restarted"
+        ));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn restored_invoices_on_an_unavailable_chain_are_called_out_by_chain() {
+        assert!(
+            report_chain_availability(
+                &chains(&[ChainType::Polygon]),
+                ChainType::Polygon,
+                &chains(&[ChainType::PolkadotAssetHub])
+            )
+            .is_ok()
+        );
+
+        assert!(logs_contain(
+            "Active invoices restored from the database are on this unavailable chain"
+        ));
+    }
+
+    /// A chain reachable enough to connect but not to answer for its assets is
+    /// no more usable than one that never connected, so it degrades the same
+    /// way instead of aborting startup.
+    #[tokio::test]
+    async fn a_client_whose_asset_info_fails_degrades_the_chain() {
+        let mut client = MockBlockChainClient::<PolygonChainConfig>::default();
+
+        client
+            .expect_init_asset_info()
+            .once()
+            .returning(|_| Err(ClientError::MetadataFetchFailed));
+
+        assert!(
+            finish_chain_client::<PolygonChainConfig, _>(
+                client,
+                &["0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359".to_string()]
+            )
+            .await
+            .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_client_that_comes_up_is_kept() {
+        let mut client = MockBlockChainClient::<PolygonChainConfig>::default();
+
+        client
+            .expect_init_asset_info()
+            .once()
+            .returning(|_| Ok(()));
+
+        assert!(
+            finish_chain_client::<PolygonChainConfig, _>(client, &[])
+                .await
+                .is_some()
+        );
+    }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -324,10 +324,17 @@ fn report_chain_availability(
             continue
         }
 
+        // Deliberately narrow. Provider-routed swaps are *not* covered: they
+        // settle through the swap provider's API rather than through our node,
+        // so `TransfersExecutor::send_transfer` still routes them and they can
+        // still execute. Saying "no payouts" here would be the same kind of
+        // false claim this whole change exists to remove.
         tracing::warn!(
             %chain,
-            "Running without this chain: no transfers will be tracked and no payouts or \
-             refunds will be submitted on it until the daemon is restarted"
+            "Running without this chain: no transfers will be tracked, and no direct payouts \
+             or refunds will be submitted on it, until the daemon is restarted. \
+             Swaps routed through a swap provider are unaffected, but their settlement \
+             cannot be confirmed while this chain is unavailable"
         );
 
         if chains_with_active_invoices.contains(&chain) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ HTTP Request → API Server (Axum) → AppState (Arc<AppState>)
                                       └→ InvoiceRegistry (in-memory)
 
 Background Tasks:
-  TransfersTracker (per chain) → TransactionsRecorder → DAO
+  TransfersTracker (per available chain) → TransactionsRecorder → DAO
   TransfersExecutor → chain clients + Keyring → DAO
   ExpirationDetector → DAO + chain clients
   WebhookSender → DAO → external webhook URLs
@@ -55,6 +55,11 @@ SQLite via sqlx 0.8. `DaoInterface` + `DaoTransactionInterface` traits (mockable
 - `polygon.rs` — Polygon via alloy 1.5 (secp256k1 keys, ERC-20 tokens, Pimlico paymaster for gas abstraction)
 
 `AssetInfoStore` trait for per-chain asset metadata. Error types in `errors.rs` follow the [error handling principles](error-handling.md).
+
+Both clients try every configured endpoint before reporting
+`ClientError::AllEndpointsUnreachable`, and a client that cannot be built at
+startup degrades its chain instead of aborting the daemon — see
+[Degraded Chains](#degraded-chains).
 
 ### `daemon/src/chain_client/keyring.rs` — Keyring (Actor)
 Actor pattern: mpsc channel + oneshot responses. Holds seed phrase (`Zeroize` + `ZeroizeOnDrop`). Handles both:
@@ -209,6 +214,58 @@ At startup, the daemon always runs SQLite's `PRAGMA integrity_check` before migr
 `require_existing` (or `KALATORI_DATABASE_REQUIRE_EXISTING`) to refuse startup when the configured
 database file is missing or empty; this is incompatible with temporary in-memory mode.
 
+## Degraded Chains
+
+**An unreachable chain does not stop the daemon.** `init_chain_client` in
+`main.rs` returns `Option<C>`: a chain whose client cannot connect, or whose
+asset metadata cannot be read, is reported at WARN and dropped, and the daemon
+serves whatever else came up. Both halves matter — a node that accepts the
+socket but cannot answer for its assets is not usable — so both degrade the
+chain identically.
+
+Connecting now walks **every** configured endpoint for the operation, in a
+shuffled order, before giving up (`ChainConfig::shuffled_requests_endpoints`,
+`shuffled_subscriptions_endpoints`). Each client used to pick one endpoint at
+random and report `ClientError::AllEndpointsUnreachable` if that single node did
+not answer, so one restarting node read as the whole chain being down — the
+error name now means what it says. Polygon's request
+endpoints are additionally probed with `eth_chainId`, since a socket that
+connects but cannot answer is not a usable endpoint.
+
+**What degraded means, per subsystem:**
+
+| Subsystem | Behaviour without the chain's client |
+|---|---|
+| `TransfersTracker` | Not started for that chain — no subscription, no incoming transfers detected |
+| `TransfersExecutor` | `ChainExecutorError::ChainUnavailable`, **retriable**: the payout/refund row goes back to `FailedRetriable` with the usual backoff rather than being failed for good over an RPC outage |
+| `BalanceChecker` | `FetchBalanceFailed` without calling any RPC. Both callers (`ExpirationDetector`, `SwapsTracker`) already treat that as "leave the invoice alone and look again later", so it needs no variant of its own — only a distinguishing log line |
+| `AppState` / HTTP API | Unchanged. `asset_names_map` and `asset_decimals_map` simply carry no entries for the chain |
+
+**Two cases are still fatal**, and only two — both enforced by
+`report_chain_availability`:
+
+- **No chain came up.** Nothing to serve.
+- **The configured `default_chain` did not come up.** Every invoice is created
+  on `default_chain` and every swap settles there, so the daemon would answer
+  requests while being unable to accept a single payment. This is also what
+  keeps the API surface unchanged: no public operation can target a chain that
+  is unavailable, so no new API error code was needed.
+
+**Recovery requires a restart.** There is no reconnection path for a chain that
+failed at startup — deliberately, because a partial one would be worse: if the
+tracker recovered while the executor did not, invoices on that chain would be
+marked paid and never paid out. The WARN lines say "until the daemon is
+restarted" for exactly this reason. Note that a client which came up and *later*
+loses its connection is a different case, already handled: `TransfersTracker`
+retries with backoff and calls `BlockChainClient::recreate` to move to another
+endpoint.
+
+**Startup ordering**: config validation (`validate_and_extend_configs`,
+recipient and asset checks) runs *before* any client is constructed, so a
+degraded chain cannot turn a startup validation into a different fatal error.
+Chains carrying restored active invoices are reported by name when they are
+unavailable, since nothing will be detected for those invoices until a restart.
+
 ## Background Task Management
 
 **TaskTracker** (`daemon/src/utils/task_tracker.rs`):
@@ -218,7 +275,7 @@ database file is missing or empty; this is incompatible with temporary in-memory
 **Shutdown sequence**:
 1. Signal received (SIGTERM/SIGINT) or fatal error → `CancellationToken` cancelled
 2. TaskTracker waits for all tasks, then cancels shutdown listener
-3. All component handles joined: Keyring, TransfersExecutor, ExpirationDetector, both TransfersTrackers, WebhookSender, API server
+3. All component handles joined: Keyring, TransfersExecutor, ExpirationDetector, one TransfersTracker per *available* chain (see [Degraded Chains](#degraded-chains)), WebhookSender, API server
 4. Loki logs flushed
 5. Clean exit
 
@@ -227,6 +284,9 @@ database file is missing or empty; this is incompatible with temporary in-memory
 1. **Configuration**: Hardcoded RPC URLs in Makefile (see TODOs)
 2. **Scalability**: TransfersTracker queries all watched accounts every block
 3. **Metadata**: Manual `metadata.scale` update process (should be automated)
+4. **Chain recovery**: a chain whose client failed at *startup* stays unavailable
+   until the daemon is restarted — see [Degraded Chains](#degraded-chains) for
+   why the partial alternative was rejected
 
 ## Future Vision
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,9 +237,31 @@ connects but cannot answer is not a usable endpoint.
 | Subsystem | Behaviour without the chain's client |
 |---|---|
 | `TransfersTracker` | Not started for that chain — no subscription, no incoming transfers detected |
-| `TransfersExecutor` | `ChainExecutorError::ChainUnavailable`, **retriable**: the payout/refund row goes back to `FailedRetriable` with the usual backoff rather than being failed for good over an RPC outage |
+| `TransfersExecutor` | **Direct transfers only**: `ChainExecutorError::ChainUnavailable`, **retriable**, so the payout/refund row goes back to `FailedRetriable` with the usual backoff rather than being failed for good over an RPC outage. **Provider-routed swaps are not blocked** — see below |
 | `BalanceChecker` | `FetchBalanceFailed` without calling any RPC. Both callers (`ExpirationDetector`, `SwapsTracker`) already treat that as "leave the invoice alone and look again later", so it needs no variant of its own — only a distinguishing log line |
 | `AppState` / HTTP API | Unchanged. `asset_names_map` and `asset_decimals_map` simply carry no entries for the chain |
+
+**The swap carve-out.** `TransfersExecutor::send_transfer` routes a same-chain
+transfer whose destination asset differs to `schedule_swap`, which never
+touches a chain client — `SwapsExecutor` holds only the DAO and the 0x/Across
+HTTP clients. Such a transfer therefore still executes while the chain is
+unavailable, because it does not need our node. This is deliberate (blocking it
+would strand payouts that can succeed), but it is a real asymmetry: the swap can
+execute while `SwapsTracker` cannot confirm its settlement, since that goes
+through `BalanceChecker`. The startup WARN says so explicitly rather than
+claiming a blanket payout freeze.
+
+**Connect timeouts.** Neither dependency bounds a connect attempt for us, and
+both let a half-open peer hang forever: jsonrpsee's 10s budget covers
+`TcpStream::connect` only (TLS handshake and WebSocket upgrade sit outside it),
+and alloy's `WsConnect` retry budget governs *reconnects* of an established
+socket, not the initial connect. A blackholed address otherwise costs the OS
+TCP timeout — ~127s per resolved address. That was survivable at one endpoint
+per client; iterating the list multiplies it, so `ENDPOINT_CONNECT_TIMEOUT`
+(`chain_client.rs`) caps each attempt and bounds startup at
+`endpoints × timeout` per connect phase. Note Polygon pays that per phase
+*twice*, since request and subscription providers are connected in separate
+loops, and the two chains are initialised sequentially.
 
 **Two cases are still fatal**, and only two — both enforced by
 `report_chain_availability`:

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -493,7 +493,12 @@ pub enum ChainError {
 - Principle 1 (within domain): Only enumerate errors requiring different handling
 - Principle 4 (between domains): Separate error types for different usage contexts
 
-**Context**: Usage-based domains align with recovery strategies. Each domain has focused error handling: initialization fails fast, queries retry with failover, subscriptions restart stream, transactions use DB-backed retry worker.
+**Context**: Usage-based domains align with recovery strategies. Each domain has focused error handling: initialization fails fast *within a client* (it stops trying that endpoint and reports), queries retry with failover, subscriptions restart stream, transactions use DB-backed retry worker.
+
+Note that "fails fast" describes the client, not the daemon. A `ClientError` at
+startup degrades its chain rather than aborting the process — see
+[Degraded Chains](architecture.md#degraded-chains) for which two cases are still
+fatal and why.
 
 ## Principle 5: Internal Errors Shouldn't Leak to API
 


### PR DESCRIPTION
Fixes roadmap finding **H13**.

## The defect

`async_try_main` logged `"Failed to initialize Asset Hub client, continuing without it"` and then returned `Error::Fatal`. The daemon stopped. The same pattern applied to the Polygon client and to both `init_asset_info` calls.

Consequences: a Polygon-only merchant could not boot while Polkadot RPC was down, and any transient connection reset at startup took the daemon with it. That is not theoretical — it reproduced in CI on 2026-08-07, where the daemon dialled chopsticks a moment too early, got a reset, and died. PR #340 added a tighter readiness probe as a workaround; the fragility was the real defect.

The log message describing behaviour the code did not implement is what let this survive. A future reader trusting that line would have concluded the degradation path already existed.

## What this changes

Chain-client initialisation returns `Option<C>`. A chain that cannot connect, or whose asset metadata cannot be read, is reported at WARN and dropped; the daemon starts and serves whatever else came up.

### 1. What degraded means, per subsystem

| Subsystem | Behaviour without the chain's client |
|---|---|
| `TransfersTracker` | Not started for that chain — no subscription, no transfers detected |
| `TransfersExecutor` | **Direct transfers**: `ChainExecutorError::ChainUnavailable`, retriable |
| `BalanceChecker` | `FetchBalanceFailed` without calling RPC |
| `AppState` / HTTP API | Unchanged |

`ChainUnavailable` is retriable deliberately. Non-retriable would permanently fail a payout because of a transient RPC outage; the existing 1m→2h backoff instead keeps the row claimable across the restart that fixes it.

`BalanceChecker` gets no new error variant. Both callers (`ExpirationDetector`, `SwapsTracker`) already treat a failed fetch identically — "leave the invoice alone and look again later" — so per Principle 1 of `docs/error-handling.md` the case needs a distinguishing log line, not a variant.

**One carve-out, and it is deliberate.** `send_transfer` routes a same-chain, different-asset transfer to `schedule_swap`, and `SwapsExecutor` holds only the DAO and the 0x/Across HTTP clients — it never touches a chain client. Such transfers still execute, because they do not need our node. Blocking them would strand payouts that can succeed. The asymmetry is real (the swap can execute while `SwapsTracker` cannot confirm settlement), so the startup WARN says so explicitly rather than claiming a blanket payout freeze.

### 2. When it is still fatal

Two cases, enforced by `report_chain_availability`:

- **No chain came up.** Nothing to serve.
- **The configured `default_chain` did not come up.** Every invoice is created on `default_chain` and every swap settles there, so the daemon would answer requests while unable to accept a single payment.

That second rule is also why **the public HTTP API is unchanged**: with `default_chain` guaranteed present, no public operation can target an unavailable chain, so no new API error code was needed.

### 3. Recovery requires a restart

Deliberate, not expedient. A partial path was available — `TransfersTracker`'s existing `recreate()` backoff loop could rebuild its own client — and was rejected: the tracker would recover while the executor stayed dark, so invoices on that chain would be marked paid and never paid out. Uniformly degraded beats inconsistently recovered. Every warning says "until the daemon is restarted".

This is about *startup* only. A client that comes up and later drops still reconnects as before.

### 4. Startup validation

No interaction. `validate_and_extend_configs` and the recipient/asset checks all run before any client is constructed. Chains carrying restored active invoices are additionally named in the warnings, since nothing will be detected for them until a restart.

## Endpoint failover, and the timeout it needed

The original review suspected `from_config` picked a single endpoint and reported `AllEndpointsUnreachable` without trying the others. It did, on both chains. Connecting now walks every configured endpoint in shuffled order, so the error name means what it says. Polygon request endpoints are additionally probed with `eth_chainId`, since a socket that connects but cannot answer is not usable.

That alone would have been a regression. Neither dependency bounds a connect attempt, and both let a half-open peer hang forever:

- jsonrpsee's 10s budget covers `TcpStream::connect` only — the TLS handshake and WebSocket upgrade sit outside it.
- alloy's `WsConnect` retry budget governs *reconnects of an established socket*. Verified against alloy 2.1.1: `alloy-pubsub`'s `connect` is a single attempt, and the two constants are merely stored for `reconnect_with_retries`. It does not bound the initial connect at all.

A blackholed address therefore costs the OS TCP timeout (~127s per resolved address), and iterating the list multiplies it. `ENDPOINT_CONNECT_TIMEOUT` caps each attempt, bounding startup at `endpoints × timeout` per connect phase. The `WS_RECONNECT_*` doc comment now states which budget it is, because it reads as a startup cost and is not one.

## Verification

- `no_chain_at_all_is_fatal`, `an_unavailable_default_chain_is_fatal`
- `a_non_default_chain_going_missing_is_degraded_not_fatal` — asserts the log names the chain and does not promise a reconnection
- `restored_invoices_on_an_unavailable_chain_are_called_out_by_chain`
- `a_client_whose_asset_info_fails_degrades_the_chain`
- `a_transfer_on_an_unavailable_chain_is_retriable_and_the_other_chain_still_works`
- `an_unavailable_chain_holds_direct_transfers_but_not_provider_routed_swaps` — pins both halves of the routing decision, which is where the WARN's claim is made or broken
- `an_unavailable_chain_reports_no_balance_without_calling_rpc`
- `shuffled_endpoints_offer_every_endpoint_allowed_for_the_operation`

The two tests that pin a routing decision were mutation-verified: flipping the dispatch makes each fail.

`b49e4bc1` separately repairs an existing test whose "Asset Hub" case was vacuous — it built a Polygon payout, never overrode `request.chain`, and asserted an error the leftover Polygon mock produced, with an expectation that carried no `times`/`once` and was therefore never verified.

Gates: `cargo check`, `RUSTFLAGS="-Dwarnings" cargo clippy`, `cargo +nightly fmt --check`, full suite green.

## Known limits and follow-ups

- **No integration test boots the binary against a dead RPC** — that needs a live node. The seams are covered instead.
- **Startup is sequential and Polygon connects twice** (request and subscription providers, separate loops), so the bounded worst case is larger than it needs to be. `tokio::join!` across the two chains would roughly halve it. Not folded in.
- **#237** — the `eth_chainId` call added here is a liveness probe only; the returned id is never compared against `CHAIN_ID`, and subscription endpoints get no probe. A Polygon request endpoint paired with an Ethereum subscription endpoint still initialises and silently watches the wrong chain. Predates this PR; [detail added there](https://github.com/Kalapaja/Kalatori/issues/237#issuecomment-5223021176).
- **#396** — invoices restored on an unavailable chain are correctly *not* expired, but only by accident: the balance fetch happens to fail and that happens to be handled as "leave it alone". Nothing states the intent, so a future fallback path could silently start expiring invoices the customer may have paid.

## Scope

No database schema changes. No public HTTP API shape changes. Docs updated: `docs/architecture.md` gains a "Degraded Chains" section; `docs/error-handling.md`'s "initialization fails fast" now distinguishes the client from the daemon.
