### PR TITLE
fix(chain): recover transfers lost while the subscription is silently down

### DIFF
--- a/daemon/src/chain/transfer_tracker.rs
+++ b/daemon/src/chain/transfer_tracker.rs
@@ -507,13 +507,13 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
                 }
 
                 // A dead subscription is exactly when the sweep earns its keep,
-                // so it keeps ticking here. The wait runs to a fixed deadline
-                // rather than a plain sleep, so a sweep in the middle of it
-                // cannot cut the backoff short.
-                // Built once and polled by reference: a `select!` arm that
-                // fires does not restart it, so a sweep in the middle of the
-                // wait cannot cut the backoff short. (`Instant + Duration`
-                // would trip the arithmetic gate for no gain.)
+                // so it keeps ticking here. The sleep is built once and polled
+                // by reference: a `select!` arm that fires drops the futures it
+                // did not pick, so a sleep recreated each iteration would have
+                // its countdown restarted by every sweep tick and the backoff
+                // would never grow. Pinning keeps the deadline inside the
+                // future. (An explicit `Instant + Duration` deadline would do
+                // the same, at the cost of tripping the arithmetic gate.)
                 let retry_sleep = tokio::time::sleep(retry_state.record_failure());
                 tokio::pin!(retry_sleep);
 

--- a/daemon/src/chain/transfer_tracker.rs
+++ b/daemon/src/chain/transfer_tracker.rs
@@ -5,6 +5,7 @@ use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 use crate::chain_client::{
+    BackfillError,
     BlockChainClient,
     ChainConfig,
     ChainTransfer,
@@ -24,6 +25,47 @@ use super::{
 const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(60);
 const DEGRADED_WARNING_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How often the catch-up sweep re-reads what the subscription may have missed
+/// (issue #333). Every tick costs one `eth_getLogs` per chain, so this is also
+/// the knob that decides whether a free public endpoint can carry a daemon.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Widest range a single sweep asks for. Providers cap `eth_getLogs` spans, and
+/// after a long outage the gap can be arbitrarily large; the cursor makes the
+/// remainder the next tick's problem.
+const MAX_SWEEP_RANGE: u64 = 1_000;
+
+/// Whether the catch-up sweep is running for this chain.
+struct SweepState {
+    enabled: bool,
+}
+
+impl SweepState {
+    fn new() -> Self {
+        Self {
+            enabled: true,
+        }
+    }
+
+    /// Stop sweeping this chain, and say so once. A chain whose client cannot
+    /// re-read past blocks keeps the gap described in #333, and a silent skip
+    /// would leave a clean log reading as "nothing to recover here".
+    fn disable(
+        &mut self,
+        chain: crate::types::ChainType,
+    ) {
+        if !self.enabled {
+            return;
+        }
+
+        tracing::warn!(
+            %chain,
+            "Chain client cannot re-read past blocks, so transfers missed while the subscription is down are recovered only by the balance check at invoice expiry"
+        );
+        self.enabled = false;
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 enum TransferTrackerError {
@@ -119,6 +161,9 @@ pub struct TransfersTracker<
     client: C,
     registry: InvoiceRegistry,
     transactions_recorder: TransactionsRecorder<D>,
+    /// Owned separately from the recorder: the sweep cursor is the tracker's
+    /// own progress, not a property of any transaction it records.
+    dao: D,
     phantom: std::marker::PhantomData<T>,
 }
 
@@ -129,11 +174,13 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
         client: C,
         registry: InvoiceRegistry,
         transactions_recorder: TransactionsRecorder<D>,
+        dao: D,
     ) -> Self {
         TransfersTracker {
             client,
             registry,
             transactions_recorder,
+            dao,
             phantom: std::marker::PhantomData,
         }
     }
@@ -161,6 +208,12 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
             .ok()
     }
 
+    /// Record a transfer against its invoice, if any invoice matches.
+    ///
+    /// A transfer nobody is waiting for, and a transfer already in the
+    /// database, are both `Ok`: nothing is left to do. Only a failed write is
+    /// an error, and only the sweep acts on it — it must not move its cursor
+    /// past a transfer that did not land.
     #[tracing::instrument(skip(self))]
     async fn process_transfer(
         &self,
@@ -246,6 +299,166 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
         }
     }
 
+    /// Re-read the blocks between the stored cursor and the chain head, and
+    /// record whatever the live subscription did not deliver (issue #333).
+    ///
+    /// Runs off the subscription entirely: alloy reconnects and resubscribes
+    /// underneath us without the stream ever ending, so there is no moment we
+    /// could hook "the subscription just came back" onto. Polling is the only
+    /// signal that does not depend on noticing the gap.
+    async fn sweep(
+        &self,
+        assets: &[T::AssetId],
+        state: &mut SweepState,
+    ) {
+        let chain = T::CHAIN_TYPE;
+
+        let head = match self
+            .client
+            .latest_confirmed_block()
+            .await
+        {
+            Ok(head) => head,
+            Err(BackfillError::Unsupported) => {
+                state.disable(chain);
+                return;
+            },
+            Err(BackfillError::RequestFailed) => {
+                tracing::debug!(
+                    %chain,
+                    "Could not read the chain head for the catch-up sweep, retrying next tick"
+                );
+                return;
+            },
+        };
+
+        let cursor = match self
+            .dao
+            .get_chain_sync_cursor(chain)
+            .await
+        {
+            Ok(cursor) => cursor,
+            Err(e) => {
+                tracing::warn!(
+                    %chain,
+                    error = ?e,
+                    "Could not read the sweep cursor, skipping this catch-up sweep"
+                );
+                return;
+            },
+        };
+
+        let Some(cursor) = cursor else {
+            // First run against this database. Starting from the head rather
+            // than from genesis: the sweep exists to close gaps in this
+            // daemon's own tracking, and invoices older than it are covered by
+            // the balance check.
+            self.store_cursor(chain, head).await;
+            tracing::info!(
+                %chain,
+                block_number = head,
+                "Catch-up sweep starting from the current chain head"
+            );
+            return;
+        };
+
+        let last_processed_block = cursor.last_processed_block;
+
+        // `head` below the cursor is not a rollback: public RPC pools answer
+        // from whichever node picked up the request, and some of them lag.
+        if head <= last_processed_block {
+            return;
+        }
+
+        let from_block = last_processed_block.saturating_add(1);
+        let to_block = head.min(
+            from_block
+                .saturating_add(MAX_SWEEP_RANGE)
+                .saturating_sub(1),
+        );
+
+        let transfers = match self
+            .client
+            .fetch_transfers_in_range(assets, from_block, to_block)
+            .await
+        {
+            Ok(transfers) => transfers,
+            Err(BackfillError::Unsupported) => {
+                state.disable(chain);
+                return;
+            },
+            Err(BackfillError::RequestFailed) => {
+                tracing::debug!(
+                    %chain,
+                    from_block,
+                    to_block,
+                    "Catch-up sweep could not read the block range, retrying next tick"
+                );
+                return;
+            },
+        };
+
+        let fetched = transfers.len();
+        let mut failed = 0_usize;
+
+        for transfer in transfers {
+            if self
+                .process_transfer(transfer.into())
+                .await
+                .is_err()
+            {
+                failed = failed.saturating_add(1);
+            }
+        }
+
+        if failed > 0 {
+            // Leaving the cursor where it is re-reads this range next tick.
+            // Re-delivering what did land is free: transfers are deduplicated
+            // by `(chain, tx_hash)` in the database.
+            tracing::warn!(
+                %chain,
+                from_block,
+                to_block,
+                failed,
+                "Catch-up sweep could not record every transfer, holding the cursor to retry the range"
+            );
+            return;
+        }
+
+        self.store_cursor(chain, to_block).await;
+
+        if fetched > 0 {
+            tracing::info!(
+                %chain,
+                from_block,
+                to_block,
+                transfers = fetched,
+                "Catch-up sweep recovered transfers the subscription did not deliver"
+            );
+        }
+    }
+
+    async fn store_cursor(
+        &self,
+        chain: crate::types::ChainType,
+        block_number: u64,
+    ) {
+        if let Err(e) = self
+            .dao
+            .advance_chain_sync_cursor(chain, block_number)
+            .await
+        {
+            // The range was processed, so nothing is lost — the next sweep
+            // re-reads it against the older cursor.
+            tracing::warn!(
+                %chain,
+                block_number,
+                error = ?e,
+                "Could not persist the sweep cursor, the next sweep will re-read this range"
+            );
+        }
+    }
+
     #[tracing::instrument(skip(self, token), fields(chain = %T::CHAIN_TYPE))]
     async fn perform(
         mut self,
@@ -259,6 +472,11 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
 
         let mut subscription = None;
         let mut retry_state = RetryState::new();
+        let mut sweep_state = SweepState::new();
+        // The first tick fires immediately, which is what establishes the
+        // cursor on a fresh database before any gap can open.
+        let mut sweep_ticker = tokio::time::interval(SWEEP_INTERVAL);
+        sweep_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         loop {
             subscription = self
@@ -288,15 +506,30 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
                     },
                 }
 
-                let retry_delay = retry_state.record_failure();
-                tokio::select! {
-                    () = tokio::time::sleep(retry_delay) => {},
-                    () = token.cancelled() => {
-                        tracing::info!(
-                            "Transfers tracker received cancellation signal, shutting down"
-                        );
-                        break;
-                    },
+                // A dead subscription is exactly when the sweep earns its keep,
+                // so it keeps ticking here. The wait runs to a fixed deadline
+                // rather than a plain sleep, so a sweep in the middle of it
+                // cannot cut the backoff short.
+                // Built once and polled by reference: a `select!` arm that
+                // fires does not restart it, so a sweep in the middle of the
+                // wait cannot cut the backoff short. (`Instant + Duration`
+                // would trip the arithmetic gate for no gain.)
+                let retry_sleep = tokio::time::sleep(retry_state.record_failure());
+                tokio::pin!(retry_sleep);
+
+                loop {
+                    tokio::select! {
+                        () = &mut retry_sleep => break,
+                        _instant = sweep_ticker.tick(), if sweep_state.enabled => {
+                            self.sweep(&assets, &mut sweep_state).await;
+                        },
+                        () = token.cancelled() => {
+                            tracing::info!(
+                                "Transfers tracker received cancellation signal, shutting down"
+                            );
+                            return;
+                        },
+                    }
                 }
 
                 continue;
@@ -337,6 +570,9 @@ impl<T: ChainConfig, C: BlockChainClient<T> + 'static, D: DaoInterface + 'static
                             }
                         },
                     }
+                },
+                _instant = sweep_ticker.tick(), if sweep_state.enabled => {
+                    self.sweep(&assets, &mut sweep_state).await;
                 },
                 () = token.cancelled() => {
                     tracing::info!(
@@ -395,8 +631,9 @@ mod tests {
         PolygonChainConfig,
         default_general_chain_transfer,
     };
-    use crate::dao::DAO;
+    use crate::dao::MockDaoInterface;
     use crate::types::{
+        ChainSyncCursor,
         ChainType,
         Invoice,
         default_invoice,
@@ -416,6 +653,9 @@ mod tests {
         chain_client
             .expect_chain_name()
             .return_const("test-chain");
+        chain_client
+            .expect_latest_confirmed_block()
+            .returning(|| Err(BackfillError::Unsupported));
         let recorded_times = std::sync::Arc::clone(&attempt_times);
         chain_client
             .expect_subscribe_transfers()
@@ -431,8 +671,13 @@ mod tests {
             .returning(|| Err(ClientError::AllEndpointsUnreachable));
 
         let registry = InvoiceRegistry::new();
-        let recorder = TransactionsRecorder::<DAO>::default();
-        let tracker = TransfersTracker::new(chain_client, registry, recorder);
+        let recorder = TransactionsRecorder::<MockDaoInterface>::default();
+        let tracker = TransfersTracker::new(
+            chain_client,
+            registry,
+            recorder,
+            MockDaoInterface::default(),
+        );
 
         let token = CancellationToken::new();
         let tracker_task = tokio::spawn(tracker.perform(vec![], token.clone()));
@@ -468,6 +713,9 @@ mod tests {
         replacement_client
             .expect_chain_name()
             .return_const("replacement-chain");
+        replacement_client
+            .expect_latest_confirmed_block()
+            .returning(|| Err(BackfillError::Unsupported));
         let replacement_attempts = Arc::clone(&subscription_attempts);
         replacement_client
             .expect_subscribe_transfers()
@@ -484,6 +732,9 @@ mod tests {
         chain_client
             .expect_chain_name()
             .return_const("initial-chain");
+        chain_client
+            .expect_latest_confirmed_block()
+            .returning(|| Err(BackfillError::Unsupported));
         let initial_attempts = Arc::clone(&subscription_attempts);
         chain_client
             .expect_subscribe_transfers()
@@ -503,7 +754,8 @@ mod tests {
         let tracker = TransfersTracker::new(
             chain_client,
             InvoiceRegistry::new(),
-            TransactionsRecorder::<DAO>::default(),
+            TransactionsRecorder::<MockDaoInterface>::default(),
+            MockDaoInterface::default(),
         );
         let token = CancellationToken::new();
         let tracker_task = tokio::spawn(tracker.perform(vec![], token.clone()));
@@ -567,6 +819,9 @@ mod tests {
         chain_client
             .expect_chain_name()
             .return_const("test-chain");
+        chain_client
+            .expect_latest_confirmed_block()
+            .returning(|| Err(BackfillError::Unsupported));
         let recorded_attempts = Arc::clone(&subscription_attempts);
         chain_client
             .expect_subscribe_transfers()
@@ -586,7 +841,8 @@ mod tests {
         let tracker = TransfersTracker::new(
             chain_client,
             InvoiceRegistry::new(),
-            TransactionsRecorder::<DAO>::default(),
+            TransactionsRecorder::<MockDaoInterface>::default(),
+            MockDaoInterface::default(),
         );
         let token = CancellationToken::new();
         let tracker_task = tokio::spawn(tracker.perform(vec![], token.clone()));
@@ -631,6 +887,9 @@ mod tests {
             .expect_chain_name()
             .return_const("test-chain");
         chain_client
+            .expect_latest_confirmed_block()
+            .returning(|| Err(BackfillError::Unsupported));
+        chain_client
             .expect_subscribe_transfers()
             .once()
             .returning(|_| Ok(pending_transfers_stream()));
@@ -639,7 +898,8 @@ mod tests {
         let tracker = TransfersTracker::new(
             chain_client,
             InvoiceRegistry::new(),
-            TransactionsRecorder::<DAO>::default(),
+            TransactionsRecorder::<MockDaoInterface>::default(),
+            MockDaoInterface::default(),
         );
         let token = CancellationToken::new();
         let started_at = tokio::time::Instant::now();
@@ -764,8 +1024,13 @@ mod tests {
         // expected flows
         let chain_client = MockBlockChainClient::<PolygonChainConfig>::default();
         let registry = InvoiceRegistry::new();
-        let recorder = TransactionsRecorder::<DAO>::default();
-        let mut tracker = TransfersTracker::new(chain_client, registry.clone(), recorder);
+        let recorder = TransactionsRecorder::<MockDaoInterface>::default();
+        let mut tracker = TransfersTracker::new(
+            chain_client,
+            registry.clone(),
+            recorder,
+            MockDaoInterface::default(),
+        );
 
         // Test case 1:
         // - No invoices with related address
@@ -932,8 +1197,13 @@ mod tests {
     async fn test_handle_subscription_event() {
         let chain_client = MockBlockChainClient::<AssetHubChainConfig>::default();
         let registry = InvoiceRegistry::new();
-        let recorder = TransactionsRecorder::<DAO>::default();
-        let mut tracker = TransfersTracker::new(chain_client, registry.clone(), recorder);
+        let recorder = TransactionsRecorder::<MockDaoInterface>::default();
+        let mut tracker = TransfersTracker::new(
+            chain_client,
+            registry.clone(),
+            recorder,
+            MockDaoInterface::default(),
+        );
 
         // Test case 1:
         // - Successful case
@@ -1010,6 +1280,309 @@ mod tests {
             Err(TransferTrackerError::Subscription(
                 SubscriptionError::SubscriptionFailed
             ))
+        ));
+    }
+
+    // ========================================================================
+    // Catch-up sweep (issue #333)
+    // ========================================================================
+
+    fn sweep_tracker(
+        chain_client: MockBlockChainClient<PolygonChainConfig>,
+        dao: MockDaoInterface,
+        registry: InvoiceRegistry,
+    ) -> TransfersTracker<
+        PolygonChainConfig,
+        MockBlockChainClient<PolygonChainConfig>,
+        MockDaoInterface,
+    > {
+        TransfersTracker::new(
+            chain_client,
+            registry,
+            TransactionsRecorder::<MockDaoInterface>::default(),
+            dao,
+        )
+    }
+
+    fn cursor_at(block_number: u64) -> ChainSyncCursor {
+        ChainSyncCursor {
+            chain: ChainType::Polygon,
+            last_processed_block: block_number,
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn polygon_transfer_to(recipient: &str) -> ChainTransfer<PolygonChainConfig> {
+        ChainTransfer {
+            asset_id: alloy::primitives::Address::from_str(
+                "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+            )
+            .expect("asset address fixture parses"),
+            asset_name: "USDC".to_string(),
+            amount: Decimal::new(10, 0),
+            sender: alloy::primitives::Address::ZERO,
+            recipient: alloy::primitives::Address::from_str(recipient)
+                .expect("recipient address fixture parses"),
+            transaction_id: "0x1234567890abcdef".to_string(),
+            timestamp: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn sweep_starts_from_the_head_when_no_cursor_exists() {
+        let mut chain_client = MockBlockChainClient::<PolygonChainConfig>::default();
+        chain_client
+            .expect_latest_confirmed_block()
+            .once()
+            .returning(|| Ok(500));
+        // Nothing to recover yet, so nothing is read.
+        chain_client
+            .expect_fetch_transfers_in_range()
+            .never();
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_get_chain_sync_cursor()
+            .once()
+            .returning(|_chain| Ok(None));
+        dao.expect_advance_chain_sync_cursor()
+            .withf(|chain, block_number| *chain == ChainType::Polygon && *block_number == 500)
+            .once()
+            .returning(|_chain, block_number| Ok(cursor_at(block_number)));
+
+        let tracker = sweep_tracker(
+            chain_client,
+            dao,
+            InvoiceRegistry::new(),
+        );
+        let mut state = SweepState::new();
+
+        tracker.sweep(&[], &mut state).await;
+
+        assert!(state.enabled);
+    }
+
+    #[tokio::test]
+    async fn sweep_reads_the_gap_and_advances_the_cursor() {
+        let mut chain_client = MockBlockChainClient::<PolygonChainConfig>::default();
+        chain_client
+            .expect_latest_confirmed_block()
+            .once()
+            .returning(|| Ok(120));
+        chain_client
+            .expect_fetch_transfers_in_range()
+            .withf(|_assets, from_block, to_block| *from_block == 101 && *to_block == 120)
+            .once()
+            .returning(|_assets, _from, _to| Ok(vec![]));
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_get_chain_sync_cursor()
+            .once()
+            .returning(|_chain| Ok(Some(cursor_at(100))));
+        dao.expect_advance_chain_sync_cursor()
+            .withf(|_chain, block_number| *block_number == 120)
+            .once()
+            .returning(|_chain, block_number| Ok(cursor_at(block_number)));
+
+        let tracker = sweep_tracker(
+            chain_client,
+            dao,
+            InvoiceRegistry::new(),
+        );
+
+        tracker
+            .sweep(&[], &mut SweepState::new())
+            .await;
+    }
+
+    #[tokio::test]
+    async fn sweep_clamps_a_long_gap_to_the_range_limit() {
+        let mut chain_client = MockBlockChainClient::<PolygonChainConfig>::default();
+        chain_client
+            .expect_latest_confirmed_block()
+            .once()
+            .returning(|| Ok(5_000));
+        chain_client
+            .expect_fetch_transfers_in_range()
+            .withf(|_assets, from_block, to_block| *from_block == 1 && *to_block == MAX_SWEEP_RANGE)
+            .once()
+            .returning(|_assets, _from, _to| Ok(vec![]));
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_get_chain_sync_cursor()
+            .once()
+            .returning(|_chain| Ok(Some(cursor_at(0))));
+        // The rest of the gap is the next tick's problem, so the cursor stops
+        // at the end of the range actually read.
+        dao.expect_advance_chain_sync_cursor()
+            .withf(|_chain, block_number| *block_number == MAX_SWEEP_RANGE)
+            .once()
+            .returning(|_chain, block_number| Ok(cursor_at(block_number)));
+
+        let tracker = sweep_tracker(
+            chain_client,
+            dao,
+            InvoiceRegistry::new(),
+        );
+
+        tracker
+            .sweep(&[], &mut SweepState::new())
+            .await;
+    }
+
+    #[tokio::test]
+    async fn sweep_ignores_a_head_behind_the_cursor() {
+        let mut chain_client = MockBlockChainClient::<PolygonChainConfig>::default();
+        // A lagging node in a public RPC pool answers with an older head.
+        chain_client
+            .expect_latest_confirmed_block()
+            .once()
+            .returning(|| Ok(150));
+        chain_client
+            .expect_fetch_transfers_in_range()
+            .never();
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_get_chain_sync_cursor()
+            .once()
+            .returning(|_chain| Ok(Some(cursor_at(200))));
+        dao.expect_advance_chain_sync_cursor()
+            .never();
+
+        let tracker = sweep_tracker(
+            chain_client,
+            dao,
+            InvoiceRegistry::new(),
+        );
+
+        tracker
+            .sweep(&[], &mut SweepState::new())
+            .await;
+    }
+
+    #[tokio::test]
+    async fn sweep_records_what_the_subscription_missed() {
+        let invoice = default_invoice().with_amount(Decimal::ZERO);
+        let registry = InvoiceRegistry::new();
+        registry
+            .add_invoice(invoice.clone())
+            .await;
+        let payment_address = invoice.invoice.payment_address.clone();
+
+        let mut chain_client = MockBlockChainClient::<PolygonChainConfig>::default();
+        chain_client
+            .expect_latest_confirmed_block()
+            .once()
+            .returning(|| Ok(120));
+        chain_client
+            .expect_fetch_transfers_in_range()
+            .once()
+            .returning(move |_assets, _from, _to| {
+                Ok(vec![polygon_transfer_to(
+                    &payment_address,
+                )])
+            });
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_get_chain_sync_cursor()
+            .once()
+            .returning(|_chain| Ok(Some(cursor_at(100))));
+        dao.expect_advance_chain_sync_cursor()
+            .once()
+            .returning(|_chain, block_number| Ok(cursor_at(block_number)));
+
+        let mut tracker = sweep_tracker(chain_client, dao, registry);
+        tracker
+            .transactions_recorder
+            .expect_process_invoice_transaction()
+            .once()
+            .returning(|_invoice, _transaction| Ok(()));
+
+        tracker
+            .sweep(&[], &mut SweepState::new())
+            .await;
+
+        tracker
+            .transactions_recorder
+            .checkpoint();
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn sweep_holds_the_cursor_when_a_transfer_cannot_be_recorded() {
+        let invoice = default_invoice().with_amount(Decimal::ZERO);
+        let registry = InvoiceRegistry::new();
+        registry
+            .add_invoice(invoice.clone())
+            .await;
+        let payment_address = invoice.invoice.payment_address.clone();
+
+        let mut chain_client = MockBlockChainClient::<PolygonChainConfig>::default();
+        chain_client
+            .expect_latest_confirmed_block()
+            .once()
+            .returning(|| Ok(120));
+        chain_client
+            .expect_fetch_transfers_in_range()
+            .once()
+            .returning(move |_assets, _from, _to| {
+                Ok(vec![polygon_transfer_to(
+                    &payment_address,
+                )])
+            });
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_get_chain_sync_cursor()
+            .once()
+            .returning(|_chain| Ok(Some(cursor_at(100))));
+        // Advancing here would lose the payment: the range would never be read
+        // again, and nothing else re-reads it before invoice expiry.
+        dao.expect_advance_chain_sync_cursor()
+            .never();
+
+        let mut tracker = sweep_tracker(chain_client, dao, registry);
+        tracker
+            .transactions_recorder
+            .expect_process_invoice_transaction()
+            .once()
+            .returning(|_invoice, _transaction| {
+                Err(TransactionsRecorderError::DaoTransactionError)
+            });
+
+        tracker
+            .sweep(&[], &mut SweepState::new())
+            .await;
+
+        assert!(logs_contain(
+            "holding the cursor to retry the range"
+        ));
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn sweep_stops_and_says_so_when_the_chain_cannot_backfill() {
+        let mut chain_client = MockBlockChainClient::<PolygonChainConfig>::default();
+        // Called once for the first sweep, and never again once disabled.
+        chain_client
+            .expect_latest_confirmed_block()
+            .once()
+            .returning(|| Err(BackfillError::Unsupported));
+
+        let mut dao = MockDaoInterface::default();
+        dao.expect_get_chain_sync_cursor()
+            .never();
+
+        let tracker = sweep_tracker(
+            chain_client,
+            dao,
+            InvoiceRegistry::new(),
+        );
+        let mut state = SweepState::new();
+
+        tracker.sweep(&[], &mut state).await;
+
+        assert!(!state.enabled);
+        assert!(logs_contain(
+            "Chain client cannot re-read past blocks"
         ));
     }
 }

--- a/daemon/src/chain_client.rs
+++ b/daemon/src/chain_client.rs
@@ -29,6 +29,7 @@ pub use asset_hub::{
     AssetHubClient,
 };
 pub use errors::{
+    BackfillError,
     ClientError,
     QueryError,
     SubscriptionError,
@@ -313,6 +314,24 @@ pub trait BlockChainClient<T: ChainConfig>: Sync {
         &self,
         asset_ids: &[T::AssetId],
     ) -> Result<TransfersStream<T>, SubscriptionError>;
+
+    /// Highest block whose transfers are safe to credit.
+    ///
+    /// This is the same depth the live path waits for, so the catch-up sweep
+    /// never releases a transfer earlier than the subscription would.
+    async fn latest_confirmed_block(&self) -> Result<u64, BackfillError>;
+
+    /// Re-read transfers in an inclusive block range.
+    ///
+    /// Used by the catch-up sweep to recover transfers the subscription missed
+    /// (issue #333). Re-delivering transfers already recorded is safe: they are
+    /// deduplicated by `(chain, tx_hash)` in the database.
+    async fn fetch_transfers_in_range(
+        &self,
+        asset_ids: &[T::AssetId],
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<ChainTransfer<T>>, BackfillError>;
 
     /// Build transaction to transfer exact amount to recipient
     async fn build_transfer(

--- a/daemon/src/chain_client/asset_hub.rs
+++ b/daemon/src/chain_client/asset_hub.rs
@@ -25,6 +25,7 @@ use crate::utils::decimal_to_base_units;
 use super::{
     AssetInfo,
     AssetInfoStore,
+    BackfillError,
     BlockChainClient,
     BlockChainClientExt,
     ChainConfig,
@@ -742,6 +743,25 @@ impl BlockChainClient<AssetHubChainConfig> for AssetHubClient {
         };
 
         Ok(Box::pin(stream))
+    }
+
+    // Backfill is not implemented here. Re-reading a past range over subxt
+    // needs a block hash per block number, which means carrying an `RpcClient`
+    // alongside the `OnlineClient` and reworking how this client is built —
+    // work that would be thrown away with the chain itself. The tracker turns
+    // the sweep off after the first `Unsupported` and says so in the log, so
+    // the gap this leaves is visible rather than assumed closed.
+    async fn latest_confirmed_block(&self) -> Result<u64, BackfillError> {
+        Err(BackfillError::Unsupported)
+    }
+
+    async fn fetch_transfers_in_range(
+        &self,
+        _asset_ids: &[u32],
+        _from_block: u64,
+        _to_block: u64,
+    ) -> Result<Vec<ChainTransfer<AssetHubChainConfig>>, BackfillError> {
+        Err(BackfillError::Unsupported)
     }
 
     #[instrument(skip(self))]

--- a/daemon/src/chain_client/errors.rs
+++ b/daemon/src/chain_client/errors.rs
@@ -59,6 +59,28 @@ pub enum QueryError {
 }
 
 // ============================================================================
+// Domain 2a: Backfill Errors (re-reading a past block range)
+// ============================================================================
+
+/// Errors for the catch-up sweep that re-reads blocks the live subscription
+/// may have missed (issue #333).
+///
+/// Split from [`QueryError`] because the caller has to tell apart "this chain
+/// will never answer" from "this call failed": the first stops the sweep for
+/// good, the second is retried on the next tick.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum BackfillError {
+    /// This client cannot re-read a past block range, so gaps in its
+    /// subscription are not recoverable. Permanent — do not retry.
+    #[error("Backfill is not supported for this chain")]
+    Unsupported,
+
+    /// The node call failed. Transient — the next sweep retries the same range.
+    #[error("Backfill request failed")]
+    RequestFailed,
+}
+
+// ============================================================================
 // Domain 3: Subscription Operation Errors (block streaming)
 // ============================================================================
 

--- a/daemon/src/chain_client/polygon.rs
+++ b/daemon/src/chain_client/polygon.rs
@@ -50,6 +50,7 @@ use crate::utils::{
 use super::{
     AssetInfo,
     AssetInfoStore,
+    BackfillError,
     BlockChainClient,
     BlockChainClientExt,
     ChainConfig,
@@ -1304,6 +1305,95 @@ impl BlockChainClient<PolygonChainConfig> for PolygonClient {
         };
 
         Ok(Box::pin(stream))
+    }
+
+    #[instrument(skip(self))]
+    async fn latest_confirmed_block(&self) -> Result<u64, BackfillError> {
+        let head = self
+            .provider
+            .get_block_number()
+            .await
+            .inspect_err(|e| {
+                tracing::debug!(
+                    error.category = CHAIN_CLIENT,
+                    error.operation = "latest_confirmed_block",
+                    error.source = ?e,
+                    "Failed to fetch the current block number"
+                );
+            })
+            .map_err(|_e| BackfillError::RequestFailed)?;
+
+        // Same depth the live path waits for, so the sweep cannot credit a
+        // transfer the confirmation buffer is still holding back.
+        Ok(head.saturating_sub(self.config.confirmations))
+    }
+
+    #[instrument(skip(self, asset_ids))]
+    async fn fetch_transfers_in_range(
+        &self,
+        asset_ids: &[PolygonAssetId],
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<ChainTransfer<PolygonChainConfig>>, BackfillError> {
+        // The same filter the subscription uses, bounded to a past range. This
+        // runs on `provider`, not `subscription_provider`: a websocket that is
+        // reconnecting must not hold up the recovery of what it dropped.
+        let filter = Filter::new()
+            .address(asset_ids.to_vec())
+            .event_signature(IERC20::Transfer::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let logs = self
+            .provider
+            .get_logs(&filter)
+            .await
+            .inspect_err(|e| {
+                tracing::debug!(
+                    error.category = CHAIN_CLIENT,
+                    error.operation = "fetch_transfers_in_range",
+                    error.source = ?e,
+                    from_block,
+                    to_block,
+                    "Failed to fetch logs for the block range"
+                );
+            })
+            .map_err(|_e| BackfillError::RequestFailed)?;
+
+        let mut transfers = Vec::with_capacity(logs.len());
+
+        for log in logs {
+            // Undecodable and unprocessable logs are skipped here exactly as
+            // they are on the live path (issue #341). Failing the whole range
+            // instead would stall the cursor permanently on a log that can
+            // never be decoded, trading a rare loss for a certain one.
+            match log.log_decode::<IERC20::Transfer>() {
+                Ok(decoded) => {
+                    let event = decoded.inner.data;
+                    match Self::log_to_transfer(&self.asset_info_store, &log, &event).await {
+                        Ok(transfer) => transfers.push(transfer),
+                        Err(e) => tracing::error!(
+                            error = ?e,
+                            tx_hash = ?log.transaction_hash,
+                            "Failed to process backfilled transfer event, skipping it"
+                        ),
+                    }
+                },
+                Err(e) => tracing::debug!(
+                    error = ?e,
+                    "Failed to decode backfilled Transfer event from log, skipping it"
+                ),
+            }
+        }
+
+        tracing::debug!(
+            from_block,
+            to_block,
+            transfers = transfers.len(),
+            "Fetched transfers for a backfill range"
+        );
+
+        Ok(transfers)
     }
 
     #[instrument(skip(self))]

--- a/daemon/src/dao.rs
+++ b/daemon/src/dao.rs
@@ -9,6 +9,7 @@
 /// - We want to be able to compare datetime fields directly in SQL queries,
 ///   so we convert `chrono::DateTime<Utc>` to `NaiveDateTime` when binding parameters
 ///   (see details [here](https://docs.rs/sqlx/latest/sqlx/sqlite/types/index.html#note-current_timestamp-and-comparisoninteroperability-of-datetime-values)).
+mod chain_sync_cursor;
 mod changes;
 mod error_parsing;
 mod interface;

--- a/daemon/src/dao/chain_sync_cursor.rs
+++ b/daemon/src/dao/chain_sync_cursor.rs
@@ -1,0 +1,242 @@
+use thiserror::Error;
+
+use crate::types::{
+    ChainSyncCursor,
+    ChainSyncCursorRow,
+    ChainType,
+};
+
+use super::DaoExecutor;
+
+#[derive(Debug, Error)]
+pub enum DaoChainSyncCursorError {
+    /// Database operation failed
+    #[error("Database error during chain sync cursor operation")]
+    DatabaseError,
+
+    /// Stored cursor cannot be represented as a block number
+    #[error("Stored chain sync cursor is invalid")]
+    InvalidCursor,
+}
+
+pub trait DaoChainSyncCursorMethods: DaoExecutor + 'static {
+    /// Read the sweep watermark for a chain. `None` means the sweep has never
+    /// run against this database — the caller decides where to start.
+    async fn get_chain_sync_cursor(
+        &self,
+        chain: ChainType,
+    ) -> Result<Option<ChainSyncCursor>, DaoChainSyncCursorError> {
+        let query = sqlx::query_as::<_, ChainSyncCursorRow>(
+            "SELECT chain, last_processed_block, updated_at
+             FROM chain_sync_cursors
+             WHERE chain = ?",
+        )
+        .bind(chain);
+
+        let row: Option<ChainSyncCursorRow> = self
+            .fetch_optional(query)
+            .await
+            .map_err(|e| {
+                tracing::debug!(
+                    error.category = "dao.chain_sync_cursor",
+                    error.operation = "get_chain_sync_cursor",
+                    error.source = ?e,
+                    %chain,
+                    "Failed to read chain sync cursor"
+                );
+
+                DaoChainSyncCursorError::DatabaseError
+            })?;
+
+        row.map(ChainSyncCursor::try_from)
+            .transpose()
+            .map_err(|e| {
+                tracing::error!(
+                    error.category = "dao.chain_sync_cursor",
+                    error.operation = "get_chain_sync_cursor",
+                    error.source = %e,
+                    %chain,
+                    "Stored chain sync cursor is out of range, refusing to use it"
+                );
+
+                DaoChainSyncCursorError::InvalidCursor
+            })
+    }
+
+    /// Move the watermark forward, and return the cursor as it now stands.
+    ///
+    /// A lower `block_number` is not an error and not a rollback: endpoints
+    /// rotate and public RPC pools contain lagging nodes, so an older head is
+    /// an ordinary observation. `MAX` in the conflict clause keeps the stored
+    /// value monotonic regardless of what the caller passes, and `updated_at`
+    /// only moves when the cursor actually advances, so it stays a truthful
+    /// answer to "is the sweep making progress?".
+    async fn advance_chain_sync_cursor(
+        &self,
+        chain: ChainType,
+        block_number: u64,
+    ) -> Result<ChainSyncCursor, DaoChainSyncCursorError> {
+        let block_number = i64::try_from(block_number).map_err(|_e| {
+            tracing::error!(
+                error.category = "dao.chain_sync_cursor",
+                error.operation = "advance_chain_sync_cursor",
+                %chain,
+                block_number,
+                "Block number exceeds what SQLite can store, refusing to advance the cursor"
+            );
+
+            DaoChainSyncCursorError::InvalidCursor
+        })?;
+
+        let query = sqlx::query_as::<_, ChainSyncCursorRow>(
+            "INSERT INTO chain_sync_cursors (chain, last_processed_block, updated_at)
+             VALUES (?, ?, ?)
+             ON CONFLICT(chain) DO UPDATE SET
+                 last_processed_block =
+                     MAX(excluded.last_processed_block, chain_sync_cursors.last_processed_block),
+                 updated_at = CASE
+                     WHEN excluded.last_processed_block > chain_sync_cursors.last_processed_block
+                         THEN excluded.updated_at
+                     ELSE chain_sync_cursors.updated_at
+                 END
+             RETURNING chain, last_processed_block, updated_at",
+        )
+        .bind(chain)
+        .bind(block_number)
+        .bind(chrono::Utc::now().naive_utc());
+
+        let row: ChainSyncCursorRow = self
+            .fetch_one(query)
+            .await
+            .map_err(|e| {
+                tracing::debug!(
+                    error.category = "dao.chain_sync_cursor",
+                    error.operation = "advance_chain_sync_cursor",
+                    error.source = ?e,
+                    %chain,
+                    block_number,
+                    "Failed to advance chain sync cursor"
+                );
+
+                DaoChainSyncCursorError::DatabaseError
+            })?;
+
+        ChainSyncCursor::try_from(row).map_err(|e| {
+            tracing::error!(
+                error.category = "dao.chain_sync_cursor",
+                error.operation = "advance_chain_sync_cursor",
+                error.source = %e,
+                %chain,
+                "Stored chain sync cursor is out of range after an advance"
+            );
+
+            DaoChainSyncCursorError::InvalidCursor
+        })
+    }
+}
+
+impl<T: DaoExecutor + 'static> DaoChainSyncCursorMethods for T {}
+
+#[cfg(test)]
+mod tests {
+    use crate::dao::create_test_dao;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn cursor_is_absent_until_first_advance() {
+        let dao = create_test_dao().await;
+
+        let cursor = dao
+            .get_chain_sync_cursor(ChainType::Polygon)
+            .await
+            .expect("read succeeds");
+
+        assert!(cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn advance_creates_then_moves_the_cursor() {
+        let dao = create_test_dao().await;
+
+        let created = dao
+            .advance_chain_sync_cursor(ChainType::Polygon, 100)
+            .await
+            .expect("first advance succeeds");
+        assert_eq!(created.last_processed_block, 100);
+
+        let moved = dao
+            .advance_chain_sync_cursor(ChainType::Polygon, 112)
+            .await
+            .expect("second advance succeeds");
+        assert_eq!(moved.last_processed_block, 112);
+
+        let stored = dao
+            .get_chain_sync_cursor(ChainType::Polygon)
+            .await
+            .expect("read succeeds")
+            .expect("cursor exists");
+        assert_eq!(stored.last_processed_block, 112);
+    }
+
+    #[tokio::test]
+    async fn lower_block_number_does_not_move_the_cursor_back() {
+        let dao = create_test_dao().await;
+
+        dao.advance_chain_sync_cursor(ChainType::Polygon, 1000)
+            .await
+            .expect("first advance succeeds");
+
+        // A lagging node in a public RPC pool reports an older head. Reported
+        // as text this would compare '999' > '1000' and win.
+        let after_lag = dao
+            .advance_chain_sync_cursor(ChainType::Polygon, 999)
+            .await
+            .expect("stale advance is not an error");
+
+        assert_eq!(after_lag.last_processed_block, 1000);
+    }
+
+    #[tokio::test]
+    async fn no_op_advance_keeps_updated_at() {
+        let dao = create_test_dao().await;
+
+        let created = dao
+            .advance_chain_sync_cursor(ChainType::Polygon, 1000)
+            .await
+            .expect("first advance succeeds");
+
+        let after_lag = dao
+            .advance_chain_sync_cursor(ChainType::Polygon, 500)
+            .await
+            .expect("stale advance is not an error");
+
+        assert_eq!(after_lag.updated_at, created.updated_at);
+    }
+
+    #[tokio::test]
+    async fn cursors_of_different_chains_are_independent() {
+        let dao = create_test_dao().await;
+
+        dao.advance_chain_sync_cursor(ChainType::Polygon, 1000)
+            .await
+            .expect("polygon advance succeeds");
+        dao.advance_chain_sync_cursor(ChainType::PolkadotAssetHub, 7)
+            .await
+            .expect("asset hub advance succeeds");
+
+        let polygon = dao
+            .get_chain_sync_cursor(ChainType::Polygon)
+            .await
+            .expect("read succeeds")
+            .expect("cursor exists");
+        let asset_hub = dao
+            .get_chain_sync_cursor(ChainType::PolkadotAssetHub)
+            .await
+            .expect("read succeeds")
+            .expect("cursor exists");
+
+        assert_eq!(polygon.last_processed_block, 1000);
+        assert_eq!(asset_hub.last_processed_block, 7);
+    }
+}

--- a/daemon/src/dao/interface.rs
+++ b/daemon/src/dao/interface.rs
@@ -13,6 +13,8 @@ use chrono::{
 use uuid::Uuid;
 
 use crate::types::{
+    ChainSyncCursor,
+    ChainType,
     ChangesResponse,
     CreateFrontEndSwapParams,
     CreateInvoiceData,
@@ -37,6 +39,10 @@ use crate::types::{
     WebhookEvent,
 };
 
+use super::chain_sync_cursor::{
+    DaoChainSyncCursorError,
+    DaoChainSyncCursorMethods,
+};
 use super::changes::{
     DaoChangesError,
     DaoChangesMethods,
@@ -284,6 +290,21 @@ pub trait DaoInterface: Send + Sync + 'static {
         &self,
         event_id: Uuid,
     ) -> Result<WebhookEvent, DaoWebhookEventError>;
+
+    // === Chain Sync Cursor Methods ===
+
+    /// Read how far the catch-up sweep has processed a chain.
+    async fn get_chain_sync_cursor(
+        &self,
+        chain: ChainType,
+    ) -> Result<Option<ChainSyncCursor>, DaoChainSyncCursorError>;
+
+    /// Move the sweep watermark forward. Never moves it backwards.
+    async fn advance_chain_sync_cursor(
+        &self,
+        chain: ChainType,
+        block_number: u64,
+    ) -> Result<ChainSyncCursor, DaoChainSyncCursorError>;
 
     // === Changes Methods ===
 
@@ -932,6 +953,21 @@ impl DaoInterface for DAO {
         event_id: Uuid,
     ) -> Result<WebhookEvent, DaoWebhookEventError> {
         DaoWebhookEventMethods::mark_webhook_event_as_sent(self, event_id).await
+    }
+
+    async fn get_chain_sync_cursor(
+        &self,
+        chain: ChainType,
+    ) -> Result<Option<ChainSyncCursor>, DaoChainSyncCursorError> {
+        DaoChainSyncCursorMethods::get_chain_sync_cursor(self, chain).await
+    }
+
+    async fn advance_chain_sync_cursor(
+        &self,
+        chain: ChainType,
+        block_number: u64,
+    ) -> Result<ChainSyncCursor, DaoChainSyncCursorError> {
+        DaoChainSyncCursorMethods::advance_chain_sync_cursor(self, chain, block_number).await
     }
 
     async fn get_invoice_changes(

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -601,6 +601,7 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
             client,
             invoice_registry.clone(),
             transactions_recorder.clone(),
+            dao.clone(),
         )
         .ignite(
             asset_hub_assets,
@@ -613,6 +614,7 @@ async fn async_try_main(shutdown_notification: ShutdownNotification) -> Result<(
             client,
             invoice_registry.clone(),
             transactions_recorder,
+            dao.clone(),
         )
         .ignite(
             polygon_assets,

--- a/daemon/src/types.rs
+++ b/daemon/src/types.rs
@@ -12,6 +12,7 @@
 /// }
 /// ```
 mod admin;
+mod chain_sync_cursor;
 mod changes;
 mod common;
 mod invoice;
@@ -23,6 +24,7 @@ mod webhook_event;
 
 // Re-export commonly used types for convenience
 pub use admin::*;
+pub use chain_sync_cursor::*;
 pub use changes::*;
 pub use common::*;
 pub use invoice::*;

--- a/daemon/src/types/chain_sync_cursor.rs
+++ b/daemon/src/types/chain_sync_cursor.rs
@@ -1,0 +1,97 @@
+use chrono::{
+    DateTime,
+    Utc,
+};
+use thiserror::Error;
+
+use super::ChainType;
+
+/// How far the catch-up sweep has processed a chain.
+///
+/// The sweep re-reads logs the live subscription may have missed, so this
+/// watermark has to survive a daemon restart — see issue #333.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainSyncCursor {
+    pub chain: ChainType,
+    /// Highest block whose transfers are known to be recorded.
+    pub last_processed_block: u64,
+    /// When the cursor last moved forward. Unchanged by a no-op advance, so it
+    /// answers "is the sweep making progress?".
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Database representation of [`ChainSyncCursor`].
+///
+/// SQLite stores integers as signed 64-bit, while block numbers are unsigned,
+/// so the column type and the domain type cannot be the same.
+#[derive(Debug, sqlx::FromRow)]
+pub struct ChainSyncCursorRow {
+    pub chain: ChainType,
+    pub last_processed_block: i64,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error("Chain sync cursor for {chain} holds a negative block number: {last_processed_block}")]
+pub struct NegativeCursorError {
+    pub chain: ChainType,
+    pub last_processed_block: i64,
+}
+
+impl TryFrom<ChainSyncCursorRow> for ChainSyncCursor {
+    type Error = NegativeCursorError;
+
+    fn try_from(row: ChainSyncCursorRow) -> Result<Self, Self::Error> {
+        // The table has `CHECK(last_processed_block >= 0)`, so this only fires
+        // for a database written by something other than this daemon.
+        let last_processed_block =
+            u64::try_from(row.last_processed_block).map_err(|_e| NegativeCursorError {
+                chain: row.chain,
+                last_processed_block: row.last_processed_block,
+            })?;
+
+        Ok(Self {
+            chain: row.chain,
+            last_processed_block,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_converts_to_cursor() {
+        let row = ChainSyncCursorRow {
+            chain: ChainType::Polygon,
+            last_processed_block: 80_000_000,
+            updated_at: Utc::now(),
+        };
+        let updated_at = row.updated_at;
+
+        let cursor = ChainSyncCursor::try_from(row).expect("non-negative block number converts");
+
+        assert_eq!(cursor.chain, ChainType::Polygon);
+        assert_eq!(cursor.last_processed_block, 80_000_000);
+        assert_eq!(cursor.updated_at, updated_at);
+    }
+
+    #[test]
+    fn negative_block_number_is_rejected() {
+        let row = ChainSyncCursorRow {
+            chain: ChainType::Polygon,
+            last_processed_block: -1,
+            updated_at: Utc::now(),
+        };
+
+        assert_eq!(
+            ChainSyncCursor::try_from(row),
+            Err(NegativeCursorError {
+                chain: ChainType::Polygon,
+                last_processed_block: -1,
+            })
+        );
+    }
+}

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -94,7 +94,9 @@ How far the catch-up sweep has processed each chain (`daemon/src/chain/transfer_
 |--------|------|-------|
 | chain | TEXT | Primary key |
 | last_processed_block | INTEGER | Highest block whose transfers are recorded, `CHECK(>= 0)` |
-| updated_at | TEXT | ISO 8601; moves only when the cursor advances |
+| updated_at | TEXT | SQLite datetime string, see below; moves only when the cursor advances |
+
+Timestamps here are **not** ISO 8601, despite the column being TEXT: the schema default writes `datetime('now')` (`2026-08-11 04:29:03` — space separator, no timezone designator, UTC by definition) and sqlx binds a `NaiveDateTime` as `%F %T%.f`, i.e. the same shape with fractional seconds. Both sort correctly as strings, which is what the comparisons rely on; but a hand-written query filtering with an ISO string like `2026-08-11T04:29:03Z` will silently match nothing. The same applies to every other timestamp column in this schema.
 
 Two properties are load-bearing and easy to break:
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -7,6 +7,10 @@ SQLite via sqlx 0.8. Requires SQLite >= 3.47.0 at runtime.
 - `migrations/20250104000001_initial_schema.sql` — Core tables: invoices, transactions, payouts, refunds, webhook_events
 - `migrations/20250211000001_create_front_end_swaps.sql` — Front-end swap tracking
 - `migrations/20250218000001_add_transaction_uniqueness_constraints.sql` — Uniqueness constraints
+- `migrations/20260303181227_add_swaps.sql` — Swaps
+- `migrations/20260401000001_refund_destination_fields.sql` — Refund destination fields
+- `migrations/20260515090507_transaction_origin_indexes.sql` — Indexed virtual columns over `transactions.origin`
+- `migrations/20260808033820_add_chain_sync_cursors.sql` — Catch-up sweep cursor
 
 Run migrations: `make sqlx-migrate`
 Prepare for compile-time verification: `make sqlx-prepare`
@@ -77,6 +81,27 @@ Queue of webhook notifications to send to merchant's configured URL.
 | entity_id | BLOB | References any entity |
 | payload | TEXT | JSON (TEXT) payload |
 | sent | INTEGER | 0 = pending, 1 = sent |
+
+## Operational Tables
+
+Not entities — daemon state that has to survive a restart.
+
+### chain_sync_cursors
+
+How far the catch-up sweep has processed each chain (`daemon/src/chain/transfer_tracker.rs`, issue [#333](https://github.com/Kalapaja/Kalatori/issues/333)). One row per chain; the database file belongs to a single daemon, so no instance column.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| chain | TEXT | Primary key |
+| last_processed_block | INTEGER | Highest block whose transfers are recorded, `CHECK(>= 0)` |
+| updated_at | TEXT | ISO 8601; moves only when the cursor advances |
+
+Two properties are load-bearing and easy to break:
+
+- **`last_processed_block` must stay INTEGER.** The cursor may never move backwards, and that guard is `MAX(excluded.last_processed_block, chain_sync_cursors.last_processed_block)` in the upsert. Stored as TEXT the comparison becomes lexicographic, where `'1000' < '999'`. An older head is a normal observation — public RPC pools answer from whichever node took the request, and some lag.
+- **The cursor cannot be reconstructed from `transactions`.** On Polygon the transfer path stores no block number (see the TODO above `log_to_transfer` in `chain_client/polygon.rs`), so `transactions.block_number` is NULL there and `SELECT MAX(block_number)` returns nothing.
+
+Re-reading a range already processed is safe: incoming transfers are deduplicated by the unique index on `(chain, tx_hash)`, so the sweep only has to be at-least-once.
 
 ## Status Transition Triggers
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,23 @@ Actor pattern: mpsc channel + oneshot responses. Holds seed phrase (`Zeroize` + 
 Client interface: `KeyringClient` (mockable via `mockall_double`).
 
 ### `daemon/src/chain/` — Chain Monitoring & Execution
-- **`transfer_tracker.rs`** (`TransfersTracker`): Subscribes to finalized blocks per chain, detects incoming transfers, and notifies `TransactionsRecorder`. Failed subscriptions and streams that end before delivering an event use a cancellation-aware exponential retry delay (1–60 seconds). Retry state resets only after a stream delivers an event; degradation is reported on entry and at most once per minute, with recovery reported separately.
+- **`transfer_tracker.rs`** (`TransfersTracker`): Subscribes to finalized blocks per chain, detects incoming transfers, and notifies `TransactionsRecorder`. Failed subscriptions and streams that end before delivering an event use a cancellation-aware exponential retry delay (1–60 seconds). Retry state resets only after a stream delivers an event; degradation is reported on entry and at most once per minute, with recovery reported separately. Alongside the subscription it runs a **catch-up sweep** — see below.
+
+#### Catch-up sweep
+
+The subscription alone loses events without ever reporting it ([#333](https://github.com/Kalapaja/Kalatori/issues/333)): alloy reconnects and resubscribes underneath the daemon without the stream ending, so `sub.next()` keeps yielding, the 10-second inactivity watchdog never fires, and `eth_subscribe("logs")` has no backfill. There is no moment the daemon could hook "the subscription just came back" onto.
+
+The sweep therefore polls instead of reacting. Every `SWEEP_INTERVAL` (30 s) it reads `chain_sync_cursors` (see [DATABASE.md](DATABASE.md)), asks the client for the confirmed head, re-reads the gap with a bounded range request, and feeds whatever it finds through the same recording path as the live subscription. This covers every cause of a miss — reconnects, endpoint rotation, a daemon restart — not just the alloy defect that exposed it.
+
+Four properties carry the correctness:
+
+- **The cursor advances only after every transfer in a range is recorded.** A failed write holds it, so the next tick retries the range. Re-delivery costs nothing: incoming transfers are deduplicated by `(chain, tx_hash)`, which makes the sweep an at-least-once mechanism rather than an exactly-once one.
+- **Reading stops at `head - confirmations`**, the same depth the live path waits for, so the sweep cannot credit a transfer the confirmation buffer is still holding back.
+- **Requests go through the HTTP provider**, not the websocket, so a socket that is reconnecting does not hold up recovery of what it dropped.
+- **A range is capped at `MAX_SWEEP_RANGE` (1000 blocks).** Providers cap `eth_getLogs` spans; the remainder of a long gap is the next tick's problem.
+
+Chain support is expressed in `BlockChainClient::latest_confirmed_block` and `fetch_transfers_in_range`, both returning `BackfillError`. Polygon implements them over `eth_blockNumber` and `eth_getLogs`. **Asset Hub returns `Unsupported`**: re-reading a range over subxt needs a block hash per block number, which means carrying an `RpcClient` beside the `OnlineClient`. The tracker disables the sweep on the first `Unsupported` and logs which chain is left uncovered — for that chain the only net remains the balance check at invoice expiry.
+
 - **`transactions_recorder.rs`** (`TransactionsRecorder`): Records detected transactions to DB, updates `InvoiceRegistry`. Its transaction-scoped recording path lets Asset Hub balance reconciliation read the persisted received total and write a synthetic adjustment in one SQLite transaction; payout/refund/webhook/status side effects use that same path and the registry changes only after commit. Checked amount failures abort the database transaction and are surfaced with invoice/transaction coordinates; durable live-event replay remains a separate persistence concern.
 - **`executor.rs`** (`TransfersExecutor`): Builds and submits payout transactions for both chains. Single executor instance handles Asset Hub + Polygon.
 - **`invoice_registry.rs`** (`InvoiceRegistry`): In-memory tracking of active invoices and their expected amounts. Thread-safe (internal `RwLock`). Invoice-data refreshes update only records that are still present, preserving the received amount; they never reinsert an invoice removed concurrently after reaching a terminal status.
@@ -170,6 +186,7 @@ Both are deterministic: same seed + same invoice params = same payment account.
 2. **Customer pays** to payment address on-chain
 3. **TransfersTracker** detects incoming transfer in finalized block → TransactionsRecorder saves transaction to DB, updates invoice status in InvoiceRegistry
    - Asset Hub balance recovery re-reads the transaction sum inside the same transaction that writes its coordinate-less adjustment. A transfer committed after the chain balance fetch is therefore included before the delta is calculated, while a genuine positive shortfall is still recorded.
+   - On Polygon a transfer the subscription dropped is recovered by the catch-up sweep within one sweep interval instead of waiting for invoice expiry. Asset Hub has no sweep, so there the expiry balance check remains the only net.
 4. **TransfersExecutor** picks up payouts from DB → builds transaction → signs via Keyring → submits to chain → records result
 5. **ExpirationDetector** periodically checks for expired invoices → updates status
 6. **WebhookSender** periodically sends unsent webhook events to configured URLs

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -403,6 +403,12 @@ pub enum SubscriptionError {
     BlockProcessingFailed { block_number: u32 },  // Skip block
 }
 
+// 3a. Re-reading a past block range (catch-up sweep)
+pub enum BackfillError {
+    Unsupported,             // Stop sweeping this chain for good
+    RequestFailed,           // Retry the same range next tick
+}
+
 // 4. Transaction lifecycle
 pub enum TransactionError<T: ChainConfig> {
     BuildFailed { reason: String },
@@ -425,6 +431,8 @@ pub enum TransactionError<T: ChainConfig> {
 
 **Why separate QueryError and SubscriptionError?**
 Different recovery: queries retry immediately with different endpoint; subscriptions restart entire stream.
+
+**Why BackfillError is not QueryError**, even though both wrap one-off RPC calls: the caller has to tell "this chain will never answer" from "this call failed". The first disables the sweep permanently and reports the chain as uncovered; the second is retried on the next tick. Two variants, because two recovery paths — a third variant nobody branches on would violate Principle 1.
 
 **Cross-Domain Conversion:**
 

--- a/migrations/20260808033820_add_chain_sync_cursors.sql
+++ b/migrations/20260808033820_add_chain_sync_cursors.sql
@@ -1,0 +1,20 @@
+-- Track how far the catch-up sweep has processed each chain (issue #333).
+--
+-- The sweep re-reads logs the live subscription may have missed, so it needs a
+-- restart-surviving watermark. This cannot be derived from existing tables: on
+-- Polygon the transfer path stores no block number at all (see the TODO above
+-- `log_to_transfer` in `chain_client/polygon.rs`), so `transactions` holds NULL
+-- there and `SELECT MAX(block_number)` would silently return nothing.
+--
+-- One row per chain. The database file belongs to a single daemon
+-- (`DatabaseConfig` is a local SQLite path), so no instance column is needed.
+--
+-- `last_processed_block` is INTEGER, not TEXT, on purpose: the cursor must
+-- never move backwards, and that guard is a numeric comparison. Stored as TEXT
+-- it would compare lexicographically, where '1000' < '999'.
+
+CREATE TABLE IF NOT EXISTS chain_sync_cursors (
+    chain                TEXT PRIMARY KEY NOT NULL,
+    last_processed_block INTEGER NOT NULL CHECK(last_processed_block >= 0),
+    updated_at           TEXT NOT NULL DEFAULT (datetime('now'))
+);


### PR DESCRIPTION
Closes #333.

## The problem

A websocket subscription can lose events without anything in the daemon noticing. When the provider sends a frame `alloy-json-rpc` cannot deserialize, `alloy-transport-ws` tears down the whole pubsub backend; `alloy-pubsub` then reconnects and re-subscribes **underneath us**, so the stream never ends. `sub.next()` keeps yielding, the 10-second inactivity watchdog never fires, and `eth_subscribe("logs")` has no backfill. The affected production instance did this every ~60 s for three months.

There is therefore no moment we can hook "the subscription just came back" onto — which is why the issue's own suggestion ("fetch the gap on resubscribe") is not directly implementable.

Whatever lands in that window surfaces only when `BalanceChecker` runs from the expiration detector, i.e. at invoice expiry — up to 24 h later. The confirmation buffer added in #348 widened the exposure from the reconnect gap itself to every unreleased transfer in the trailing ~12 blocks (see #357).

## What this does

Adds a catch-up sweep that does not depend on noticing the gap. Every 30 s the tracker reads a persisted cursor, asks the client for the confirmed head, re-reads the gap with `eth_getLogs`, and feeds the result through the same recording path as the live subscription. That covers every cause of a miss — this alloy defect, endpoint rotation, a daemon restart — rather than the one that exposed it.

Four properties carry the correctness:

- **The cursor advances only after every transfer in a range is recorded.** A failed write holds it so the next tick retries the range. Re-delivery is free: incoming transfers are deduplicated by the unique index on `(chain, tx_hash)`, so the sweep only has to be at-least-once, not exactly-once.
- **Reading stops at `head - confirmations`** — the same depth the live path waits for, so the sweep cannot credit a transfer the confirmation buffer is deliberately holding back.
- **Requests go through the HTTP provider**, not the websocket: a socket that is reconnecting must not hold up recovery of what it dropped.
- **A range is capped at 1000 blocks.** Providers cap `eth_getLogs` spans; the rest of a long gap is the next tick's problem.

The cursor lives in a new `chain_sync_cursors` table. It cannot be derived from existing state: on Polygon the transfer path stores no block number at all (the TODO above `log_to_transfer`), so `transactions.block_number` is NULL there. Monotonicity is enforced in SQL rather than by the caller — an older head is an ordinary observation, since public RPC pools answer from whichever node took the request. That guard is a numeric comparison, which is why the column is `INTEGER` and not a value in a generic key/value table.

## Asset Hub is not covered, on purpose

`latest_confirmed_block` and `fetch_transfers_in_range` return `BackfillError::Unsupported` there. Re-reading a range over subxt needs a block hash per block number, which means carrying an `RpcClient` beside the `OnlineClient` and reworking how that client is built — and the chain is being retired.

It is not a silent skip: the tracker disables the sweep on the first `Unsupported` and logs which chain is left uncovered, with what remains as its safety net. A partial fix to a reliability feature that says nothing is worse than none, because a clean log then reads as "fully covered".

`BackfillError` is separate from `QueryError` for exactly this reason — the caller must distinguish "this chain will never answer" (stop for good) from "this call failed" (retry next tick). Two variants, two recovery paths.

## Tests

14 new, all verified by mutation — each was made to fail by breaking the property it guards:

- cursor (7): row/domain conversion and rejection of a negative value; absent until first advance; create and advance; a lagging head does not roll it back; a no-op advance leaves `updated_at` alone; per-chain independence.
- sweep (7): starts from the head on an empty database; reads the gap and advances; clamps a long gap to the range limit; ignores a head behind the cursor; records what it fetched; **holds the cursor when a write fails**; disables itself and says so on `Unsupported`.

The two that matter most, and what breaking them produces: dropping `MAX()` from the upsert → `left: 999, right: 1000`; dropping the early return before the cursor advance → the `never()` expectation on `advance_chain_sync_cursor` fires, i.e. the test catches "database blinked, payment lost until expiry".

Full suite 388 green, clippy clean under `-Dwarnings` with the arithmetic gate from #340 in place. Rebased onto 0.9.5: the live path's error propagation, which landed on main meanwhile, is kept as main has it — this PR only needs `process_transfer` to be fallible, which it now is.

## Open questions for review

1. `SWEEP_INTERVAL` is a constant (30 s). Worth moving next to `confirmations` in the chain config? It decides directly whether a free public endpoint can carry a daemon — one `eth_getLogs` per interval per chain.
2. #357 proposes gating on the `finalized` tag instead of a block count, over the same `eth_getLogs` backfill. Deliberately left out here to keep this reviewable; happy to do it next if you want them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
